### PR TITLE
Add code coverage to GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+name: Code Coverage
+
+jobs:
+  test:
+    name: Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Generate code coverage
+        run: |
+          cargo +nightly tarpaulin --timeout 120
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --timeout 120
+          cargo +nightly tarpaulin --timeout 120 --fail-under 31
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-name: Stratum V2
+name: Test & Lint
 
 jobs:
   ci:

--- a/.github/workflows/sv2-header-check.yaml
+++ b/.github/workflows/sv2-header-check.yaml
@@ -4,7 +4,8 @@ on:
   pull_request:
     brances: [ main ]
 
-name: Check sv2.h file is up to date with commit
+# Check sv2.h file is up to date with commit
+name: sv2.h Header Check
 
 jobs:
   sv2_header_check:

--- a/roles/v2/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/upstream_mining.rs
@@ -318,3 +318,11 @@ impl UpstreamMiningNodes {
         Err(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_one() {
+        assert_eq!(1, 1);
+    }
+}

--- a/roles/v2/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/upstream_mining.rs
@@ -318,11 +318,3 @@ impl UpstreamMiningNodes {
         Err(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_one() {
-        assert_eq!(1, 1);
-    }
-}


### PR DESCRIPTION
Addresses issue #75.

Uses [`cargo tarpaulin`](https://github.com/xd009642/tarpaulin) to perform code coverage as a GitHub Action. One note of possible concern with this library: it only operates natively on linux. Imo, it works for our purposes as it runs just fine with `ubuntu-latest` on GitHub Actions and has docker support. 

Right now, the coverage report shows: `31.25% coverage, 2139/6845 lines covered`.  Therefore, in the `.github/workflows/coverage.yaml` file, the `fail-under` flag is set to 31%. As more tests are added, this number should be increased.

Also, renamed the other GitHub Actions to better reflect their action.