### PR TITLE
Set default-features to true in messages-sv2 Cargo toml so cargo compiles

### DIFF
--- a/protocols/v2/messages-sv2/Cargo.toml
+++ b/protocols/v2/messages-sv2/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true}
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2/binary-sv2" }
+binary_sv2 = {version = "0.1.3", path = "../../../protocols/v2/binary-sv2/binary-sv2", default-features = true }
 common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "0.1.3" }
 mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "0.1.0" }
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "0.1.3"}


### PR DESCRIPTION
`cargo check` was failing with these errors:
```
➜  stratum git:(main) cargo check
    Checking mining_sv2 v0.1.0 (/Users/rachelrybarczyk/Development/StratumV2/Dev/stratum/protocols/v2/subprotocols/mining)
error[E0599]: no method named `inner_as_ref` found for enum `binary_codec_sv2::datatypes::non_copy_data_types::inner::Inner<'a, true, 32_usize, 0_usize, 0_usize>` in the current scope
   --> protocols/v2/subprotocols/mining/src/lib.rs:208:23
    |
208 |         let inner = v.inner_as_ref();
    |                       ^^^^^^^^^^^^ method not found in `binary_codec_sv2::datatypes::non_copy_data_types::inner::Inner<'a, true, 32_usize, 0_usize, 0_usize>`

error[E0599]: no method named `inner_as_ref` found for enum `binary_codec_sv2::datatypes::non_copy_data_types::inner::Inner<'a, true, 32_usize, 0_usize, 0_usize>` in the current scope
   --> protocols/v2/subprotocols/mining/src/lib.rs:253:23
    |
253 |         let inner = v.inner_as_ref();
    |                       ^^^^^^^^^^^^ method not found in `binary_codec_sv2::datatypes::non_copy_data_types::inner::Inner<'a, true, 32_usize, 0_usize, 0_usize>`

error[E0599]: no method named `inner_as_ref` found for enum `binary_codec_sv2::datatypes::non_copy_data_types::inner::Inner<'a, false, 1_usize, 1_usize, 32_usize>` in the current scope
   --> protocols/v2/subprotocols/mining/src/lib.rs:270:23
    |
270 |         let inner = v.inner_as_ref();
    |                       ^^^^^^^^^^^^ method not found in `binary_codec_sv2::datatypes::non_copy_data_types::inner::Inner<'a, false, 1_usize, 1_usize, 32_usize>`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0599`.
error: could not compile `mining_sv2`

To learn more, run the command again with --verbose.
```

The solution is to add `default-features=true` when importing `binary_sv2` to the `Cargo.toml` in the `messages-sv2` crate. 