### PR TITLE
Run GitHub Actions Clippy on Examples

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -70,3 +70,21 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+      - name: Cargo clippy lint ping-pong-with-noise example
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path examples/ping-pong-with-noise/Cargo.toml -- -D warnings
+
+      - name: Cargo clippy lint ping-pong-without-noise example
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path examples/ping-pong-without-noise/Cargo.toml -- -D warnings
+
+      - name: Cargo clippy lint sv1-client-and-server example
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path examples/sv1-client-and-server/Cargo.toml -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /ignore
 /vendor/ed25519-dalek/target
 /utils/buffer/target
+*.sw[op]
+.DS_Store

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 
+#[cfg(feature = "noise_sv2")]
 use alloc::{boxed::Box, vec::Vec};
 
 mod buffer;


### PR DESCRIPTION
For each example runs:
- [x] `cargo clippy`
~~- [ ] `rustfmt`~~

Also updates `.gitignore` to ignore swap files and .DS_Store on OSx.

When running `rustfmt` on the examples, the compiler complains that async features are not permitted in Rust 2015 and suggests to update the `Cargo.toml` to the 2018 edition. However, the `Cargo.toml` does specify the 2018 edition. I do not know where this discrepancy is originating from. 

```
$ rustfmt examples/sv1-client-and-server/src/*
error[E0670]: `async fn` is not permitted in Rust 2015
  --> /home/rrybarczyk/Dev/stratum-v2/stratum/examples/sv1-client-and-server/src/main.rs:43:1
   |
43 | async fn server_pool() {
   | ^^^^^ to use `async fn`, switch to Rust 2018 or later
   |
   = help: set `edition = "2018"` in `Cargo.toml`
   = note: for more on editions, read https://doc.rust-lang.org/edition-guide

error[E0670]: `async fn` is not permitted in Rust 2015
  --> /home/rrybarczyk/Dev/stratum-v2/stratum/examples/sv1-client-and-server/src/main.rs:55:9
   |
55 |     pub async fn new(stream: TcpStream) -> Arc<Mutex<Self>> {
   |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
   |
   = help: set `edition = "2018"` in `Cargo.toml`
   = note: for more on editions, read https://doc.rust-lang.org/edition-guide

error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found keyword `move`
  --> /home/rrybarczyk/Dev/stratum-v2/stratum/examples/sv1-client-and-server/src/main.rs:63:27
   |
63 |         task::spawn(async move {
   |                           ^^^^ expected one of 8 possible tokens
```

Should we try and fix this, or skip running `rustfmt` on the examples for now and create an issue to deal with later?