### PR TITLE
Fix guix build

### DIFF
--- a/.github/workflows/sv2-header-check.yaml
+++ b/.github/workflows/sv2-header-check.yaml
@@ -20,6 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          profile: minimal
+          toolchain: 1.51.0
+          override: true
 
       - name: Check sv2 header file is up to date with commit
         run: |

--- a/.github/workflows/test-lint.yaml
+++ b/.github/workflows/test-lint.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           profile: minimal
-          toolchain: 1.53.0
+          toolchain: 1.51.0
           override: true
           components: clippy
 

--- a/build_header.sh
+++ b/build_header.sh
@@ -1,5 +1,7 @@
 #! /bin/sh 
 
+cargo install  --version 0.20.0 cbindgen
+
 rm -f ./sv2.h
 touch ./sv2.h
 

--- a/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
@@ -20,8 +20,8 @@ pub fn clone_message<T: Serialize>(_: T) -> T {
 pub fn u256_from_int<V: Into<u64>>(value: V) -> U256<'static> {
     let mut u256 = vec![0_u8; 24];
     let val: u64 = value.into();
-    for v in val.to_le_bytes() {
-        u256.push(v)
+    for v in &(val.to_le_bytes()) {
+        u256.push(*v)
     }
     let u256: U256 = u256.try_into().unwrap();
     u256

--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -235,6 +235,7 @@ pub struct CSetupConnectionError {
 #[cfg(not(feature = "with_serde"))]
 impl<'a> CSetupConnectionError {
     #[cfg(not(feature = "with_serde"))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<SetupConnectionError<'a>, Error> {
         let error_code: Str0255 = self.error_code.as_mut_slice().try_into()?;
 

--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -128,6 +128,7 @@ pub struct CSetupConnection {
 #[cfg(not(feature = "with_serde"))]
 impl<'a> CSetupConnection {
     #[cfg(not(feature = "with_serde"))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<SetupConnection<'a>, Error> {
         let endpoint_host: Str0255 = self.endpoint_host.as_mut_slice().try_into()?;
         let vendor: Str0255 = self.vendor.as_mut_slice().try_into()?;

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -124,6 +124,7 @@ impl<'a> From<NewTemplate<'a>> for CNewTemplate {
 #[cfg(not(feature = "with_serde"))]
 impl<'a> CNewTemplate {
     #[cfg(not(feature = "with_serde"))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<NewTemplate<'a>, Error> {
         let coinbase_prefix: B0255 = self.coinbase_prefix.as_mut_slice().try_into()?;
         let coinbase_tx_outputs: B064K = self.coinbase_tx_outputs.as_mut_slice().try_into()?;

--- a/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
@@ -69,6 +69,7 @@ pub struct CRequestTransactionDataSuccess {
 #[cfg(not(feature = "with_serde"))]
 impl<'a> CRequestTransactionDataSuccess {
     #[cfg(not(feature = "with_serde"))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<RequestTransactionDataSuccess<'a>, Error> {
         let excess_data: B064K = self.excess_data.as_mut_slice().try_into()?;
         let transaction_list_ = self.transaction_list.as_mut_slice();
@@ -131,6 +132,7 @@ pub struct CRequestTransactionDataError {
 #[cfg(not(feature = "with_serde"))]
 impl<'a> CRequestTransactionDataError {
     #[cfg(not(feature = "with_serde"))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<RequestTransactionDataError<'a>, Error> {
         let error_code: Str0255 = self.error_code.as_mut_slice().try_into()?;
         Ok(RequestTransactionDataError {

--- a/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
@@ -48,6 +48,7 @@ pub struct CSetNewPrevHash {
 #[cfg(not(feature = "with_serde"))]
 impl<'a> CSetNewPrevHash {
     #[cfg(not(feature = "with_serde"))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<SetNewPrevHash<'a>, Error> {
         let prev_hash: U256 = self.prev_hash.as_mut_slice().try_into()?;
         let target: U256 = self.target.as_mut_slice().try_into()?;

--- a/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
@@ -47,6 +47,7 @@ pub struct CSubmitSolution {
 #[cfg(not(feature = "with_serde"))]
 impl<'a> CSubmitSolution {
     #[cfg(not(feature = "with_serde"))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<SubmitSolution<'a>, Error> {
         let coinbase_tx: B064K = self.coinbase_tx.as_mut_slice().try_into()?;
 

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -146,6 +146,7 @@ impl<'a> From<Sv2Message<'a>> for CSv2Message {
 }
 
 impl<'a> CSv2Message {
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<Sv2Message<'a>, Error> {
         match self {
             CSv2Message::NewTemplate(v) => Ok(Sv2Message::NewTemplate(v.to_rust_rep_mut()?)),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-channel = "1.53.0"
+channel = "1.51.0"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"
-

--- a/sv2-header-check.sh
+++ b/sv2-header-check.sh
@@ -15,6 +15,8 @@
 # This script is called by `.github/workflows/sv2-header-check.yaml` on every PR onto the main branch.
 #
 
+cargo install  --version 0.20.0 cbindgen
+
 set -e
 # cargo install cbindgen --force bts
 # cbindgen -V


### PR DESCRIPTION
Crates in this workspace must be buildable on guix, for that the
required rust version is lowered to one supported on guix.