### PR TITLE
Make v1::methods public

### DIFF
--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -38,7 +38,7 @@
 
 pub mod error;
 pub mod json_rpc;
-mod methods;
+pub mod methods;
 pub mod utils;
 
 use std::convert::TryInto;


### PR DESCRIPTION
Make `v1::methods` public to access `Client2Server` for `sv1-to-sv2` example.