### PR TITLE
Add Copy trait to SetupConnectionSuccess and enable conversion from CSv2Message

### DIFF
--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -179,7 +179,7 @@ impl<'a> From<SetupConnection<'a>> for CSetupConnection {
 /// ## SetupConnection.Success (Server -> Client)
 /// Response to [`SetupConnection`] message if the server accepts the connection. The client is
 /// required to verify the set of feature flags that the server supports and act accordingly.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct SetupConnectionSuccess {
     /// Selected version proposed by the connecting node that the upstream

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -160,7 +160,7 @@ impl<'a> CSv2Message {
             CSv2Message::SetupConnectionError(v) => {
                 Ok(Sv2Message::SetupConnectionError(v.to_rust_rep_mut()?))
             }
-            //CSv2Message::SetupConnectionSuccess(v) => {Ok(Sv2Message::SetupConnectionSuccess(*v))}
+            CSv2Message::SetupConnectionSuccess(v) => Ok(Sv2Message::SetupConnectionSuccess(*v)),
             _ => todo!(),
         }
     }


### PR DESCRIPTION
Implement the Copy derive trait for SetupConnectionSuccess so that the message can be copied when converting a pointer from a CSv2Message to a Rust SetupConnectionSuccess message.

This allows a C implementation to create the SetupConnectionSuccess using the Rust FFI.