### PR TITLE
Add import rules to rustfmt and apply

### DIFF
--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -23,16 +23,14 @@ jobs:
             target: x86_64-unknown-linux-musl
 
     steps:
-      - name: Install stable toolchain & components
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt, clippy
-
-      - name: Rust fmt lint
-        uses: actions-rs/cargo@v1
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check

--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+name: Rustfmt
+
+jobs:
+  fmt:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: 
+          - macos-latest
+          - ubuntu-latest
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+
+    steps:
+      - name: Install stable toolchain & components
+        uses: actions/checkout@v2
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Rust fmt lint
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/.github/workflows/test-lint.yaml
+++ b/.github/workflows/test-lint.yaml
@@ -29,7 +29,7 @@ jobs:
           profile: minimal
           toolchain: 1.53.0
           override: true
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -58,12 +58,6 @@ jobs:
         with:
           command: build
           args: --manifest-path examples/sv1-client-and-server/Cargo.toml
-
-      - name: Rust fmt lint
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
 
       - name: Cargo clippy lint
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -82,3 +82,6 @@ reviewed:
 
 For everything else including performance an safety issues just accept the PR then amend the
 problematic code and do another PR tagging the author of the amended PR.
+
+#### Formatting
+Before merging, run `cargo +nightly fmt` to properly apply the settings in `rustfmt.toml`.

