### PR TITLE
translator: use base58 auth key string

### DIFF
--- a/roles/translator/proxy-config.toml
+++ b/roles/translator/proxy-config.toml
@@ -1,7 +1,7 @@
 # Upstream connection information
 upstream_address = "127.0.0.1"
 upstream_port = 34254
-upstream_authority_pubkey = [ 215, 11, 47, 78, 34, 232, 25, 192, 195, 168, 170, 209, 95, 181, 40, 114, 154, 226, 176, 190, 90, 169, 238, 89, 191, 183, 97, 63, 194, 119, 11, 31]
+upstream_authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
 
 # Downstream connection information
 downstream_address = "127.0.0.1"

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -74,7 +74,10 @@ async fn main() {
     // Instantiate a new `Upstream`
     let upstream = upstream_sv2::Upstream::new(
         upstream_addr,
-        proxy_config.upstream_authority_pubkey.into_inner().to_bytes(),
+        proxy_config
+            .upstream_authority_pubkey
+            .into_inner()
+            .to_bytes(),
         recv_submit_to_sv2,
         sender_new_prev_hash,
         sender_new_extended_mining_job,

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -74,7 +74,7 @@ async fn main() {
     // Instantiate a new `Upstream`
     let upstream = upstream_sv2::Upstream::new(
         upstream_addr,
-        proxy_config.upstream_authority_pubkey,
+        proxy_config.upstream_authority_pubkey.into_inner().to_bytes(),
         recv_submit_to_sv2,
         sender_new_prev_hash,
         sender_new_extended_mining_job,

--- a/roles/translator/src/proxy_config.rs
+++ b/roles/translator/src/proxy_config.rs
@@ -1,10 +1,11 @@
 use serde::Deserialize;
+use codec_sv2::noise_sv2::formats::EncodedEd25519PublicKey;
 
 #[derive(Debug, Deserialize)]
 pub struct ProxyConfig {
     pub upstream_address: String,
     pub upstream_port: u16,
-    pub upstream_authority_pubkey: [u8; 32],
+    pub upstream_authority_pubkey: EncodedEd25519PublicKey,
     pub downstream_address: String,
     pub downstream_port: u16,
     pub max_supported_version: u16,

--- a/roles/translator/src/proxy_config.rs
+++ b/roles/translator/src/proxy_config.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use codec_sv2::noise_sv2::formats::EncodedEd25519PublicKey;
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct ProxyConfig {


### PR DESCRIPTION
fixes #297

Replaces the auth pubkey decimal array in the proxy config file with the base58 encoded string and deserializes the key.