### PR TITLE
binary-sv2: add inner_as_ref() to Seq064K

### DIFF
--- a/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
@@ -273,6 +273,15 @@ mod test {
 
             assert_eq!(deserialized, expected);
         }
+
+        #[test]
+        fn test_inner_as_ref() {
+            let mut input = [1, 2, 9];
+            let b: B064K = (&mut input[..]).try_into().unwrap();
+
+            let borrow = b.inner_as_ref();
+            assert_eq!(&borrow[..], &[1, 2, 9]);
+        }
     }
 
     mod test_seq0255_u256 {

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -109,6 +109,12 @@ impl<'a, T: 'a> Seq064K<'a, T> {
             Err(Error::SeqExceedsMaxSize)
         }
     }
+
+    /// Return a reference to the inner vector of T with the same lifetime
+    /// guarantees as the struct.
+    pub fn inner_as_ref(&'a self) -> &'a Vec<T> {
+        &self.0
+    }
 }
 
 impl<'a, T: GetSize> GetSize for Seq064K<'a, T> {


### PR DESCRIPTION
Adds  a method to borrow the inner vector of T for Seq064K. This is specifically required when the job_creator receives a NewTemplate with coinbase_tx_outputs and will need to deserialize each item into a TxOut.