### PR TITLE
71 - Attempt to fix client/server deadlock example in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,3 +73,8 @@ jobs:
           command: run
           args: --bin ping_pong_without_noise -- 10
 
+      - name: Run client-server example
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin client_and_server -- 20

--- a/examples/sv1-client-and-server/src/main.rs
+++ b/examples/sv1-client-and-server/src/main.rs
@@ -100,6 +100,9 @@ impl Server {
                     let incoming = self_.receiver_incoming.try_recv();
                     self_.parse_message(incoming).await;
                     drop(self_);
+                    //It's healthy to sleep after giving up the lock so the other thread has a shot
+                    //at acquiring it.
+                    sleep(Duration::from_millis(100));
                 };
             }
         });
@@ -348,6 +351,9 @@ impl Client {
                     let incoming = self_.receiver_incoming.try_recv();
                     self_.parse_message(incoming).await;
                 }
+                //It's healthy to sleep after giving up the lock so the other thread has a shot
+                //at acquiring it - it also prevents pegging the cpu
+                sleep(Duration::from_millis(100));
             }
         });
 


### PR DESCRIPTION
I think the problem with github is the lack of cpu power that we are running these tests with - the server/client example doesn't sleep between lock drop/acquire - I think there is just 1 thread that always gets the lock so nothing progresses and the cpu is pegged which makes github angry.

It'd be great if someone who doesn't have github actions block could run this action to see if it fixes the issue.