### PR TITLE
TProxy future job handling

### DIFF
--- a/roles/translator/src/downstream_sv1/downstream.rs
+++ b/roles/translator/src/downstream_sv1/downstream.rs
@@ -97,7 +97,7 @@ impl Downstream {
                 while let Some(incoming) = messages.next().await {
                     let incoming =
                         incoming.expect("Err reading next incoming message from SV1 Downstream");
-                    //info!("\nInfo:: Down: Receiving: {:?}", &incoming);
+                    info!("Receiving from Mining Device: {:?}", &incoming);
                     let incoming: Result<json_rpc::Message, _> = serde_json::from_str(&incoming);
                     let incoming = incoming.expect("Err serializing incoming message from SV1 Downstream into JSON from `String`");
                     // Handle what to do with message
@@ -116,7 +116,7 @@ impl Downstream {
                     serde_json::to_string(&to_send)
                         .expect("Err deserializing JSON message for SV1 Downstream into `String`")
                 );
-                //info!("\nInfo:: Down: Sending: {:?}", &to_send);
+                info!("Sending to Mining Device: {:?}", &to_send);
                 (&*socket_writer_clone)
                     .write_all(to_send.as_bytes())
                     .await

--- a/roles/translator/src/proxy/bridge.rs
+++ b/roles/translator/src/proxy/bridge.rs
@@ -9,7 +9,7 @@ use v1::{client_to_server::Submit, server_to_client};
 
 use super::next_mining_notify::NextMiningNotify;
 use crate::{Error, ProxyResult};
-use tracing::{info, warn};
+use tracing::warn;
 
 /// Bridge between the SV2 `Upstream` and SV1 `Downstream` responsible for the following messaging
 /// translation:

--- a/roles/translator/src/proxy/bridge.rs
+++ b/roles/translator/src/proxy/bridge.rs
@@ -49,6 +49,9 @@ pub struct Bridge {
     /// a Downstream role connects and receives the first notify values, this member field is no
     /// longer used.
     last_notify: Arc<Mutex<Option<server_to_client::Notify>>>,
+    /// Stores SV2 `NewExtendedMiningJob` messages intended for future SV2 `SetNewPrevHash`
+    /// messages (when the SV2 `NewExtendedMiningJob` message has a `future_job=false`). The
+    /// `job_id` is the key, and the `NewExtendedMiningJob` is the value.
     job_mapper: HashMap<u32, NewExtendedMiningJob<'static>>,
 }
 

--- a/roles/translator/src/proxy/next_mining_notify.rs
+++ b/roles/translator/src/proxy/next_mining_notify.rs
@@ -1,5 +1,5 @@
 use roles_logic_sv2::mining_sv2::{NewExtendedMiningJob, SetNewPrevHash};
-use tracing::info;
+use tracing::{debug, error};
 use v1::{
     server_to_client,
     utils::{HexBytes, HexU32Be, PrevHash},
@@ -73,7 +73,7 @@ impl NextMiningNotify {
                 (None, Some(nemj)) => (None, Some(nemj.job_id)),
                 (None, None) => (None, None),
             };
-            info!(
+            error!(
                 "Job Id Mismatch. SetNewPrevHash Job Id: {:?}, NewExtendedMiningJob Job Id: {:?}",
                 snph_job_id, nemj_job_id
             );
@@ -117,7 +117,7 @@ impl NextMiningNotify {
                     time,
                     clean_jobs,
                 };
-                info!("\nNMN: {:?}\n", &self);
+                debug!("\nNextMiningNotify: {:?}\n", &self);
                 Some(notify_response)
             }
             // If either of the SV2 `SetNewPrevHash` or `NewExtendedMiningJob` have not been

--- a/roles/translator/src/proxy/next_mining_notify.rs
+++ b/roles/translator/src/proxy/next_mining_notify.rs
@@ -1,4 +1,5 @@
 use roles_logic_sv2::mining_sv2::{NewExtendedMiningJob, SetNewPrevHash};
+use tracing::info;
 use v1::{
     server_to_client,
     utils::{HexBytes, HexU32Be, PrevHash},
@@ -44,21 +45,39 @@ impl NextMiningNotify {
         self.new_extended_mining_job = Some(new_extended_mining_job);
     }
 
+    /// Checks that `SetNewPrevHash` and `NewExtendedMiningJob` stored in `NextMiningNotify` are
+    /// for the same job (aka each message has the same `job_id` field).
+    pub(crate) fn matching_job_id(&self) -> bool {
+        if let (Some(snph), Some(nemj)) = (
+            self.set_new_prev_hash.as_ref(),
+            self.new_extended_mining_job.as_ref(),
+        ) {
+            snph.job_id.eq(&nemj.job_id)
+        } else {
+            false
+        }
+    }
+
     /// Creates a new SV1 `mining.notify` message if both SV2 `SetNewPrevHash` and
     /// `NewExtendedMiningJob` messages have been received. If one of these messages is still being
     /// waited on, the function returns `None`.
     pub(crate) fn create_notify(&self) -> Option<server_to_client::Notify> {
         // Make sure that SetNewPrevHash + NewExtendedMiningJob is matching (not future)
-        if self.set_new_prev_hash.is_some() && self.new_extended_mining_job.is_some() {
-            let set_new_prev_hash_job_id = &self.set_new_prev_hash.as_ref().unwrap().job_id;
-            let new_extended_mining_job_job_id =
-                &self.new_extended_mining_job.as_ref().unwrap().job_id;
-            if set_new_prev_hash_job_id != new_extended_mining_job_job_id {
-                panic!(
-                    "Job Id Mismatch. SetNewPrevHash Job Id: {}, NewExtendedMiningJob Job Id: {}",
-                    set_new_prev_hash_job_id, new_extended_mining_job_job_id
-                );
-            }
+        if !self.matching_job_id() {
+            let (snph_job_id, nemj_job_id) = match (
+                self.set_new_prev_hash.as_ref(),
+                self.new_extended_mining_job.as_ref(),
+            ) {
+                (Some(snph), Some(nemj)) => (Some(snph.job_id), Some(nemj.job_id)),
+                (Some(snph), None) => (Some(snph.job_id), None),
+                (None, Some(nemj)) => (None, Some(nemj.job_id)),
+                (None, None) => (None, None),
+            };
+            info!(
+                "Job Id Mismatch. SetNewPrevHash Job Id: {:?}, NewExtendedMiningJob Job Id: {:?}",
+                snph_job_id, nemj_job_id
+            );
+            return None;
         }
 
         match (&self.set_new_prev_hash, &self.new_extended_mining_job) {
@@ -98,6 +117,7 @@ impl NextMiningNotify {
                     time,
                     clean_jobs,
                 };
+                info!("\nNMN: {:?}\n", &self);
                 Some(notify_response)
             }
             // If either of the SV2 `SetNewPrevHash` or `NewExtendedMiningJob` have not been

--- a/roles/translator/src/upstream_sv2/upstream.rs
+++ b/roles/translator/src/upstream_sv2/upstream.rs
@@ -29,7 +29,7 @@ use roles_logic_sv2::{
     utils::{get_target, Mutex},
 };
 use std::{net::SocketAddr, sync::Arc};
-use tracing::{debug, info, trace};
+use tracing::{debug, info, warn};
 
 /// Represents the currently active mining job being worked on.
 #[allow(dead_code)]
@@ -313,6 +313,7 @@ impl Upstream {
                                 sender.send(extended).await.unwrap();
                             }
                             Mining::NewExtendedMiningJob(m) => {
+                                warn!("parse_incoming Mining::NewExtendedMiningJob msg");
                                 let job_id = m.job_id;
                                 let sender = self_
                                     .safe_lock(|s| s.new_extended_mining_job_sender.clone())
@@ -325,6 +326,7 @@ impl Upstream {
                                 sender.send(m).await.unwrap();
                             }
                             Mining::SetNewPrevHash(m) => {
+                                warn!("parse_incoming Mining::SetNewPrevHash msg");
                                 let sender =
                                     self_.safe_lock(|s| s.new_prev_hash_sender.clone()).unwrap();
                                 sender.send(m).await.unwrap();
@@ -478,7 +480,7 @@ impl ParseUpstreamCommonMessages<NoRouting> for Upstream {
         &mut self,
         _: roles_logic_sv2::common_messages_sv2::SetupConnectionSuccess,
     ) -> Result<SendToCommon, roles_logic_sv2::errors::Error> {
-        trace!("Up: Handling SetupConnectionSuccess");
+        debug!("Up: Handling SetupConnectionSuccess");
         Ok(SendToCommon::None(None))
     }
 
@@ -658,8 +660,11 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
         if !m.future_job {
             todo!()
         }
+        info!("Is future job: {}\n", &m.future_job);
+
         if !m.version_rolling_allowed {
-            todo!()
+            warn!("VERSION ROLLING NOT ALLOWED IS A TODO");
+            // todo!()
         }
         let job = Job_ {
             id: m.job_id,
@@ -704,6 +709,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
         m: roles_logic_sv2::mining_sv2::SetNewPrevHash,
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, roles_logic_sv2::errors::Error>
     {
+        warn!("handle_set_new_prev_hash msg");
         let prev_hash: [u8; 32] = m.prev_hash.to_vec().try_into().unwrap();
         let prev_hash = DHash::from_inner(prev_hash);
         let prev_hash = BlockHash::from_hash(prev_hash);

--- a/roles/translator/src/upstream_sv2/upstream.rs
+++ b/roles/translator/src/upstream_sv2/upstream.rs
@@ -29,7 +29,7 @@ use roles_logic_sv2::{
     utils::{get_target, Mutex},
 };
 use std::{net::SocketAddr, sync::Arc};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 /// Represents the currently active mining job being worked on.
 #[allow(dead_code)]
@@ -313,7 +313,7 @@ impl Upstream {
                                 sender.send(extended).await.unwrap();
                             }
                             Mining::NewExtendedMiningJob(m) => {
-                                warn!("parse_incoming Mining::NewExtendedMiningJob msg");
+                                debug!("parse_incoming Mining::NewExtendedMiningJob msg");
                                 let job_id = m.job_id;
                                 let sender = self_
                                     .safe_lock(|s| s.new_extended_mining_job_sender.clone())
@@ -326,7 +326,7 @@ impl Upstream {
                                 sender.send(m).await.unwrap();
                             }
                             Mining::SetNewPrevHash(m) => {
-                                warn!("parse_incoming Mining::SetNewPrevHash msg");
+                                debug!("parse_incoming Mining::SetNewPrevHash msg");
                                 let sender =
                                     self_.safe_lock(|s| s.new_prev_hash_sender.clone()).unwrap();
                                 sender.send(m).await.unwrap();
@@ -657,9 +657,6 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, roles_logic_sv2::errors::Error>
     {
         debug!("Received NewExtendedMiningJob: {:?}", &m);
-        if !m.future_job {
-            todo!()
-        }
         info!("Is future job: {}\n", &m.future_job);
 
         if !m.version_rolling_allowed {
@@ -709,7 +706,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
         m: roles_logic_sv2::mining_sv2::SetNewPrevHash,
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, roles_logic_sv2::errors::Error>
     {
-        warn!("handle_set_new_prev_hash msg");
+        trace!("handle_set_new_prev_hash msg");
         let prev_hash: [u8; 32] = m.prev_hash.to_vec().try_into().unwrap();
         let prev_hash = DHash::from_inner(prev_hash);
         let prev_hash = BlockHash::from_hash(prev_hash);


### PR DESCRIPTION
The Translator Proxy only supports `future_job=true`. This works with the current Braiins pool behavior as it only sends future jobs. This PR handles the case when `future_job=false`.

It is worth noting that there has been a [spec change](https://github.com/stratum-mining/sv2-spec/pull/12) that removes the `future_job` field from the mining job messages and replaces it with `min_ntime`. Once this PR has been reviewed and merged, another PR will be opened to migrate from `future_job`s to `min_ntime`. This change also impacts SRI's pool application and will need to be updated there as well.