### PR TITLE
Some Build errors fixed

### DIFF
--- a/protocols/v2/subprotocols/mining/src/lib.rs
+++ b/protocols/v2/subprotocols/mining/src/lib.rs
@@ -216,7 +216,7 @@ impl From<Target> for U256<'static> {
     fn from(v: Target) -> Self {
         let mut inner = v.head.to_le_bytes().to_vec();
         inner.extend_from_slice(&v.tail.to_le_bytes());
-        inner.try_into().unwrap()
+        (inner[..]).try_into().unwrap()
     }
 }
 
@@ -257,7 +257,7 @@ impl<'a> From<Extranonce> for U256<'a> {
     fn from(v: Extranonce) -> Self {
         let mut inner = v.head.to_le_bytes().to_vec();
         inner.extend_from_slice(&v.tail.to_le_bytes());
-        inner.try_into().unwrap()
+        inner[..].try_into().unwrap()
     }
 }
 


### PR DESCRIPTION
While running `cargo build --features with_serde` 
I encountered some errors.
```
error[E0277]: the trait bound `U256<'_>: From<Vec<u8>>` is not satisfied
   --> protocols/v2/subprotocols/mining/src/lib.rs:260:15
    |
260 |         inner.try_into().unwrap()
    |               ^^^^^^^^ the trait `From<Vec<u8>>` is not implemented for `U256<'_>`
```
This PR fixes these errors.