### PR TITLE
pool: refactor naming of channels in pool main

### DIFF
--- a/roles/v2/pool/src/main.rs
+++ b/roles/v2/pool/src/main.rs
@@ -120,17 +120,17 @@ async fn main() {
         }
     };
 
-    let (s_new_t, r_new_t) = bounded(10);
-    let (s_prev_hash, r_prev_hash) = bounded(10);
-    let (s_solution, r_solution) = bounded(10);
+    let (template_tx, template_rx) = bounded(10);
+    let (prev_hash_tx, prev_hash_rx) = bounded(10);
+    let (solution_tx, solution_rx) = bounded(10);
     info!("POOL INITIALIZING ");
     TemplateRx::connect(
         config.tp_address.parse().unwrap(),
-        s_new_t,
-        s_prev_hash,
-        r_solution,
+        template_tx,
+        prev_hash_tx,
+        solution_rx,
     )
     .await;
     info!("POOL INITIALIZED");
-    Pool::start(config, r_new_t, r_prev_hash, s_solution).await;
+    Pool::start(config, template_rx, prev_hash_rx, solution_tx).await;
 }


### PR DESCRIPTION
* Improve the readability of the purpose of each channel before being moved to Pool and TemplateRx. Previously the purpose of the channel wasn't clear and the reader had to look up the parameter definition in the callee function.

* Additionally, imho we should favour the Rust naming conventions of channels using tx and rx.