--- a/examples/interop-cpp/src/main.rs
+++ b/examples/interop-cpp/src/main.rs
@@ -14,17 +14,20 @@ mod main_ {
 mod main_ {
     use codec_sv2::{Encoder, Frame, StandardDecoder, StandardSv2Frame};
     use common_messages_sv2::{Protocol, SetupConnection, SetupConnectionError};
-    use const_sv2::CHANNEL_BIT_SETUP_CONNECTION;
-    use const_sv2::MESSAGE_TYPE_SETUP_CONNECTION;
-    use const_sv2::MESSAGE_TYPE_SETUP_CONNECTION_ERROR;
-    use std::convert::TryFrom;
-    use std::convert::TryInto;
-    use std::io::{Read, Write};
-    use std::net::TcpStream;
+    use const_sv2::{
+        CHANNEL_BIT_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION,
+        MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
+    };
+    use std::{
+        convert::{TryFrom, TryInto},
+        io::{Read, Write},
+        net::TcpStream,
+    };
 
     use binary_sv2::{
-        decodable::DecodableField, decodable::FieldMarker, encodable::EncodableField, from_bytes,
-        Deserialize, Error,
+        decodable::{DecodableField, FieldMarker},
+        encodable::EncodableField,
+        from_bytes, Deserialize, Error,
     };
 
     #[derive(Clone, Debug)]

--- a/examples/ping-pong-with-noise/src/main.rs
+++ b/examples/ping-pong-with-noise/src/main.rs
@@ -1,8 +1,10 @@
 mod messages;
 mod node;
-use async_std::net::{TcpListener, TcpStream};
-use async_std::prelude::*;
-use async_std::task;
+use async_std::{
+    net::{TcpListener, TcpStream},
+    prelude::*,
+    task,
+};
 use codec_sv2::{HandshakeRole, Initiator, Responder};
 use std::time;
 

--- a/examples/ping-pong-with-noise/src/messages.rs
+++ b/examples/ping-pong-with-noise/src/messages.rs
@@ -1,8 +1,6 @@
-use binary_sv2::GetSize;
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::{binary_codec_sv2, decodable::DecodableField, decodable::FieldMarker};
-use binary_sv2::{Bytes as Sv2Bytes, Seq064K, Str0255, U24, U256};
-use binary_sv2::{Deserialize, Serialize};
+use binary_sv2::{Bytes as Sv2Bytes, Deserialize, GetSize, Seq064K, Serialize, Str0255, U24, U256};
 use rand::{distributions::Alphanumeric, Rng};
 use std::convert::TryInto;
 

--- a/examples/ping-pong-with-noise/src/node.rs
+++ b/examples/ping-pong-with-noise/src/node.rs
@@ -5,12 +5,13 @@ use rand::Rng;
 use async_channel::{Receiver, Sender};
 use async_std::net::TcpStream;
 
-use async_std::sync::{Arc, Mutex};
-use async_std::task;
+use async_std::{
+    sync::{Arc, Mutex},
+    task,
+};
 use core::convert::TryInto;
 
-use codec_sv2::Frame;
-use codec_sv2::{HandshakeRole, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{Frame, HandshakeRole, StandardEitherFrame, StandardSv2Frame};
 
 use std::time;
 

--- a/examples/ping-pong-without-noise/src/main.rs
+++ b/examples/ping-pong-without-noise/src/main.rs
@@ -1,8 +1,10 @@
 mod messages;
 mod node;
-use async_std::net::{TcpListener, TcpStream};
-use async_std::prelude::*;
-use async_std::task;
+use async_std::{
+    net::{TcpListener, TcpStream},
+    prelude::*,
+    task,
+};
 use std::time;
 
 const ADDR: &str = "127.0.0.1:34254";

--- a/examples/ping-pong-without-noise/src/messages.rs
+++ b/examples/ping-pong-without-noise/src/messages.rs
@@ -1,8 +1,6 @@
-use binary_sv2::GetSize;
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::{binary_codec_sv2, decodable::DecodableField, decodable::FieldMarker};
-use binary_sv2::{Bytes as Sv2Bytes, Seq064K, Str0255, U24, U256};
-use binary_sv2::{Deserialize, Serialize};
+use binary_sv2::{Bytes as Sv2Bytes, Deserialize, GetSize, Seq064K, Serialize, Str0255, U24, U256};
 use rand::{distributions::Alphanumeric, Rng};
 use std::convert::TryInto;
 

--- a/examples/ping-pong-without-noise/src/node.rs
+++ b/examples/ping-pong-without-noise/src/node.rs
@@ -3,10 +3,12 @@ use binary_sv2::{from_bytes, U256};
 use rand::Rng;
 
 use async_channel::{bounded, Receiver, Sender};
-use async_std::net::TcpStream;
-use async_std::prelude::*;
-use async_std::sync::{Arc, Mutex};
-use async_std::task;
+use async_std::{
+    net::TcpStream,
+    prelude::*,
+    sync::{Arc, Mutex},
+    task,
+};
 
 use codec_sv2::{Frame, StandardDecoder, StandardSv2Frame};
 

--- a/examples/sv1-client-and-server/src/main.rs
+++ b/examples/sv1-client-and-server/src/main.rs
@@ -2,16 +2,21 @@ use async_std::net::{TcpListener, TcpStream};
 use std::convert::TryInto;
 
 use async_channel::{bounded, Receiver, Sender};
-use async_std::io::BufReader;
-use async_std::prelude::*;
-use async_std::sync::{Arc, Mutex};
-use async_std::task;
+use async_std::{
+    io::BufReader,
+    prelude::*,
+    sync::{Arc, Mutex},
+    task,
+};
 use std::time;
 
 const ADDR: &str = "127.0.0.1:34254";
 
 use v1::{
-    client_to_server, error::Error, json_rpc, server_to_client, utils::HexBytes, utils::HexU32Be,
+    client_to_server,
+    error::Error,
+    json_rpc, server_to_client,
+    utils::{HexBytes, HexU32Be},
     ClientStatus, IsClient, IsServer,
 };
 

--- a/examples/template-provider-test/src/main.rs
+++ b/examples/template-provider-test/src/main.rs
@@ -1,11 +1,15 @@
 use async_channel::{Receiver, Sender};
 use async_std::net::TcpStream;
 use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame, Sv2Frame};
-use messages_sv2::parsers::{IsSv2Message, TemplateDistribution};
-use messages_sv2::template_distribution_sv2::SubmitSolution;
+use messages_sv2::{
+    parsers::{IsSv2Message, TemplateDistribution},
+    template_distribution_sv2::SubmitSolution,
+};
 use network_helpers::PlainConnection;
-use std::convert::TryInto;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::{
+    convert::TryInto,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
 
 pub type Message = TemplateDistribution<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;

--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -45,9 +45,7 @@ use std::convert::TryInto;
 // use error::Result;
 use error::Error;
 pub use json_rpc::Message;
-pub use methods::client_to_server;
-pub use methods::server_to_client;
-pub use methods::MethodError;
+pub use methods::{client_to_server, server_to_client, MethodError};
 use utils::{HexBytes, HexU32Be};
 
 /// json_rpc Response are not handled cause startum v1 do not have any request from a server to a

--- a/protocols/v1/src/methods/client_to_server.rs
+++ b/protocols/v1/src/methods/client_to_server.rs
@@ -1,12 +1,13 @@
-use serde_json::Value;
-use serde_json::Value::Array as JArrary;
-use serde_json::Value::Number as JNumber;
-use serde_json::Value::String as JString;
-use std::convert::TryFrom;
-use std::convert::TryInto;
+use serde_json::{
+    Value,
+    Value::{Array as JArrary, Number as JNumber, String as JString},
+};
+use std::convert::{TryFrom, TryInto};
 
-use crate::json_rpc::{Message, Response, StandardRequest};
-use crate::utils::{HexBytes, HexU32Be};
+use crate::{
+    json_rpc::{Message, Response, StandardRequest},
+    utils::{HexBytes, HexU32Be},
+};
 
 use crate::methods::{MethodError, ParsingMethodError};
 

--- a/protocols/v1/src/methods/mod.rs
+++ b/protocols/v1/src/methods/mod.rs
@@ -1,7 +1,6 @@
 use bitcoin_hashes::Error as BTCHashError;
 use hex::FromHexError;
-use std::convert::TryFrom;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 
 pub mod client_to_server;
 pub mod server_to_client;

--- a/protocols/v1/src/methods/server_to_client.rs
+++ b/protocols/v1/src/methods/server_to_client.rs
@@ -1,14 +1,14 @@
-use serde_json::Value;
-use serde_json::Value::Array as JArrary;
-use serde_json::Value::Bool as JBool;
-use serde_json::Value::Number as JNumber;
-use serde_json::Value::String as JString;
-use std::convert::TryFrom;
-use std::convert::TryInto;
+use serde_json::{
+    Value,
+    Value::{Array as JArrary, Bool as JBool, Number as JNumber, String as JString},
+};
+use std::convert::{TryFrom, TryInto};
 
-use crate::json_rpc::{Message, Notification, Response};
-use crate::methods::{MethodError, ParsingMethodError};
-use crate::utils::{HexBytes, HexU32Be, PrevHash};
+use crate::{
+    json_rpc::{Message, Notification, Response},
+    methods::{MethodError, ParsingMethodError},
+    utils::{HexBytes, HexU32Be, PrevHash},
+};
 
 // client.get_version() TODO
 

--- a/protocols/v1/src/utils.rs
+++ b/protocols/v1/src/utils.rs
@@ -2,8 +2,7 @@ use bitcoin_hashes::hex::{FromHex, ToHex};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
 use hex::FromHexError;
 use serde_json::Value;
-use std::convert::TryFrom;
-use std::mem::size_of;
+use std::{convert::TryFrom, mem::size_of};
 
 /// Helper type that allows simple serialization and deserialization of byte vectors
 /// that are represented as hex strings in JSON

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/decodable.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/decodable.rs
@@ -1,6 +1,8 @@
-use crate::codec::{GetSize, SizeHint};
-use crate::datatypes::{Bytes, Signature, Sv2DataType, B016M, B0255, B032, B064K, U24, U256};
-use crate::Error;
+use crate::{
+    codec::{GetSize, SizeHint},
+    datatypes::{Bytes, Signature, Sv2DataType, B016M, B0255, B032, B064K, U24, U256},
+    Error,
+};
 use alloc::vec::Vec;
 #[cfg(not(feature = "no_std"))]
 use std::io::{Cursor, Read};

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/encodable.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/encodable.rs
@@ -1,6 +1,8 @@
-use crate::codec::GetSize;
-use crate::datatypes::{Bytes, Signature, Sv2DataType, B016M, B0255, B032, B064K, U24, U256};
-use crate::Error;
+use crate::{
+    codec::GetSize,
+    datatypes::{Bytes, Signature, Sv2DataType, B016M, B0255, B032, B064K, U24, U256},
+    Error,
+};
 use alloc::vec::Vec;
 #[cfg(not(feature = "no_std"))]
 use std::io::{Error as E, Write};

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/impls.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/impls.rs
@@ -1,9 +1,13 @@
-use crate::codec::decodable::{
-    Decodable, DecodableField, DecodablePrimitive, FieldMarker, GetMarker, PrimitiveMarker,
+use crate::{
+    codec::{
+        decodable::{
+            Decodable, DecodableField, DecodablePrimitive, FieldMarker, GetMarker, PrimitiveMarker,
+        },
+        encodable::{EncodableField, EncodablePrimitive},
+    },
+    datatypes::*,
+    Error,
 };
-use crate::codec::encodable::{EncodableField, EncodablePrimitive};
-use crate::datatypes::*;
-use crate::Error;
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/copy_data_types.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/copy_data_types.rs
@@ -1,7 +1,5 @@
 //! Copy data types
-use crate::codec::Fixed;
-use crate::datatypes::Sv2DataType;
-use crate::Error;
+use crate::{codec::Fixed, datatypes::Sv2DataType, Error};
 use core::convert::{TryFrom, TryInto};
 
 #[cfg(not(feature = "no_std"))]

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/mod.rs
@@ -1,5 +1,7 @@
-use crate::codec::{GetSize, SizeHint};
-use crate::Error;
+use crate::{
+    codec::{GetSize, SizeHint},
+    Error,
+};
 mod non_copy_data_types;
 
 mod copy_data_types;

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
@@ -1,7 +1,9 @@
 use super::IntoOwned;
-use crate::codec::{GetSize, SizeHint};
-use crate::datatypes::Sv2DataType;
-use crate::Error;
+use crate::{
+    codec::{GetSize, SizeHint},
+    datatypes::Sv2DataType,
+    Error,
+};
 use core::convert::TryFrom;
 
 #[cfg(not(feature = "no_std"))]

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -1,10 +1,12 @@
-use crate::codec::decodable::{Decodable, DecodableField, FieldMarker, GetMarker, PrimitiveMarker};
-use crate::codec::encodable::{EncodableField, EncodablePrimitive};
-use crate::codec::Fixed;
-use crate::codec::GetSize;
-use crate::datatypes::Sv2DataType;
-use crate::datatypes::*;
-use crate::Error;
+use crate::{
+    codec::{
+        decodable::{Decodable, DecodableField, FieldMarker, GetMarker, PrimitiveMarker},
+        encodable::{EncodableField, EncodablePrimitive},
+        Fixed, GetSize,
+    },
+    datatypes::{Sv2DataType, *},
+    Error,
+};
 use core::marker::PhantomData;
 
 // TODO add test for that implement also with serde!!!!

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
@@ -33,10 +33,11 @@ pub use datatypes::{
     U256,
 };
 
-pub use crate::codec::decodable::Decodable;
-pub use crate::codec::encodable::{Encodable, EncodableField};
-pub use crate::codec::GetSize;
-pub use crate::codec::SizeHint;
+pub use crate::codec::{
+    decodable::Decodable,
+    encodable::{Encodable, EncodableField},
+    GetSize, SizeHint,
+};
 
 #[allow(clippy::wrong_self_convention)]
 pub fn to_bytes<T: Encodable + GetSize>(src: T) -> Result<Vec<u8>, Error> {
@@ -56,15 +57,12 @@ pub fn from_bytes<'a, T: Decodable<'a>>(data: &'a mut [u8]) -> Result<T, Error> 
 }
 
 pub mod decodable {
-    pub use crate::codec::decodable::Decodable;
-    pub use crate::codec::decodable::DecodableField;
-    pub use crate::codec::decodable::FieldMarker;
+    pub use crate::codec::decodable::{Decodable, DecodableField, FieldMarker};
     //pub use crate::codec::decodable::PrimitiveMarker;
 }
 
 pub mod encodable {
-    pub use crate::codec::encodable::Encodable;
-    pub use crate::codec::encodable::EncodableField;
+    pub use crate::codec::encodable::{Encodable, EncodableField};
 }
 
 #[macro_use]

--- a/protocols/v2/binary-sv2/serde-sv2/src/de.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/de.rs
@@ -5,8 +5,10 @@
 use alloc::vec::Vec;
 use core::convert::TryInto;
 
-use serde::de::{self, DeserializeSeed, SeqAccess, Visitor};
-use serde::Deserialize;
+use serde::{
+    de::{self, DeserializeSeed, SeqAccess, Visitor},
+    Deserialize,
+};
 
 use crate::error::{Error, Result};
 
@@ -634,8 +636,7 @@ fn test_b064k() {
 
 #[test]
 fn test_seq0255_u256() {
-    use crate::primitives::Seq0255;
-    use crate::primitives::U256;
+    use crate::primitives::{Seq0255, U256};
     use serde::Serialize;
 
     let u256_1: crate::primitives::U256 = (&[6; 32][..]).try_into().unwrap();
@@ -685,8 +686,7 @@ fn test_seq0255_bool() {
 
 #[test]
 fn test_seq0255_u16() {
-    use crate::primitives::Seq0255;
-    use crate::primitives::U16;
+    use crate::primitives::{Seq0255, U16};
     use serde::Serialize;
 
     let s: crate::primitives::Seq0255<U16> = Seq0255::new(vec![10, 43, 89]).unwrap();
@@ -707,8 +707,7 @@ fn test_seq0255_u16() {
 
 #[test]
 fn test_seq0255_u24() {
-    use crate::primitives::Seq0255;
-    use crate::primitives::U24;
+    use crate::primitives::{Seq0255, U24};
     use serde::Serialize;
 
     let u24_1 = U24(56);
@@ -757,8 +756,7 @@ fn test_seq0255_u32() {
 
 #[test]
 fn test_seq0255_signature() {
-    use crate::primitives::Seq0255;
-    use crate::primitives::Signature;
+    use crate::primitives::{Seq0255, Signature};
     use serde::Serialize;
 
     let siganture_1: Signature = (&[88; 64][..]).try_into().unwrap();
@@ -785,8 +783,7 @@ fn test_seq0255_signature() {
 
 #[test]
 fn test_seq064k_u256() {
-    use crate::primitives::Seq064K;
-    use crate::primitives::U256;
+    use crate::primitives::{Seq064K, U256};
     use serde::Serialize;
 
     let u256_1: crate::primitives::U256 = (&[6; 32][..]).try_into().unwrap();
@@ -842,8 +839,7 @@ fn test_seq064k_bool() {
 
 #[test]
 fn test_seq064k_u16() {
-    use crate::primitives::Seq064K;
-    use crate::primitives::U16;
+    use crate::primitives::{Seq064K, U16};
     use serde::Serialize;
 
     let s: Seq064K<U16> = Seq064K::new(vec![10, 43, 89]).unwrap();
@@ -864,8 +860,7 @@ fn test_seq064k_u16() {
 
 #[test]
 fn test_seq064k_u24() {
-    use crate::primitives::Seq064K;
-    use crate::primitives::U24;
+    use crate::primitives::{Seq064K, U24};
     use serde::Serialize;
 
     let u24_1 = U24(56);
@@ -914,8 +909,7 @@ fn test_seq064k_u32() {
 
 #[test]
 fn test_seq064k_signature() {
-    use crate::primitives::Seq064K;
-    use crate::primitives::Signature;
+    use crate::primitives::{Seq064K, Signature};
     use serde::Serialize;
 
     let siganture_1: Signature = (&[88_u8; 64][..]).try_into().unwrap();
@@ -942,8 +936,7 @@ fn test_seq064k_signature() {
 
 #[test]
 fn test_seq064k_b016m() {
-    use crate::primitives::Seq064K;
-    use crate::primitives::B016M;
+    use crate::primitives::{Seq064K, B016M};
     use serde::Serialize;
 
     let bytes_1: B016M = (&[88_u8; 64][..]).try_into().unwrap();

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b016m.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b016m.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::primitives::GetSize;
+use crate::{error::Error, primitives::GetSize};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use serde::{de::Visitor, ser, ser::SerializeTuple, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b0255.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b0255.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::primitives::GetSize;
+use crate::{error::Error, primitives::GetSize};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use serde::{de::Visitor, ser, ser::SerializeTuple, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b032.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b032.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::primitives::GetSize;
+use crate::{error::Error, primitives::GetSize};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use serde::{de::Visitor, ser, ser::SerializeTuple, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b064k.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::primitives::GetSize;
+use crate::{error::Error, primitives::GetSize};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use serde::{de::Visitor, ser, ser::SerializeTuple, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/mod.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/mod.rs
@@ -5,13 +5,8 @@ mod signature;
 mod u24;
 mod u256;
 
-pub use byte_arrays::b016m::B016M;
-pub use byte_arrays::b0255::B0255;
-pub use byte_arrays::b032::B032;
-pub use byte_arrays::b064k::B064K;
-pub use byte_arrays::bytes::Bytes;
-pub use sequences::seq0255::Seq0255;
-pub use sequences::seq064k::Seq064K;
+pub use byte_arrays::{b016m::B016M, b0255::B0255, b032::B032, b064k::B064K, bytes::Bytes};
+pub use sequences::{seq0255::Seq0255, seq064k::Seq064K};
 
 pub use signature::Signature;
 pub use u24::U24;

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq0255.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq0255.rs
@@ -1,8 +1,11 @@
-use super::super::{Signature, U24, U256};
-use super::{Seq, SeqMaxLen, SeqVisitor, TryFromBSlice};
-use crate::primitives::FixedSize;
-use crate::primitives::GetSize;
-use crate::Error;
+use super::{
+    super::{Signature, U24, U256},
+    Seq, SeqMaxLen, SeqVisitor, TryFromBSlice,
+};
+use crate::{
+    primitives::{FixedSize, GetSize},
+    Error,
+};
 use alloc::vec::Vec;
 use serde::{ser, ser::SerializeTuple, Deserialize, Deserializer, Serialize};
 

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
@@ -1,8 +1,11 @@
-use super::super::{Signature, B016M, B064K, U24, U256};
-use super::{Seq, SeqMaxLen, SeqVisitor, TryFromBSlice};
-use crate::primitives::FixedSize;
-use crate::primitives::GetSize;
-use crate::Error;
+use super::{
+    super::{Signature, B016M, B064K, U24, U256},
+    Seq, SeqMaxLen, SeqVisitor, TryFromBSlice,
+};
+use crate::{
+    primitives::{FixedSize, GetSize},
+    Error,
+};
 use alloc::vec::Vec;
 use serde::{ser, ser::SerializeTuple, Deserialize, Deserializer, Serialize};
 

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/signature.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/signature.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::primitives::FixedSize;
+use crate::{error::Error, primitives::FixedSize};
 use alloc::boxed::Box;
 use core::convert::TryFrom;
 use serde::{de::Visitor, ser, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/u256.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/u256.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::primitives::FixedSize;
+use crate::{error::Error, primitives::FixedSize};
 use alloc::boxed::Box;
 use core::convert::TryFrom;
 use serde::{de::Visitor, ser, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -4,15 +4,19 @@ use binary_sv2::Deserialize;
 use binary_sv2::GetSize;
 use binary_sv2::Serialize;
 use core::marker::PhantomData;
-use framing_sv2::framing2::{EitherFrame, Frame as F_, Sv2Frame};
 #[cfg(feature = "noise_sv2")]
 use framing_sv2::framing2::{HandShakeFrame, NoiseFrame};
-use framing_sv2::header::Header;
 #[cfg(feature = "noise_sv2")]
 use framing_sv2::header::NoiseHeader;
+use framing_sv2::{
+    framing2::{EitherFrame, Frame as F_, Sv2Frame},
+    header::Header,
+};
 
-use crate::buffer::{Buffer, SlowAndCorrect};
-use crate::error::{Error, Result};
+use crate::{
+    buffer::{Buffer, SlowAndCorrect},
+    error::{Error, Result},
+};
 #[cfg(feature = "noise_sv2")]
 use crate::{State, TransportMode};
 

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
-use binary_sv2::GetSize;
-use binary_sv2::Serialize;
+use binary_sv2::{GetSize, Serialize};
 #[cfg(feature = "noise_sv2")]
 use core::cmp::min;
 #[cfg(feature = "noise_sv2")]

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -12,8 +12,7 @@ mod error;
 
 pub use error::Error;
 
-pub use decoder::StandardEitherFrame;
-pub use decoder::StandardSv2Frame;
+pub use decoder::{StandardEitherFrame, StandardSv2Frame};
 
 pub use decoder::StandardDecoder;
 #[cfg(feature = "noise_sv2")]

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -1,8 +1,6 @@
-use crate::header::Header;
-use crate::header::NoiseHeader;
+use crate::header::{Header, NoiseHeader};
 use alloc::vec::Vec;
-use binary_sv2::Serialize;
-use binary_sv2::{to_writer, GetSize};
+use binary_sv2::{to_writer, GetSize, Serialize};
 use core::convert::TryFrom;
 
 const NOISE_MAX_LEN: usize = const_sv2::NOISE_FRAME_MAX_SIZE;

--- a/protocols/v2/framing-sv2/src/header.rs
+++ b/protocols/v2/framing-sv2/src/header.rs
@@ -2,8 +2,7 @@
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::binary_codec_sv2;
-use binary_sv2::U24;
-use binary_sv2::{Deserialize, Serialize};
+use binary_sv2::{Deserialize, Serialize, U24};
 use core::convert::TryInto;
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone)]

--- a/protocols/v2/messages-sv2/src/common_properties.rs
+++ b/protocols/v2/messages-sv2/src/common_properties.rs
@@ -4,6 +4,8 @@ use crate::selectors::{
 };
 use common_messages_sv2::{has_requires_std_job, Protocol, SetupConnection};
 use mining_sv2::{Extranonce, Target};
+use std::collections::HashMap;
+use std::fmt::Debug as D;
 use std::{collections::HashMap, fmt::Debug as D};
 
 /// What define a mining downstream node at the very basic

--- a/protocols/v2/messages-sv2/src/common_properties.rs
+++ b/protocols/v2/messages-sv2/src/common_properties.rs
@@ -2,11 +2,9 @@
 use crate::selectors::{
     DownstreamMiningSelector, DownstreamSelector, NullDownstreamMiningSelector,
 };
-use common_messages_sv2::has_requires_std_job;
-use common_messages_sv2::{Protocol, SetupConnection};
+use common_messages_sv2::{has_requires_std_job, Protocol, SetupConnection};
 use mining_sv2::{Extranonce, Target};
-use std::collections::HashMap;
-use std::fmt::Debug as D;
+use std::{collections::HashMap, fmt::Debug as D};
 
 /// What define a mining downstream node at the very basic
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]

--- a/protocols/v2/messages-sv2/src/common_properties.rs
+++ b/protocols/v2/messages-sv2/src/common_properties.rs
@@ -4,8 +4,6 @@ use crate::selectors::{
 };
 use common_messages_sv2::{has_requires_std_job, Protocol, SetupConnection};
 use mining_sv2::{Extranonce, Target};
-use std::collections::HashMap;
-use std::fmt::Debug as D;
 use std::{collections::HashMap, fmt::Debug as D};
 
 /// What define a mining downstream node at the very basic

--- a/protocols/v2/messages-sv2/src/handlers/common.rs
+++ b/protocols/v2/messages-sv2/src/handlers/common.rs
@@ -1,9 +1,11 @@
 use super::SendTo_;
-use crate::common_properties::CommonDownstreamData;
-use crate::errors::Error;
-use crate::parsers::CommonMessages;
-use crate::routing_logic::{CommonRouter, CommonRoutingLogic};
-use crate::utils::Mutex;
+use crate::{
+    common_properties::CommonDownstreamData,
+    errors::Error,
+    parsers::CommonMessages,
+    routing_logic::{CommonRouter, CommonRoutingLogic},
+    utils::Mutex,
+};
 use common_messages_sv2::{
     ChannelEndpointChanged, SetupConnection, SetupConnectionError, SetupConnectionSuccess,
 };

--- a/protocols/v2/messages-sv2/src/handlers/mining.rs
+++ b/protocols/v2/messages-sv2/src/handlers/mining.rs
@@ -1,6 +1,4 @@
-use crate::common_properties::RequestIdMapper;
-use crate::errors::Error;
-use crate::parsers::Mining;
+use crate::{common_properties::RequestIdMapper, errors::Error, parsers::Mining};
 use core::convert::TryInto;
 use mining_sv2::{
     CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannel,
@@ -11,15 +9,16 @@ use mining_sv2::{
     UpdateChannelError,
 };
 
-use crate::common_properties::{IsMiningDownstream, IsMiningUpstream};
-use crate::routing_logic::{MiningRouter, MiningRoutingLogic};
-use crate::selectors::DownstreamMiningSelector;
+use crate::{
+    common_properties::{IsMiningDownstream, IsMiningUpstream},
+    routing_logic::{MiningRouter, MiningRoutingLogic},
+    selectors::DownstreamMiningSelector,
+};
 
 use super::SendTo_;
 
 use crate::utils::Mutex;
-use std::fmt::Debug as D;
-use std::sync::Arc;
+use std::{fmt::Debug as D, sync::Arc};
 
 pub type SendTo<Remote> = SendTo_<Mining<'static>, Remote>;
 

--- a/protocols/v2/messages-sv2/src/handlers/template_distribution.rs
+++ b/protocols/v2/messages-sv2/src/handlers/template_distribution.rs
@@ -1,7 +1,5 @@
 use super::SendTo_;
-use crate::errors::Error;
-use crate::parsers::TemplateDistribution;
-use crate::utils::Mutex;
+use crate::{errors::Error, parsers::TemplateDistribution, utils::Mutex};
 use template_distribution_sv2::{
     CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, RequestTransactionDataError,
     RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution,

--- a/protocols/v2/messages-sv2/src/job_creator.rs
+++ b/protocols/v2/messages-sv2/src/job_creator.rs
@@ -1,13 +1,18 @@
 use crate::utils::Id;
 use binary_sv2::B064K;
-use bitcoin::blockdata::script::Script;
-use bitcoin::blockdata::transaction::{OutPoint, Transaction, TxIn, TxOut};
-use bitcoin::consensus::encode::Encodable;
-pub use bitcoin::secp256k1::SecretKey;
-pub use bitcoin::util::ecdsa::{PrivateKey, PublicKey};
+use bitcoin::{
+    blockdata::{
+        script::Script,
+        transaction::{OutPoint, Transaction, TxIn, TxOut},
+    },
+    consensus::encode::Encodable,
+};
+pub use bitcoin::{
+    secp256k1::SecretKey,
+    util::ecdsa::{PrivateKey, PublicKey},
+};
 use mining_sv2::NewExtendedMiningJob;
-use std::collections::HashMap;
-use std::convert::TryInto;
+use std::{collections::HashMap, convert::TryInto};
 use template_distribution_sv2::NewTemplate;
 
 /// Used by pool one for each group channel

--- a/protocols/v2/messages-sv2/src/routing_logic.rs
+++ b/protocols/v2/messages-sv2/src/routing_logic.rs
@@ -19,23 +19,20 @@
 //! MiningProxyRoutingLogic -> routing logic valid for a standard Sv2 mining proxy it is both a
 //!     CommonRouter and a MiningRouter
 //!
-use crate::common_properties::{
-    CommonDownstreamData, IsMiningDownstream, IsMiningUpstream, PairSettings,
+use crate::{
+    common_properties::{CommonDownstreamData, IsMiningDownstream, IsMiningUpstream, PairSettings},
+    errors::Error,
+    selectors::{
+        DownstreamMiningSelector, GeneralMiningSelector, NullDownstreamMiningSelector,
+        UpstreamMiningSelctor,
+    },
+    utils::{Id, Mutex},
 };
-use crate::errors::Error;
-use crate::selectors::{
-    DownstreamMiningSelector, GeneralMiningSelector, NullDownstreamMiningSelector,
-    UpstreamMiningSelctor,
-};
-use crate::utils::{Id, Mutex};
 use common_messages_sv2::{
     has_requires_std_job, Protocol, SetupConnection, SetupConnectionSuccess,
 };
 use mining_sv2::{OpenStandardMiningChannel, OpenStandardMiningChannelSuccess};
-use std::collections::HashMap;
-use std::fmt::Debug as D;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{collections::HashMap, fmt::Debug as D, marker::PhantomData, sync::Arc};
 
 /// CommonRouter trait it define a router needed by
 /// crate::handlers::common::ParseUpstreamCommonMessages and

--- a/protocols/v2/messages-sv2/src/selectors.rs
+++ b/protocols/v2/messages-sv2/src/selectors.rs
@@ -1,11 +1,11 @@
 //! Selectors are used from the routing logic in order to chose to which remote or set of remotes
 //! a message should be ralyied, or to which remote or set of remotes a message should be sent.
-use crate::common_properties::{IsDownstream, IsMiningDownstream, IsMiningUpstream, PairSettings};
-use crate::errors::Error;
-use crate::utils::Mutex;
-use std::collections::HashMap;
-use std::fmt::Debug as D;
-use std::sync::Arc;
+use crate::{
+    common_properties::{IsDownstream, IsMiningDownstream, IsMiningUpstream, PairSettings},
+    errors::Error,
+    utils::Mutex,
+};
+use std::{collections::HashMap, fmt::Debug as D, sync::Arc};
 
 /// A DownstreamMiningSelector useful for routing messages in a mining proxy
 #[derive(Debug, Clone, Default)]

--- a/protocols/v2/messages-sv2/src/utils.rs
+++ b/protocols/v2/messages-sv2/src/utils.rs
@@ -1,14 +1,15 @@
 //! Useful struct used into this crate and by crates that want to interact with this one
 use crate::errors::Error;
 use binary_sv2::U256;
-use bitcoin::hashes::sha256d::Hash as DHash;
 use bitcoin::{
     blockdata::block::BlockHeader,
     hash_types::{BlockHash, TxMerkleNode},
-    hashes::{sha256d, Hash, HashEngine},
+    hashes::{sha256d, sha256d::Hash as DHash, Hash, HashEngine},
 };
-use std::convert::TryInto;
-use std::sync::{Mutex as Mutex_, MutexGuard, PoisonError}; //compact_target_from_u256
+use std::{
+    convert::TryInto,
+    sync::{Mutex as Mutex_, MutexGuard, PoisonError},
+}; //compact_target_from_u256
 
 /// Generator of unique ids
 #[derive(Debug, PartialEq)]

--- a/protocols/v2/noise-sv2/src/auth.rs
+++ b/protocols/v2/noise-sv2/src/auth.rs
@@ -1,11 +1,12 @@
 use bytes::{BufMut, BytesMut};
-use core::convert::{TryFrom, TryInto};
-use core::time::Duration;
+use core::{
+    convert::{TryFrom, TryInto},
+    time::Duration,
+};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
-use crate::StaticPublicKey;
-use crate::{Error, Result};
+use crate::{Error, Result, StaticPublicKey};
 
 use ed25519_dalek::Signer;
 
@@ -106,15 +107,14 @@ impl SignedPartHeader {
         SystemTime::UNIX_EPOCH
             .checked_add(Duration::from_secs(unix_timestamp.into()))
             .ok_or(
-                Error {}
-                //ErrorKind::Noise(
-                //    format!(
-                //        "Cannot convert unix timestamp ({}) to system time",
-                //        unix_timestamp
-                //    )
-                //    .to_string(),
-                //)
-                //.into(),
+                Error {}, //ErrorKind::Noise(
+                          //    format!(
+                          //        "Cannot convert unix timestamp ({}) to system time",
+                          //        unix_timestamp
+                          //    )
+                          //    .to_string(),
+                          //)
+                          //.into(),
             )
     }
 }

--- a/protocols/v2/noise-sv2/src/formats.rs
+++ b/protocols/v2/noise-sv2/src/formats.rs
@@ -1,12 +1,13 @@
 use alloc::string::String;
-use core::convert::TryFrom;
-use core::fmt;
+use core::{convert::TryFrom, fmt};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
-use crate::auth::{SignatureNoiseMessage, SignedPart, SignedPartHeader};
-use crate::error::{Error, Result};
-use crate::{StaticPublicKey, StaticSecretKey};
+use crate::{
+    auth::{SignatureNoiseMessage, SignedPart, SignedPartHeader},
+    error::{Error, Result},
+    StaticPublicKey, StaticSecretKey,
+};
 
 use ed25519_dalek::ed25519::signature::Signature;
 

--- a/protocols/v2/noise-sv2/src/lib.rs
+++ b/protocols/v2/noise-sv2/src/lib.rs
@@ -7,13 +7,11 @@ pub mod handshake;
 
 use alloc::vec::Vec;
 use bytes::Bytes;
-use core::convert::TryFrom;
-use core::time::Duration;
+use core::{convert::TryFrom, time::Duration};
 use error::{Error, Result};
 use snow::{params::NoiseParams, Builder, HandshakeState, TransportState};
 
-pub use auth::SignatureNoiseMessage;
-pub use auth::SignedPartHeader;
+pub use auth::{SignatureNoiseMessage, SignedPartHeader};
 pub use formats::Certificate;
 
 /// Static keypair (aka 's' and 'rs') from the noise handshake patterns. This has to be used by

--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -1,12 +1,11 @@
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
-use binary_sv2::Str0255;
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::{
     binary_codec_sv2, binary_codec_sv2::CVec, decodable::DecodableField, decodable::FieldMarker,
     free_vec, Error, GetSize,
 };
-use binary_sv2::{Deserialize, Serialize};
+use binary_sv2::{Deserialize, Serialize, Str0255};
 use const_sv2::{
     SV2_JOB_DISTR_PROTOCOL_DISCRIMINANT, SV2_JOB_NEG_PROTOCOL_DISCRIMINANT,
     SV2_MINING_PROTOCOL_DISCRIMINANT, SV2_TEMPLATE_DISTR_PROTOCOL_DISCRIMINANT,

--- a/protocols/v2/subprotocols/mining/src/lib.rs
+++ b/protocols/v2/subprotocols/mining/src/lib.rs
@@ -105,8 +105,10 @@
 //! This protocol explicitly expects that upstream server software is able to manage the size of the
 //! hashing space correctly for its clients and can provide new jobs quickly enough.
 use binary_sv2::{B032, U256};
-use core::cmp::{Ord, PartialOrd};
-use core::convert::TryInto;
+use core::{
+    cmp::{Ord, PartialOrd},
+    convert::TryInto,
+};
 
 extern crate alloc;
 mod close_channel;
@@ -122,11 +124,11 @@ mod submit_shares;
 mod update_channel;
 
 pub use close_channel::CloseChannel;
-pub use new_mining_job::NewExtendedMiningJob;
-pub use new_mining_job::NewMiningJob;
-pub use open_channel::OpenMiningChannelError;
-pub use open_channel::{OpenExtendedMiningChannel, OpenExtendedMiningChannelSuccess};
-pub use open_channel::{OpenStandardMiningChannel, OpenStandardMiningChannelSuccess};
+pub use new_mining_job::{NewExtendedMiningJob, NewMiningJob};
+pub use open_channel::{
+    OpenExtendedMiningChannel, OpenExtendedMiningChannelSuccess, OpenMiningChannelError,
+    OpenStandardMiningChannel, OpenStandardMiningChannelSuccess,
+};
 pub use reconnect::Reconnect;
 pub use set_custom_mining_job::{
     SetCustomMiningJob, SetCustomMiningJobError, SetCustomMiningJobSuccess,
@@ -135,9 +137,9 @@ pub use set_extranonce_prefix::SetExtranoncePrefix;
 pub use set_group_channel::SetGroupChannel;
 pub use set_new_prev_hash::SetNewPrevHash;
 pub use set_target::SetTarget;
-pub use submit_shares::SubmitSharesExtended;
-pub use submit_shares::SubmitSharesStandard;
-pub use submit_shares::{SubmitSharesError, SubmitSharesSuccess};
+pub use submit_shares::{
+    SubmitSharesError, SubmitSharesExtended, SubmitSharesStandard, SubmitSharesSuccess,
+};
 pub use update_channel::{UpdateChannel, UpdateChannelError};
 
 pub fn target_from_hr(_hr: f32) -> U256<'static> {

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -4,8 +4,7 @@ use alloc::vec::Vec;
 use binary_sv2::binary_codec_sv2::{self, free_vec, free_vec_2, CVec, CVec2};
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::Error;
-use binary_sv2::{Deserialize, Serialize};
-use binary_sv2::{Seq0255, B0255, B064K, U256};
+use binary_sv2::{Deserialize, Seq0255, Serialize, B0255, B064K, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 

--- a/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
@@ -4,8 +4,7 @@ use alloc::vec::Vec;
 use binary_sv2::binary_codec_sv2::{self, free_vec, free_vec_2, CVec, CVec2};
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::Error;
-use binary_sv2::{Deserialize, Serialize};
-use binary_sv2::{Seq064K, Str0255, B016M, B064K};
+use binary_sv2::{Deserialize, Seq064K, Serialize, Str0255, B016M, B064K};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 

--- a/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
@@ -4,8 +4,7 @@ use alloc::vec::Vec;
 use binary_sv2::binary_codec_sv2::{self, free_vec, CVec};
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::Error;
-use binary_sv2::U256;
-use binary_sv2::{Deserialize, Serialize};
+use binary_sv2::{Deserialize, Serialize, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 

--- a/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
@@ -4,8 +4,7 @@ use alloc::vec::Vec;
 use binary_sv2::binary_codec_sv2::{self, free_vec, CVec};
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::Error;
-use binary_sv2::B064K;
-use binary_sv2::{Deserialize, Serialize};
+use binary_sv2::{Deserialize, Serialize, B064K};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -12,8 +12,10 @@ use template_distribution_sv2::{
 };
 
 use binary_sv2::{
-    binary_codec_sv2::CVec, decodable::DecodableField, decodable::FieldMarker,
-    encodable::EncodableField, from_bytes, Deserialize, Error,
+    binary_codec_sv2::CVec,
+    decodable::{DecodableField, FieldMarker},
+    encodable::EncodableField,
+    from_bytes, Deserialize, Error,
 };
 
 use const_sv2::{

--- a/roles/v2/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/downstream_mining.rs
@@ -1,22 +1,23 @@
 use super::upstream_mining::{JobDispatcher, StdFrame as UpstreamFrame, UpstreamMiningNode};
 use async_channel::{Receiver, SendError, Sender};
-use messages_sv2::common_messages_sv2::{SetupConnection, SetupConnectionSuccess};
-use messages_sv2::common_properties::{
-    CommonDownstreamData, DownstreamChannel, IsDownstream, IsMiningDownstream,
+use messages_sv2::{
+    common_messages_sv2::{SetupConnection, SetupConnectionSuccess},
+    common_properties::{
+        CommonDownstreamData, DownstreamChannel, IsDownstream, IsMiningDownstream,
+    },
+    errors::Error,
+    handlers::{
+        common::{ParseDownstreamCommonMessages, SendTo as SendToCommon},
+        mining::{ChannelType, ParseDownstreamMiningMessages, SendTo},
+    },
+    mining_sv2::*,
+    parsers::{Mining, MiningDeviceMessages, PoolMessages},
+    routing_logic::{CommonRoutingLogic, MiningProxyRoutingLogic, MiningRoutingLogic},
+    utils::Mutex,
 };
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::common::{ParseDownstreamCommonMessages, SendTo as SendToCommon};
-use messages_sv2::handlers::mining::{ChannelType, ParseDownstreamMiningMessages, SendTo};
-use messages_sv2::mining_sv2::*;
-use messages_sv2::parsers::{Mining, MiningDeviceMessages, PoolMessages};
-use messages_sv2::routing_logic::{
-    CommonRoutingLogic, MiningProxyRoutingLogic, MiningRoutingLogic,
-};
-use messages_sv2::utils::Mutex;
 use std::collections::HashMap;
 
-use codec_sv2::Frame;
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
 
 pub type Message = MiningDeviceMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
@@ -79,8 +80,7 @@ impl DownstreamMiningNodeStatus {
     }
 }
 
-use async_std::sync::Arc;
-use async_std::task;
+use async_std::{sync::Arc, task};
 use core::convert::TryInto;
 
 impl DownstreamMiningNode {
@@ -306,8 +306,7 @@ impl
     }
 }
 
-use async_std::net::TcpListener;
-use async_std::prelude::*;
+use async_std::{net::TcpListener, prelude::*};
 use network_helpers::PlainConnection;
 use std::net::SocketAddr;
 

--- a/roles/v2/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/upstream_mining.rs
@@ -1,25 +1,25 @@
 use super::downstream_mining::{DownstreamMiningNode, StdFrame as DownstreamFrame};
 use async_channel::{Receiver, SendError, Sender};
 use async_recursion::async_recursion;
-use async_std::net::TcpStream;
-use async_std::task;
+use async_std::{net::TcpStream, task};
 use codec_sv2::{Frame, HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
-use messages_sv2::common_messages_sv2::{Protocol, SetupConnection};
-use messages_sv2::common_properties::{
-    DownstreamChannel, IsMiningDownstream, IsMiningUpstream, IsUpstream, RequestIdMapper,
-    StandardChannel, UpstreamChannel,
+use messages_sv2::{
+    common_messages_sv2::{Protocol, SetupConnection},
+    common_properties::{
+        DownstreamChannel, IsMiningDownstream, IsMiningUpstream, IsUpstream, RequestIdMapper,
+        StandardChannel, UpstreamChannel,
+    },
+    errors::Error,
+    handlers::mining::{ChannelType, ParseUpstreamMiningMessages, SendTo},
+    job_dispatcher::GroupChannelJobDispatcher,
+    mining_sv2::*,
+    parsers::{CommonMessages, Mining, MiningDeviceMessages, PoolMessages},
+    routing_logic::{MiningProxyRoutingLogic, MiningRoutingLogic},
+    selectors::{DownstreamMiningSelector, ProxyDownstreamMiningSelector as Prs},
+    utils::{Id, Mutex},
 };
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::mining::{ChannelType, ParseUpstreamMiningMessages, SendTo};
-use messages_sv2::job_dispatcher::GroupChannelJobDispatcher;
-use messages_sv2::mining_sv2::*;
-use messages_sv2::parsers::{CommonMessages, Mining, MiningDeviceMessages, PoolMessages};
-use messages_sv2::routing_logic::{MiningProxyRoutingLogic, MiningRoutingLogic};
-use messages_sv2::selectors::{DownstreamMiningSelector, ProxyDownstreamMiningSelector as Prs};
-use messages_sv2::utils::{Id, Mutex};
 use network_helpers::Connection;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 pub type Message = PoolMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
@@ -78,8 +78,7 @@ pub struct UpstreamMiningNode {
     downstream_selector: ProxyRemoteSelector,
 }
 
-use crate::MAX_SUPPORTED_VERSION;
-use crate::MIN_SUPPORTED_VERSION;
+use crate::{MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION};
 use core::convert::TryInto;
 use std::net::SocketAddr;
 

--- a/roles/v2/mining-proxy/src/main.rs
+++ b/roles/v2/mining-proxy/src/main.rs
@@ -35,11 +35,12 @@ use std::str::FromStr;
 // TODO make them configurable via flags or config file
 pub const MAX_SUPPORTED_VERSION: u16 = 2;
 pub const MIN_SUPPORTED_VERSION: u16 = 2;
-use messages_sv2::routing_logic::MiningProxyRoutingLogic;
-use messages_sv2::selectors::{GeneralMiningSelector, UpstreamMiningSelctor};
-use messages_sv2::utils::{Id, Mutex};
-use std::collections::HashMap;
-use std::sync::Arc;
+use messages_sv2::{
+    routing_logic::MiningProxyRoutingLogic,
+    selectors::{GeneralMiningSelector, UpstreamMiningSelctor},
+    utils::{Id, Mutex},
+};
+use std::{collections::HashMap, sync::Arc};
 
 type RLogic = MiningProxyRoutingLogic<
     crate::lib::downstream_mining::DownstreamMiningNode,

--- a/roles/v2/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/v2/pool/src/lib/mining_pool/message_handler.rs
@@ -1,14 +1,15 @@
 use crate::lib::mining_pool::Downstream;
 use binary_sv2::u256_from_int;
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::mining::{ChannelType, ParseDownstreamMiningMessages, SendTo};
-use messages_sv2::mining_sv2::*;
-use messages_sv2::parsers::Mining;
-use messages_sv2::routing_logic::NoRouting;
-use messages_sv2::selectors::NullDownstreamMiningSelector;
-use messages_sv2::utils::Mutex;
-use std::convert::TryInto;
-use std::sync::Arc;
+use messages_sv2::{
+    errors::Error,
+    handlers::mining::{ChannelType, ParseDownstreamMiningMessages, SendTo},
+    mining_sv2::*,
+    parsers::Mining,
+    routing_logic::NoRouting,
+    selectors::NullDownstreamMiningSelector,
+    utils::Mutex,
+};
+use std::{convert::TryInto, sync::Arc};
 
 impl ParseDownstreamMiningMessages<(), NullDownstreamMiningSelector, NoRouting> for Downstream {
     fn get_channel_type(&self) -> ChannelType {

--- a/roles/v2/pool/src/lib/mining_pool/mod.rs
+++ b/roles/v2/pool/src/lib/mining_pool/mod.rs
@@ -1,6 +1,4 @@
-use async_std::net::TcpListener;
-use async_std::prelude::*;
-use async_std::task;
+use async_std::{net::TcpListener, prelude::*, task};
 use codec_sv2::{HandshakeRole, Responder};
 use network_helpers::Connection;
 
@@ -8,19 +6,18 @@ use crate::{EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};
 use async_std::sync::Arc;
 use codec_sv2::Frame;
-use messages_sv2::common_properties::{CommonDownstreamData, IsDownstream, IsMiningDownstream};
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::mining::{ParseDownstreamMiningMessages, SendTo};
-use messages_sv2::job_creator::JobsCreators;
-use messages_sv2::mining_sv2::NewExtendedMiningJob;
-use messages_sv2::mining_sv2::SetNewPrevHash as NewPrevHash;
-use messages_sv2::parsers::{Mining, PoolMessages};
-use messages_sv2::routing_logic::MiningRoutingLogic;
-use messages_sv2::template_distribution_sv2::{NewTemplate, SetNewPrevHash};
-use messages_sv2::utils::Id;
-use messages_sv2::utils::Mutex;
-use std::collections::HashMap;
-use std::convert::TryInto;
+use messages_sv2::{
+    common_properties::{CommonDownstreamData, IsDownstream, IsMiningDownstream},
+    errors::Error,
+    handlers::mining::{ParseDownstreamMiningMessages, SendTo},
+    job_creator::JobsCreators,
+    mining_sv2::{NewExtendedMiningJob, SetNewPrevHash as NewPrevHash},
+    parsers::{Mining, PoolMessages},
+    routing_logic::MiningRoutingLogic,
+    template_distribution_sv2::{NewTemplate, SetNewPrevHash},
+    utils::{Id, Mutex},
+};
+use std::{collections::HashMap, convert::TryInto};
 
 pub mod setup_connection;
 use setup_connection::SetupConnectionHandler;

--- a/roles/v2/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/v2/pool/src/lib/mining_pool/setup_connection.rs
@@ -1,19 +1,19 @@
 use crate::{EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};
 use codec_sv2::Frame;
-use messages_sv2::common_messages_sv2::{
-    has_requires_std_job, has_version_rolling, has_work_selection, SetupConnection,
-    SetupConnectionSuccess,
+use messages_sv2::{
+    common_messages_sv2::{
+        has_requires_std_job, has_version_rolling, has_work_selection, SetupConnection,
+        SetupConnectionSuccess,
+    },
+    common_properties::CommonDownstreamData,
+    errors::Error,
+    handlers::common::ParseDownstreamCommonMessages,
+    parsers::{CommonMessages, PoolMessages},
+    routing_logic::{CommonRoutingLogic, NoRouting},
+    utils::Mutex,
 };
-use messages_sv2::common_properties::CommonDownstreamData;
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::common::ParseDownstreamCommonMessages;
-use messages_sv2::parsers::{CommonMessages, PoolMessages};
-use messages_sv2::routing_logic::CommonRoutingLogic;
-use messages_sv2::routing_logic::NoRouting;
-use messages_sv2::utils::Mutex;
-use std::convert::TryInto;
-use std::sync::Arc;
+use std::{convert::TryInto, sync::Arc};
 
 pub struct SetupConnectionHandler {
     header_only: Option<bool>,

--- a/roles/v2/pool/src/lib/template_receiver/message_handler.rs
+++ b/roles/v2/pool/src/lib/template_receiver/message_handler.rs
@@ -1,10 +1,10 @@
 use crate::lib::template_receiver::TemplateRx;
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::template_distribution::{
-    ParseServerTemplateDistributionMessages, SendTo,
+use messages_sv2::{
+    errors::Error,
+    handlers::template_distribution::{ParseServerTemplateDistributionMessages, SendTo},
+    parsers::TemplateDistribution,
+    template_distribution_sv2::*,
 };
-use messages_sv2::parsers::TemplateDistribution;
-use messages_sv2::template_distribution_sv2::*;
 
 impl ParseServerTemplateDistributionMessages for TemplateRx {
     fn handle_new_template(&mut self, m: NewTemplate) -> Result<SendTo, Error> {

--- a/roles/v2/pool/src/lib/template_receiver/mod.rs
+++ b/roles/v2/pool/src/lib/template_receiver/mod.rs
@@ -1,17 +1,16 @@
 use crate::{EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};
 //use std::sync::mpsc::Sender as SSender;
-use async_std::net::TcpStream;
-use async_std::task;
+use async_std::{net::TcpStream, task};
 use codec_sv2::Frame;
-use messages_sv2::handlers::template_distribution::ParseServerTemplateDistributionMessages;
-use messages_sv2::parsers::TemplateDistribution;
-use messages_sv2::template_distribution_sv2::{NewTemplate, SetNewPrevHash};
-use messages_sv2::utils::Mutex;
+use messages_sv2::{
+    handlers::template_distribution::ParseServerTemplateDistributionMessages,
+    parsers::TemplateDistribution,
+    template_distribution_sv2::{NewTemplate, SetNewPrevHash},
+    utils::Mutex,
+};
 use network_helpers::PlainConnection;
-use std::convert::TryInto;
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 
 mod message_handler;
 mod setup_connection;

--- a/roles/v2/pool/src/lib/template_receiver/setup_connection.rs
+++ b/roles/v2/pool/src/lib/template_receiver/setup_connection.rs
@@ -1,16 +1,14 @@
 use crate::{EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};
 use codec_sv2::Frame;
-use messages_sv2::common_messages_sv2::{Protocol, SetupConnection};
-use messages_sv2::handlers::common::ParseUpstreamCommonMessages;
-use messages_sv2::handlers::common::SendTo;
-use messages_sv2::parsers::PoolMessages;
-use messages_sv2::routing_logic::CommonRoutingLogic;
-use messages_sv2::routing_logic::NoRouting;
-use messages_sv2::utils::Mutex;
-use std::convert::TryInto;
-use std::net::SocketAddr;
-use std::sync::Arc;
+use messages_sv2::{
+    common_messages_sv2::{Protocol, SetupConnection},
+    handlers::common::{ParseUpstreamCommonMessages, SendTo},
+    parsers::PoolMessages,
+    routing_logic::{CommonRoutingLogic, NoRouting},
+    utils::Mutex,
+};
+use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 
 pub struct SetupConnectionHandler {}
 

--- a/roles/v2/pool/src/main.rs
+++ b/roles/v2/pool/src/main.rs
@@ -1,12 +1,13 @@
 use async_channel::bounded;
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use messages_sv2::bitcoin::{secp256k1::Secp256k1, Network, PrivateKey, PublicKey};
-use messages_sv2::parsers::PoolMessages;
+use messages_sv2::{
+    bitcoin::{secp256k1::Secp256k1, Network, PrivateKey, PublicKey},
+    parsers::PoolMessages,
+};
 
 mod lib;
 
-use lib::mining_pool::Pool;
-use lib::template_receiver::TemplateRx;
+use lib::{mining_pool::Pool, template_receiver::TemplateRx};
 
 pub type Message = PoolMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -1,8 +1,9 @@
-use async_std::net::TcpStream;
-use async_std::task;
+use async_std::{net::TcpStream, task};
 use network_helpers::PlainConnection;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::Arc;
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 async fn connect(address: SocketAddr) {
     let stream = TcpStream::connect(address).await.unwrap();
@@ -23,16 +24,20 @@ async fn main() {
 use async_channel::{Receiver, Sender};
 use binary_sv2::u256_from_int;
 use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
-use messages_sv2::common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess};
-use messages_sv2::common_properties::{IsMiningUpstream, IsUpstream};
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::common::ParseUpstreamCommonMessages;
-use messages_sv2::handlers::mining::{ChannelType, ParseUpstreamMiningMessages, SendTo};
-use messages_sv2::mining_sv2::*;
-use messages_sv2::parsers::{Mining, MiningDeviceMessages};
-use messages_sv2::routing_logic::{CommonRoutingLogic, MiningRoutingLogic, NoRouting};
-use messages_sv2::selectors::NullDownstreamMiningSelector;
-use messages_sv2::utils::Mutex;
+use messages_sv2::{
+    common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess},
+    common_properties::{IsMiningUpstream, IsUpstream},
+    errors::Error,
+    handlers::{
+        common::ParseUpstreamCommonMessages,
+        mining::{ChannelType, ParseUpstreamMiningMessages, SendTo},
+    },
+    mining_sv2::*,
+    parsers::{Mining, MiningDeviceMessages},
+    routing_logic::{CommonRoutingLogic, MiningRoutingLogic, NoRouting},
+    selectors::NullDownstreamMiningSelector,
+    utils::Mutex,
+};
 
 pub type Message = MiningDeviceMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;

--- a/roles/v2/test-utils/pool/src/main.rs
+++ b/roles/v2/test-utils/pool/src/main.rs
@@ -1,6 +1,4 @@
-use async_std::net::TcpListener;
-use async_std::prelude::*;
-use async_std::task;
+use async_std::{net::TcpListener, prelude::*, task};
 use codec_sv2::{HandshakeRole, Responder};
 use network_helpers::Connection;
 use std::sync::Arc as SArc;
@@ -9,17 +7,20 @@ use async_channel::{Receiver, Sender};
 use async_std::sync::Arc;
 use binary_sv2::{u256_from_int, B032};
 use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
-use messages_sv2::common_messages_sv2::{SetupConnection, SetupConnectionSuccess};
-use messages_sv2::common_properties::{CommonDownstreamData, IsDownstream, IsMiningDownstream};
-use messages_sv2::errors::Error;
-use messages_sv2::handlers::common::ParseDownstreamCommonMessages;
-use messages_sv2::handlers::mining::{ChannelType, ParseDownstreamMiningMessages, SendTo};
-use messages_sv2::mining_sv2::*;
-use messages_sv2::parsers::Mining;
-use messages_sv2::parsers::{CommonMessages, PoolMessages};
-use messages_sv2::routing_logic::{CommonRoutingLogic, MiningRoutingLogic, NoRouting};
-use messages_sv2::selectors::NullDownstreamMiningSelector;
-use messages_sv2::utils::Mutex;
+use messages_sv2::{
+    common_messages_sv2::{SetupConnection, SetupConnectionSuccess},
+    common_properties::{CommonDownstreamData, IsDownstream, IsMiningDownstream},
+    errors::Error,
+    handlers::{
+        common::ParseDownstreamCommonMessages,
+        mining::{ChannelType, ParseDownstreamMiningMessages, SendTo},
+    },
+    mining_sv2::*,
+    parsers::{CommonMessages, Mining, PoolMessages},
+    routing_logic::{CommonRoutingLogic, MiningRoutingLogic, NoRouting},
+    selectors::NullDownstreamMiningSelector,
+    utils::Mutex,
+};
 use std::convert::TryInto;
 
 pub type Message = PoolMessages<'static>;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,4 @@
 edition = "2018"
+imports_indent = "Block"
+imports_layout = "Mixed"
+imports_granularity = "Crate"

--- a/utils/buffer/benches/control_struct.rs
+++ b/utils/buffer/benches/control_struct.rs
@@ -1,8 +1,7 @@
 use buffer_sv2::{Buffer, Slice};
 use std::sync::{Arc, Mutex};
 
-use core::sync::atomic::Ordering;
-use core::time::Duration;
+use core::{sync::atomic::Ordering, time::Duration};
 use rand::Rng;
 
 const FILE_LEN: usize = 5242880;

--- a/utils/buffer/benches/pool_benchmark.rs
+++ b/utils/buffer/benches/pool_benchmark.rs
@@ -1,15 +1,15 @@
 use core::sync::atomic::Ordering;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use buffer_sv2::BufferFromSystemMemory as BufferFromMemory;
-use buffer_sv2::BufferPool as Pool;
-use buffer_sv2::{Buffer, Slice};
+use buffer_sv2::{Buffer, BufferFromSystemMemory as BufferFromMemory, BufferPool as Pool, Slice};
 use core::time::Duration;
 use rand::Rng;
 
 mod control_struct;
-use control_struct::{add_random_bytes, bench_no_thread, keep_slice, Load, DATA};
-use control_struct::{MaxESlice, MaxEfficeincy, PPool, SSlice};
+use control_struct::{
+    add_random_bytes, bench_no_thread, keep_slice, Load, MaxESlice, MaxEfficeincy, PPool, SSlice,
+    DATA,
+};
 
 fn with_pool(data: &[u8]) {
     let capacity: usize = 2_usize.pow(16) * 5;

--- a/utils/buffer/benches/pool_iai.rs
+++ b/utils/buffer/benches/pool_iai.rs
@@ -1,15 +1,15 @@
 use core::sync::atomic::Ordering;
 use iai::{black_box, main};
 
-use buffer_sv2::BufferFromSystemMemory as BufferFromMemory;
-use buffer_sv2::BufferPool as Pool;
-use buffer_sv2::{Buffer, Slice};
+use buffer_sv2::{Buffer, BufferFromSystemMemory as BufferFromMemory, BufferPool as Pool, Slice};
 use core::time::Duration;
 use rand::Rng;
 
 mod control_struct;
-use control_struct::{add_random_bytes, bench_no_thread, keep_slice, Load, DATA};
-use control_struct::{MaxESlice, MaxEfficeincy, PPool, SSlice};
+use control_struct::{
+    add_random_bytes, bench_no_thread, keep_slice, Load, MaxESlice, MaxEfficeincy, PPool, SSlice,
+    DATA,
+};
 
 fn with_pool() {
     let data = DATA;

--- a/utils/buffer/src/buffer_pool/mod.rs
+++ b/utils/buffer/src/buffer_pool/mod.rs
@@ -1,11 +1,13 @@
 use alloc::{vec, vec::Vec};
 use core::sync::atomic::Ordering;
 
-use crate::buffer::BufferFromSystemMemory;
 #[cfg(test)]
 use crate::buffer::TestBufferFromMemory;
-use crate::slice::{SharedState, Slice};
-use crate::Buffer;
+use crate::{
+    buffer::BufferFromSystemMemory,
+    slice::{SharedState, Slice},
+    Buffer,
+};
 #[cfg(feature = "debug")]
 use std::time::SystemTime;
 

--- a/utils/buffer/src/buffer_pool/pool_back.rs
+++ b/utils/buffer/src/buffer_pool/pool_back.rs
@@ -1,7 +1,4 @@
-use crate::buffer_pool::InnerMemory;
-use crate::buffer_pool::PoolFront;
-use crate::buffer_pool::PoolMode;
-use crate::buffer_pool::POOL_CAPACITY;
+use crate::buffer_pool::{InnerMemory, PoolFront, PoolMode, POOL_CAPACITY};
 
 #[derive(Debug, Clone)]
 pub struct PoolBack {

--- a/utils/buffer/src/test.rs
+++ b/utils/buffer/src/test.rs
@@ -1,8 +1,6 @@
 use alloc::vec::Vec;
 
-use crate::buffer_pool::BufferPool as Pool;
-use crate::slice::Slice;
-use crate::Buffer;
+use crate::{buffer_pool::BufferPool as Pool, slice::Slice, Buffer};
 use rand::Rng;
 
 #[test]

--- a/utils/network-helpers/src/noise_connection_async_std.rs
+++ b/utils/network-helpers/src/noise_connection_async_std.rs
@@ -1,8 +1,10 @@
 use async_channel::{bounded, Receiver, Sender};
-use async_std::net::{TcpListener, TcpStream};
-use async_std::prelude::*;
-use async_std::sync::{Arc, Mutex};
-use async_std::task;
+use async_std::{
+    net::{TcpListener, TcpStream},
+    prelude::*,
+    sync::{Arc, Mutex},
+    task,
+};
 use binary_sv2::{Deserialize, Serialize};
 use core::convert::TryInto;
 use std::time::Duration;

--- a/utils/network-helpers/src/plain_connection_async_std.rs
+++ b/utils/network-helpers/src/plain_connection_async_std.rs
@@ -1,7 +1,9 @@
 use async_channel::{bounded, Receiver, Sender};
-use async_std::net::{TcpListener, TcpStream};
-use async_std::prelude::*;
-use async_std::task;
+use async_std::{
+    net::{TcpListener, TcpStream},
+    prelude::*,
+    task,
+};
 use binary_sv2::{Deserialize, Serialize};
 use core::convert::TryInto;
 


### PR DESCRIPTION
This PR adds rules to the `rustfmt` that define how the import statements are formatted.

`imports_indent = "Block"`  this is the default setting, added for clarity
`imports_layout = "Mixed"` this is the default setting, added for clarity
`imports_granularity = "Crate"` this groups import statements from the same crate together, [reference here](https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#imports_granularity)

These rules are not yet stable, so `nightly` must be used when running `rustfmt` as such: `% cargo +nightly fmt`.
Because the toolchain must be `nightly` for this to compile, the `rustfmt` GitHub Actions logic is separated out of `test-lint.yaml` (renamed from `rust.yaml`) and put into a new file called `fmt.yaml` that uses the `nightly` toolchain.