### PR TITLE
207 logging via tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +239,7 @@ dependencies = [
  "derive_codec_sv2",
  "serde",
  "serde_sv2",
+ "tracing",
 ]
 
 [[package]]
@@ -1069,6 +1079,8 @@ dependencies = [
  "serde",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1120,6 +1132,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snow",
+ "tracing",
 ]
 
 [[package]]
@@ -1318,6 +1331,8 @@ dependencies = [
  "serde",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1697,6 +1712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +1889,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +1948,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "translator"
 version = "0.1.0"
 dependencies = [
@@ -1932,6 +2023,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "v1",
 ]
 
@@ -1982,7 +2075,14 @@ dependencies = [
  "quickcheck_macros 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
+ "tracing",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/protocols/v1/Cargo.toml
+++ b/protocols/v1/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.0"
 hex = "0.3.2"
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
+tracing = {version = "0.1"}
 
 [dev-dependencies]
 quickcheck = "1"

--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -42,6 +42,7 @@ pub mod methods;
 pub mod utils;
 
 use std::convert::TryInto;
+use tracing::{warn, debug};
 
 // use error::Result;
 use error::Error;
@@ -95,7 +96,7 @@ pub trait IsServer {
                 Ok(Some(authorize.respond(authorized)))
             }
             methods::Client2Server::Configure(configure) => {
-                println!("{:?}", configure);
+                debug!("{:?}", configure);
                 self.set_version_rolling_mask(configure.version_rolling_mask());
                 self.set_version_rolling_min_bit(configure.version_rolling_min_bit_count());
                 let (version_rolling, min_diff) = self.handle_configure(&configure);
@@ -313,7 +314,7 @@ pub trait IsClient {
                 self.set_version_rolling_mask(configure.version_rolling_mask());
                 self.set_version_rolling_min_bit(configure.version_rolling_min_bit());
                 self.set_status(ClientStatus::Configured);
-                println!("WARNING: Subscribe extranonce is hardcoded by server");
+                warn!("WARNING: Subscribe extranonce is hardcoded by server");
                 let subscribe = self
                     .subscribe(configure.id, Some("08000002".try_into()?))
                     .ok();

--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -42,7 +42,7 @@ pub mod methods;
 pub mod utils;
 
 use std::convert::TryInto;
-use tracing::{warn, debug};
+use tracing::{debug, warn};
 
 // use error::Result;
 use error::Error;

--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -13,6 +13,7 @@ serde_sv2 = {version = "0.1.0", path = "../serde-sv2", optional = true}
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true }
 binary_codec_sv2 = {version = "0.1.*", path = "../no-serde-sv2/codec", optional = true}
 derive_codec_sv2 = {version = "0.1.1", path = "../no-serde-sv2/derive_codec", optional = true}
+tracing = {version = "0.1"}
 
 [features]
 default = ["core"]

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -20,3 +20,4 @@ rand = "0.7.3"
 const_sv2 = {version = "0.1.*", path = "../../../protocols/v2/const-sv2"}
 buffer_sv2 = {version = "0.1.*", path = "../../../utils/buffer"}
 binary_sv2 = { version = "0.1.3", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
+tracing = { version = "0.1"}

--- a/protocols/v2/noise-sv2/src/lib.rs
+++ b/protocols/v2/noise-sv2/src/lib.rs
@@ -16,6 +16,7 @@ use snow::{params::NoiseParams, Builder, HandshakeState, TransportState};
 // Export for use in `codec_sv2::error::Error::SnowError`
 pub use snow::Error as NoiseSv2SnowError;
 use std::fmt;
+use tracing::{debug, info};
 
 pub use auth::{SignatureNoiseMessage, SignedPartHeader};
 pub use formats::Certificate;
@@ -339,7 +340,7 @@ impl handshake::Step for Responder {
                 match negotiation_message {
                     Ok(negotiation_message) => {
                         let algos: Vec<EncryptionAlgorithm> = negotiation_message.get_algos()?;
-                        println!("-> suggested algorithms received {:?}", algos);
+                        info!("-> suggested algorithms received {:?}", algos);
 
                         let chosen_algorithm = self
                             .algorithms
@@ -347,7 +348,7 @@ impl handshake::Step for Responder {
                             .find(|&a| algos.contains(a))
                             .copied()
                             .ok_or(Error::EncryptionAlgorithmNotFound)?;
-                        println!("<- chosen algorith: {:?}", chosen_algorithm);
+                        debug!("<- chosen algorithm: {:?}", chosen_algorithm);
                         self.requested_algorithms = algos;
                         self.chosen_algorithm = Some(chosen_algorithm);
 
@@ -375,7 +376,7 @@ impl handshake::Step for Responder {
                     .as_mut()
                     .expect("BUG: Handshake must be set at this point")
                     .read_message(&in_msg, &mut [0; BUFFER_LEN])?;
-                println!("-> token received: e");
+                debug!("-> token received: e");
 
                 let mut noise_bytes = vec![0; BUFFER_LEN];
 
@@ -387,7 +388,7 @@ impl handshake::Step for Responder {
                     .as_mut()
                     .expect("BUG: Handshake must be set at this point")
                     .write_message(&self.signature_noise_message, &mut noise_bytes)?;
-                println!("<- tokens sent: e, ee, s, es, SIG_NOISE_MSG");
+                debug!("<- tokens sent: e, ee, s, es, SIG_NOISE_MSG");
 
                 debug_assert_eq!(BUFFER_LEN, len_written);
                 handshake::StepResult::NoMoreReply(noise_bytes)

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1.0.89", default-features = false, features = ["derive", "a
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 tokio = { version = "1", features = ["full"] }
 toml = { git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }
 v1 = { path = "../../protocols/v1" }
 
 [features]

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -20,8 +20,6 @@ use std::{
 };
 use v1::server_to_client;
 
-use tracing_subscriber;
-
 use tracing::{error, warn};
 
 /// Process CLI args, if any.

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -24,7 +24,6 @@ use tracing_subscriber;
 
 use tracing::{error, warn};
 
-
 /// Process CLI args, if any.
 fn process_cli_args() -> ProxyResult<ProxyConfig> {
     let args = match Args::from_args() {

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -20,12 +20,17 @@ use std::{
 };
 use v1::server_to_client;
 
+use tracing_subscriber;
+
+use tracing::{error, warn};
+
+
 /// Process CLI args, if any.
 fn process_cli_args() -> ProxyResult<ProxyConfig> {
     let args = match Args::from_args() {
         Ok(cfg) => cfg,
         Err(help) => {
-            println!("{}", help);
+            error!("{}", help);
             return Err(Error::BadCliArgs);
         }
     };
@@ -35,8 +40,10 @@ fn process_cli_args() -> ProxyResult<ProxyConfig> {
 
 #[async_std::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
+
     let proxy_config = process_cli_args().unwrap();
-    println!("PC: {:?}", &proxy_config);
+    warn!("PC: {:?}", &proxy_config);
 
     // Sender/Receiver to send a SV1 `mining.submit` from the `Downstream` to the `Bridge`
     // (Sender<v1::client_to_server::Submit>, Receiver<Submit>)

--- a/roles/translator/src/upstream_sv2/upstream.rs
+++ b/roles/translator/src/upstream_sv2/upstream.rs
@@ -31,7 +31,6 @@ use roles_logic_sv2::{
 use std::{net::SocketAddr, sync::Arc};
 use tracing::{debug, info};
 
-
 /// Represents the currently active mining job being worked on.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -357,10 +356,7 @@ impl Upstream {
                 sv2_submit.job_id = self_.safe_lock(|s| s.job_id.unwrap()).unwrap();
 
                 info!("Up: Submitting Share");
-                debug!(
-                    "Up: Handling SubmitSharesExtended: {:?}",
-                    &sv2_submit
-                );
+                debug!("Up: Handling SubmitSharesExtended: {:?}", &sv2_submit);
 
                 //match self_
                 //    .safe_lock(|s| s.current_job.clone().get_candidate_hash(&sv2_submit))
@@ -543,10 +539,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
         self.min_extranonce_size = m.extranonce_size;
 
         info!("Up: Successfully Opened Extended Mining Channel");
-        debug!(
-            "Up: Handling OpenExtendedMiningChannelSuccess: {:?}",
-            &m
-        );
+        debug!("Up: Handling OpenExtendedMiningChannelSuccess: {:?}", &m);
         self.channel_id = Some(m.channel_id);
         self.extranonce_prefix = Some(m.extranonce_prefix.to_vec());
         let m = Mining::OpenExtendedMiningChannelSuccess(OpenExtendedMiningChannelSuccess {

--- a/roles/v2/mining-proxy/Cargo.toml
+++ b/roles/v2/mining-proxy/Cargo.toml
@@ -18,3 +18,5 @@ roles_logic_sv2 = { path = "../../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 tokio = { version = "1", features = ["full"] }
 toml = { git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
+tracing = {version = "0.1"}
+tracing-subscriber = {version = "0.3"}

--- a/roles/v2/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/downstream_mining.rs
@@ -16,6 +16,7 @@ use roles_logic_sv2::{
     utils::Mutex,
 };
 use std::collections::HashMap;
+use tracing::{info};
 
 use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
 
@@ -244,7 +245,7 @@ impl
         &mut self,
         m: SubmitSharesStandard,
     ) -> Result<SendTo<UpstreamMiningNode>, Error> {
-        println!("{:?}", m);
+        info!("{:?}", m);
         match self.channel_id_to_group_id.get(&m.channel_id) {
             Some(group_id) => match crate::upstream_from_job_id(m.job_id) {
                 Some(remote) => {

--- a/roles/v2/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/v2/mining-proxy/src/lib/downstream_mining.rs
@@ -16,7 +16,7 @@ use roles_logic_sv2::{
     utils::Mutex,
 };
 use std::collections::HashMap;
-use tracing::{info};
+use tracing::info;
 
 use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
 

--- a/roles/v2/mining-proxy/src/main.rs
+++ b/roles/v2/mining-proxy/src/main.rs
@@ -225,7 +225,6 @@ mod args {
 ///    upstream_mining::UpstreamMiningNode begin
 #[tokio::main]
 async fn main() {
-
     tracing_subscriber::fmt::init();
 
     let args = match args::Args::from_args() {

--- a/roles/v2/mining-proxy/src/main.rs
+++ b/roles/v2/mining-proxy/src/main.rs
@@ -19,7 +19,6 @@
 //!
 mod lib;
 use std::net::SocketAddr;
-use tracing_subscriber;
 
 use tracing::{error, info};
 

--- a/roles/v2/pool/Cargo.toml
+++ b/roles/v2/pool/Cargo.toml
@@ -19,3 +19,5 @@ roles_logic_sv2 = { path = "../../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 tokio = { version = "1", features = ["full"] }
 toml = { git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
+tracing = { version = "0.1" }
+tracing-subscriber = "0.3"

--- a/roles/v2/pool/src/main.rs
+++ b/roles/v2/pool/src/main.rs
@@ -8,7 +8,6 @@ use roles_logic_sv2::{
     parsers::PoolMessages,
 };
 use serde::Deserialize;
-use tracing_subscriber;
 
 use tracing::{error, info};
 


### PR DESCRIPTION
This pr introduces the tokio tracing crate to the library and applications to be used for logging. The applications use a simple tracing_subscriber crate to print logging out to stdout but we can later decide to use a different crate to log in different formats or different outputs.