### PR TITLE
Add RelaySameMessageToSv1 variant to SendTo

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -6,6 +6,8 @@ use std::fmt::{self, Display, Formatter};
 pub enum Error {
     ExpectedLen32(usize),
     BinarySv2Error(BinarySv2Error),
+    /// Errors if a `SendTo::RelaySameMessageSv1` request is made on a SV2-only application.
+    CannotRelaySv1Message,
     NoGroupsFound,
     WrongMessageType(u8),
     UnexpectedMessage,
@@ -35,6 +37,12 @@ impl Display for Error {
                 "BinarySv2Error: error in serializing/deserilizing binary format {:?}",
                 v
             ),
+            CannotRelaySv1Message => {
+                write!(
+                    f,
+                    "Cannot process request: Received SV1 relay request on a SV2-only application"
+                )
+            }
             ExpectedLen32(l) => write!(f, "Expected length of 32, but received length of {}", l),
             NoGroupsFound => write!(
                 f,

--- a/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
@@ -36,7 +36,7 @@ pub enum SendTo_<SubProtocol, Remote> {
     RelaySameMessage(Arc<Mutex<Remote>>),
     /// Used by SV1<->SV2 translator proxies to relay a SV2 message to be translated to a SV1
     /// message by the proxy.
-    RelaySameMessageSv1(SubProtocol),
+    RelaySameMessageToSv1(SubProtocol),
     /// Used by proxyies and other roles to directly respond.
     Respond(SubProtocol),
     /// Used when multiple type of SendTo are needed
@@ -50,7 +50,7 @@ impl<SubProtocol, Remote> SendTo_<SubProtocol, Remote> {
         match self {
             Self::RelayNewMessage(_, m) => Some(m),
             Self::RelaySameMessage(_) => None,
-            Self::RelaySameMessageSv1(m) => Some(m),
+            Self::RelaySameMessageToSv1(m) => Some(m),
             Self::Respond(m) => Some(m),
             Self::Multiple(_) => None,
             Self::None(m) => m,
@@ -60,7 +60,7 @@ impl<SubProtocol, Remote> SendTo_<SubProtocol, Remote> {
         match self {
             Self::RelayNewMessage(r, _) => Some(r),
             Self::RelaySameMessage(r) => Some(r),
-            Self::RelaySameMessageSv1(_) => None,
+            Self::RelaySameMessageToSv1(_) => None,
             Self::Respond(_) => None,
             Self::Multiple(_) => None,
             Self::None(_) => None,

--- a/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
@@ -1,55 +1,61 @@
-//! Handlers are divided per (sub)protocol and per downstream/upstream
-//! Each (sup)protocol define an handler for both the upstream node and the downstream node
-//! Handlers are trait called Parse[Downstream/Upstream][(sub)protocol] (eg. ParseDownstreamCommonMessages)
+//! Handlers are divided per (sub)protocol and per Downstream/Upstream.
+//! Each (sup)protocol defines a handler for both the Upstream node and the Downstream node
+//! Handlers are a trait called `Parse[Downstream/Upstream][(sub)protocol]`
+//! (eg. `ParseDownstreamCommonMessages`).
 //!
-//! When implemented an handler make avaiable a funtction called
-//! handle_message_[(sub)protoco](..) (eg handle_message_common(..))
+//! When implemented, the handler makes the `handle_message_[(sub)protoco](..)` (e.g.
+//! `handle_message_common(..)`) function available.
 //!
-//! The trait require the implementor to define one function for each message type that a role
-//! defined by the (sub)protocl and the upstream/downstream state could receive.
+//! The trait requires the implementer to define one function for each message type that a role
+//! defined by the (sub)protocol and the Upstream/Downstream state could receive.
 //!
-//! This funtcion will always take a mutable ref to self, a message payload and a message type and
-//! a routing logic.
-//! Using parsers in crate::parser the payload and message type are parsed in an actual Sv2
+//! This function will always take a mutable ref to `self`, a message payload + message type, and
+//! the routing logic.
+//! Using `parsers` in `crate::parser`, the payload and message type are parsed in an actual SV2
 //! message.
-//! Routing logic is used in order to select the correct downstream/upstream to which the message
-//! must be realyied/sent
+//! Routing logic is used in order to select the correct Downstream/Upstream to which the message
+//! must be relayed/sent.
 //! Routing logic is used to update the request id when needed.
-//! After that the specific function for the message type (implemented by the implementor) is
-//! called with the Sv2 message and the remote that must receive the message.
+//! After that, the specific function for the message type (implemented by the implementer) is
+//! called with the SV2 message and the remote that must receive the message.
 //!
-//! A Result<SendTo_, Error> is returned and is duty of the implementor to send the message
+//! A `Result<SendTo_, Error>` is returned and it is the duty of the implementer to send the
+//! message.
+//!
 pub mod common;
 pub mod mining;
 pub mod template_distribution;
 use crate::utils::Mutex;
 use std::sync::Arc;
 
-/// SubProtocol is the Sv2 (sub)protocol that the implementor is implementing (eg: mining, common,
-/// ...)
-/// Remote is wathever type the implementor use to represent remote connection
+/// SubProtocol is the SV2 (sub)protocol that the implementer is implementing (e.g.: `mining`,
+/// `common`, ect.)
+/// Remote is whatever type the implementer uses to represent the remote connection.
 pub enum SendTo_<SubProtocol, Remote> {
-    /// Used by proxyies to realy messages. It allocate a new message.
-    RelayNewMessage(Arc<Mutex<Remote>>, SubProtocol),
-    /// Used by proxyies to relay messages. It do not allocate a new message and use the received
+    /// Used by SV2-only proxies to allocate a new message + relay.
+    RelayNewMessageToSv2(Arc<Mutex<Remote>>, SubProtocol),
+    /// Used by SV2-only proxies to relay the same message it receives.
     /// one.
-    RelaySameMessage(Arc<Mutex<Remote>>),
+    RelaySameMessageToSv2(Arc<Mutex<Remote>>),
     /// Used by SV1<->SV2 translator proxies to relay a SV2 message to be translated to a SV1
     /// message by the proxy.
     RelaySameMessageToSv1(SubProtocol),
-    /// Used by proxyies and other roles to directly respond.
+    /// Used by all proxies and other roles to directly respond to a received SV2 message with
+    /// the proper SV2 message response.
     Respond(SubProtocol),
-    /// Used when multiple type of SendTo are needed
+    /// Return multiple types of `SendTo`, e.g. `SendTo::Respond` + `SendTo::Relay*`. In the case
+    /// where multiple `SendTo::Relay*` is received in this variant, that indicates there are
+    /// multiple Downstream roles connected to the application.
     Multiple(Vec<SendTo_<SubProtocol, Remote>>),
-    /// Used by proxyies and other roles when no messages need to be sent.
+    /// Used by all proxies and other roles when no messages need to be sent.
     None(Option<SubProtocol>),
 }
 
 impl<SubProtocol, Remote> SendTo_<SubProtocol, Remote> {
     pub fn into_message(self) -> Option<SubProtocol> {
         match self {
-            Self::RelayNewMessage(_, m) => Some(m),
-            Self::RelaySameMessage(_) => None,
+            Self::RelayNewMessageToSv2(_, m) => Some(m),
+            Self::RelaySameMessageToSv2(_) => None,
             Self::RelaySameMessageToSv1(m) => Some(m),
             Self::Respond(m) => Some(m),
             Self::Multiple(_) => None,
@@ -58,8 +64,8 @@ impl<SubProtocol, Remote> SendTo_<SubProtocol, Remote> {
     }
     pub fn into_remote(self) -> Option<Arc<Mutex<Remote>>> {
         match self {
-            Self::RelayNewMessage(r, _) => Some(r),
-            Self::RelaySameMessage(r) => Some(r),
+            Self::RelayNewMessageToSv2(r, _) => Some(r),
+            Self::RelaySameMessageToSv2(r) => Some(r),
             Self::RelaySameMessageToSv1(_) => None,
             Self::Respond(_) => None,
             Self::Multiple(_) => None,

--- a/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
@@ -34,6 +34,9 @@ pub enum SendTo_<SubProtocol, Remote> {
     /// Used by proxyies to relay messages. It do not allocate a new message and use the received
     /// one.
     RelaySameMessage(Arc<Mutex<Remote>>),
+    /// Used by SV1<->SV2 translator proxies to relay a SV2 message to be translated to a SV1
+    /// message by the proxy.
+    RelaySameMessageSv1(SubProtocol),
     /// Used by proxyies and other roles to directly respond.
     Respond(SubProtocol),
     /// Used when multiple type of SendTo are needed
@@ -47,6 +50,7 @@ impl<SubProtocol, Remote> SendTo_<SubProtocol, Remote> {
         match self {
             Self::RelayNewMessage(_, m) => Some(m),
             Self::RelaySameMessage(_) => None,
+            Self::RelaySameMessageSv1(m) => Some(m),
             Self::Respond(m) => Some(m),
             Self::Multiple(_) => None,
             Self::None(m) => m,
@@ -56,6 +60,7 @@ impl<SubProtocol, Remote> SendTo_<SubProtocol, Remote> {
         match self {
             Self::RelayNewMessage(r, _) => Some(r),
             Self::RelaySameMessage(r) => Some(r),
+            Self::RelaySameMessageSv1(_) => None,
             Self::Respond(_) => None,
             Self::Multiple(_) => None,
             Self::None(_) => None,

--- a/roles/v2/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/downstream_mining.rs
@@ -180,7 +180,7 @@ impl DownstreamMiningNode {
                 todo!();
             }
             // TODO: Rm panic and replace w proper error handling
-            Ok(SendTo::RelaySameMessageSv1(_)) => panic!("{:?}", Error::CannotRelaySv1Message),
+            Ok(SendTo::RelaySameMessageToSv1(_)) => panic!("{:?}", Error::CannotRelaySv1Message),
             Ok(SendTo::None(_)) => (),
             Err(Error::UnexpectedMessage) => todo!("148"),
             Err(_) => todo!("149"),

--- a/roles/v2/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/downstream_mining.rs
@@ -179,6 +179,8 @@ impl DownstreamMiningNode {
             Ok(SendTo::Multiple(_sends_to)) => {
                 todo!();
             }
+            // TODO: Rm panic and replace w proper error handling
+            Ok(SendTo::RelaySameMessageSv1(_)) => panic!("{:?}", Error::CannotRelaySv1Message),
             Ok(SendTo::None(_)) => (),
             Err(Error::UnexpectedMessage) => todo!("148"),
             Err(_) => todo!("149"),

--- a/roles/v2/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/upstream_mining.rs
@@ -325,7 +325,7 @@ impl UpstreamMiningNode {
                         SendTo::None(_) => (),
                         SendTo::Multiple(_) => panic!("Nested SendTo::Multiple not supported"),
                         // TODO: Rm panic and replace w proper error handling
-                        SendTo::RelaySameMessageSv1(_) => {
+                        SendTo::RelaySameMessageToSv1(_) => {
                             panic!("{:?}", Error::CannotRelaySv1Message)
                         }
                     }
@@ -333,7 +333,7 @@ impl UpstreamMiningNode {
             }
             Ok(SendTo::None(_)) => (),
             // TODO: Rm panic and replace w proper error handling
-            Ok(SendTo::RelaySameMessageSv1(_)) => {
+            Ok(SendTo::RelaySameMessageToSv1(_)) => {
                 panic!("{:?}", Error::CannotRelaySv1Message)
             }
             Err(Error::NoDownstreamsConnected) => (),

--- a/roles/v2/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/upstream_mining.rs
@@ -324,10 +324,18 @@ impl UpstreamMiningNode {
                         }
                         SendTo::None(_) => (),
                         SendTo::Multiple(_) => panic!("Nested SendTo::Multiple not supported"),
+                        // TODO: Rm panic and replace w proper error handling
+                        SendTo::RelaySameMessageSv1(_) => {
+                            panic!("{:?}", Error::CannotRelaySv1Message)
+                        }
                     }
                 }
             }
             Ok(SendTo::None(_)) => (),
+            // TODO: Rm panic and replace w proper error handling
+            Ok(SendTo::RelaySameMessageSv1(_)) => {
+                panic!("{:?}", Error::CannotRelaySv1Message)
+            }
             Err(Error::NoDownstreamsConnected) => (),
             Err(Error::UnexpectedMessage) => todo!(),
             Err(_) => todo!(),

--- a/roles/v2/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/upstream_mining.rs
@@ -276,7 +276,7 @@ impl UpstreamMiningNode {
             routing_logic,
         );
         match next_message_to_send {
-            Ok(SendTo::RelaySameMessage(downstream)) => {
+            Ok(SendTo::RelaySameMessageToSv2(downstream)) => {
                 let sv2_frame: codec_sv2::Sv2Frame<MiningDeviceMessages, buffer_sv2::Slice> =
                     incoming.map(|payload| payload.try_into().unwrap());
 
@@ -284,7 +284,7 @@ impl UpstreamMiningNode {
                     .await
                     .unwrap();
             }
-            Ok(SendTo::RelayNewMessage(downstream_mutex, message)) => {
+            Ok(SendTo::RelayNewMessageToSv2(downstream_mutex, message)) => {
                 let message = MiningDeviceMessages::Mining(message);
                 let frame: DownstreamFrame = message.try_into().unwrap();
                 DownstreamMiningNode::send(downstream_mutex, frame)
@@ -299,14 +299,14 @@ impl UpstreamMiningNode {
             Ok(SendTo::Multiple(sends_to)) => {
                 for send_to in sends_to {
                     match send_to {
-                        SendTo::RelayNewMessage(downstream_mutex, message) => {
+                        SendTo::RelayNewMessageToSv2(downstream_mutex, message) => {
                             let message = MiningDeviceMessages::Mining(message);
                             let frame: DownstreamFrame = message.try_into().unwrap();
                             DownstreamMiningNode::send(downstream_mutex, frame)
                                 .await
                                 .unwrap();
                         }
-                        SendTo::RelaySameMessage(downstream_mutex) => {
+                        SendTo::RelaySameMessageToSv2(downstream_mutex) => {
                             let frame: codec_sv2::Sv2Frame<
                                 MiningDeviceMessages,
                                 buffer_sv2::Slice,
@@ -529,7 +529,7 @@ impl
             }
         }
 
-        let open_channel = SendTo::RelaySameMessage(remote.clone().unwrap());
+        let open_channel = SendTo::RelaySameMessageToSv2(remote.clone().unwrap());
 
         match (&self.last_prev_hash, &self.last_extended_jobs.len()) {
             (Some(_), 0) => {
@@ -548,7 +548,7 @@ impl
                     min_ntime: new_prev_hash.min_ntime,
                     nbits: new_prev_hash.nbits,
                 });
-                responses.push(SendTo::RelayNewMessage(remote.unwrap(), new_prev_hash));
+                responses.push(SendTo::RelayNewMessageToSv2(remote.unwrap(), new_prev_hash));
                 for job in &self.last_extended_jobs {
                     // TODO the below unwrap is not safe
                     for job in
@@ -607,7 +607,7 @@ impl
             .downstream_selector
             .downstream_from_channel_id(m.channel_id)
         {
-            Some(d) => Ok(SendTo::RelaySameMessage(d.clone())),
+            Some(d) => Ok(SendTo::RelaySameMessageToSv2(d.clone())),
             None => todo!(),
         }
     }
@@ -635,7 +635,7 @@ impl
                     self.id,
                     downstream.safe_lock(|d| d.prev_job_id).unwrap(),
                 );
-                Ok(SendTo::RelaySameMessage(downstream.clone()))
+                Ok(SendTo::RelaySameMessageToSv2(downstream.clone()))
             }
             None => Err(Error::NoDownstreamsConnected),
         }
@@ -683,7 +683,7 @@ impl
                     .get_downstreams_in_channel(m.channel_id)
                     .ok_or(Error::NoDownstreamsConnected)?;
                 // If upstream is header only one and only one downstream is in channel
-                Ok(SendTo::RelaySameMessage(downstreams[0].clone()))
+                Ok(SendTo::RelaySameMessageToSv2(downstreams[0].clone()))
             }
             (false, Some(JobDispatcher::Group(dispatcher))) => {
                 let mut channel_id_to_job_id = dispatcher.on_new_prev_hash(&m).unwrap();
@@ -711,7 +711,7 @@ impl
                                             nbits: m.nbits,
                                         };
                                         let message = Mining::SetNewPrevHash(new_prev_hash);
-                                        messages.push(SendTo::RelayNewMessage(
+                                        messages.push(SendTo::RelayNewMessageToSv2(
                                             downstream.clone(),
                                             message,
                                         ));
@@ -828,14 +828,17 @@ fn jobs_to_relay(
                         DownstreamChannel::Extended(_) => todo!(),
                         DownstreamChannel::Group(_) => {
                             crate::add_job_id(m.job_id, id, prev_id);
-                            messages.push(SendTo::RelaySameMessage(downstream.clone()))
+                            messages.push(SendTo::RelaySameMessageToSv2(downstream.clone()))
                         }
                         DownstreamChannel::Standard(channel) => {
                             if let JobDispatcher::Group(d) = dispacther {
                                 let job = d.on_new_extended_mining_job(m, channel).unwrap();
                                 crate::add_job_id(job.job_id, id, prev_id);
                                 let message = Mining::NewMiningJob(job);
-                                messages.push(SendTo::RelayNewMessage(downstream.clone(), message));
+                                messages.push(SendTo::RelayNewMessageToSv2(
+                                    downstream.clone(),
+                                    message,
+                                ));
                             } else {
                                 panic!()
                             };

--- a/roles/v2/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/v2/pool/src/lib/mining_pool/message_handler.rs
@@ -137,7 +137,7 @@ impl ParseDownstreamMiningMessages<(), NullDownstreamMiningSelector, NoRouting> 
                 }
             }
         };
-        Ok(SendTo::RelayNewMessage(
+        Ok(SendTo::RelayNewMessageToSv2(
             Arc::new(Mutex::new(())),
             Mining::OpenStandardMiningChannelSuccess(message),
         ))
@@ -204,7 +204,7 @@ impl ParseDownstreamMiningMessages<(), NullDownstreamMiningSelector, NoRouting> 
             extranonce_size: 128,
             extranonce_prefix: extended.try_into().unwrap(),
         };
-        Ok(SendTo::RelayNewMessage(
+        Ok(SendTo::RelayNewMessageToSv2(
             Arc::new(Mutex::new(())),
             Mining::OpenExtendedMiningChannelSuccess(message),
         ))

--- a/roles/v2/pool/src/lib/mining_pool/mod.rs
+++ b/roles/v2/pool/src/lib/mining_pool/mod.rs
@@ -438,7 +438,7 @@ impl Downstream {
             MiningRoutingLogic::None,
         );
         match next_message_to_send {
-            Ok(SendTo::RelayNewMessage(_, message)) => {
+            Ok(SendTo::RelayNewMessageToSv2(_, message)) => {
                 Self::send(self_mutex, message).await.unwrap();
             }
             Ok(SendTo::Respond(message)) => {

--- a/roles/v2/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/v2/pool/src/lib/mining_pool/setup_connection.rs
@@ -66,7 +66,7 @@ impl ParseDownstreamCommonMessages<NoRouting> for SetupConnectionHandler {
         use roles_logic_sv2::handlers::common::SendTo;
         let header_only = incoming.requires_standard_job();
         self.header_only = Some(header_only);
-        Ok(SendTo::RelayNewMessage(
+        Ok(SendTo::RelayNewMessageToSv2(
             Arc::new(Mutex::new(())),
             CommonMessages::SetupConnectionSuccess(SetupConnectionSuccess {
                 flags: 0,

--- a/roles/v2/pool/src/lib/template_receiver/message_handler.rs
+++ b/roles/v2/pool/src/lib/template_receiver/message_handler.rs
@@ -24,7 +24,7 @@ impl ParseServerTemplateDistributionMessages for TemplateRx {
             merkle_path: m.merkle_path.into_static(),
         };
         let new_template = TemplateDistribution::NewTemplate(new_template);
-        Ok(SendTo::RelayNewMessage(
+        Ok(SendTo::RelayNewMessageToSv2(
             Arc::new(Mutex::new(())),
             new_template,
         ))
@@ -39,7 +39,7 @@ impl ParseServerTemplateDistributionMessages for TemplateRx {
             target: m.target.into_static(),
         };
         let new_prev_hash = TemplateDistribution::SetNewPrevHash(new_prev_hash);
-        Ok(SendTo::RelayNewMessage(
+        Ok(SendTo::RelayNewMessageToSv2(
             Arc::new(Mutex::new(())),
             new_prev_hash,
         ))

--- a/roles/v2/pool/src/lib/template_receiver/mod.rs
+++ b/roles/v2/pool/src/lib/template_receiver/mod.rs
@@ -72,7 +72,7 @@ impl TemplateRx {
             )
             .unwrap()
             {
-                roles_logic_sv2::handlers::SendTo_::RelayNewMessage(_, m) => match m {
+                roles_logic_sv2::handlers::SendTo_::RelayNewMessageToSv2(_, m) => match m {
                     TemplateDistribution::CoinbaseOutputDataSize(_) => todo!(),
                     TemplateDistribution::NewTemplate(m) => {
                         new_template_sender.send(m).await.unwrap()

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -220,7 +220,7 @@ impl Device {
             )
             .unwrap();
             match next {
-                SendTo::RelayNewMessage(_, m) => {
+                SendTo::RelayNewMessageToSv2(_, m) => {
                     let sv2_frame: StdFrame = MiningDeviceMessages::Mining(m).try_into().unwrap();
                     let either_frame: EitherFrame = sv2_frame.into();
                     sender.send(either_frame).await.unwrap();

--- a/roles/v2/test-utils/pool/src/main.rs
+++ b/roles/v2/test-utils/pool/src/main.rs
@@ -143,7 +143,7 @@ impl ParseDownstreamCommonMessages<NoRouting> for SetupConnectionHandler {
         self.header_only = Some(header_only);
         println!("POOL: setup connection");
         println!("POOL: connection require_std_job: {}", header_only);
-        Ok(SendTo::RelayNewMessage(
+        Ok(SendTo::RelayNewMessageToSv2(
             Arc::new(Mutex::new(())),
             CommonMessages::SetupConnectionSuccess(SetupConnectionSuccess {
                 flags: 0,
@@ -210,7 +210,7 @@ impl Downstream {
             MiningRoutingLogic::None,
         );
         match next_message_to_send {
-            Ok(SendTo::RelayNewMessage(_, message)) => {
+            Ok(SendTo::RelayNewMessageToSv2(_, message)) => {
                 let sv2_frame: StdFrame = PoolMessages::Mining(message).try_into().unwrap();
                 let sender = self_mutex.safe_lock(|self_| self_.sender.clone()).unwrap();
                 sender.send(sv2_frame.into()).await.unwrap();
@@ -301,7 +301,7 @@ impl ParseDownstreamMiningMessages<(), NullDownstreamMiningSelector, NoRouting> 
             }
             (true, Some(_)) => panic!(),
         };
-        Ok(SendTo::RelayNewMessage(
+        Ok(SendTo::RelayNewMessageToSv2(
             Arc::new(Mutex::new(())),
             Mining::OpenStandardMiningChannelSuccess(message),
         ))


### PR DESCRIPTION
- Adds a new `RelaySameMessageToSv1` variant to the `SendTo` enum
- Used to support message handling in applications that use both SV1 + SV2 protocols, like a SV1 <-> SV2 translator proxy
- Renames `RelaySameMessage` variant to `RelaySameMessageToSv2`
- Renames `RelayNewMessage` variant to `RelayNewMessageToSv2`
- Updates `protocols/v2/roles-logic-sv2/src/handlers/mod.rs` doc comments