### PR TITLE
Segwit compatibility in the Pool

### DIFF
--- a/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
@@ -273,6 +273,15 @@ mod test {
 
             assert_eq!(deserialized, expected);
         }
+
+        #[test]
+        fn test_inner_as_ref() {
+            let mut input = [1, 2, 9];
+            let b: B064K = (&mut input[..]).try_into().unwrap();
+
+            let borrow = b.inner_as_ref();
+            assert_eq!(&borrow[..], &[1, 2, 9]);
+        }
     }
 
     mod test_seq0255_u256 {

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -109,6 +109,12 @@ impl<'a, T: 'a> Seq064K<'a, T> {
             Err(Error::SeqExceedsMaxSize)
         }
     }
+
+    /// Return a reference to the inner vector of T with the same lifetime
+    /// guarantees as the struct.
+    pub fn inner_as_ref(&'a self) -> &'a Vec<T> {
+        &self.0
+    }
 }
 
 impl<'a, T: GetSize> GetSize for Seq064K<'a, T> {

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -19,6 +19,13 @@ const SCRIPT_PREFIX_LEN: usize = 4;
 const PREV_OUT_LEN: usize = 38;
 const EXTRANONCE_LEN: usize = 32;
 
+/// Hardcoded value if/when a spec change is approved to send this value from the
+/// TemplateProvider: https://github.com/stratum-mining/sv2-spec/pull/15
+///
+/// The WITNESS_RESERVE_VALUE is used to validate a witness commitment given:
+/// SHA256^2(witness_reserve_value, witness_root);
+const WITNESS_RESERVE_VALUE: [u8; 32] = [0x00; 32];
+
 /// Used by pool one for each group channel
 /// extended and standard channel not supported
 #[derive(Debug)]
@@ -114,7 +121,7 @@ impl JobCreator {
             previous_output: OutPoint::null(),
             script_sig: bip34_bytes.into(),
             sequence,
-            witness: vec![],
+            witness: vec![WITNESS_RESERVE_VALUE.to_vec()],
         };
         Transaction {
             version,

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -35,10 +35,6 @@ impl JobCreator {
         new_template: &mut NewTemplate,
         coinbase_outputs: &[TxOut],
     ) -> Result<NewExtendedMiningJob<'static>, Error> {
-        assert!(
-            new_template.coinbase_tx_outputs_count == 0,
-            "node provided outputs not supported yet"
-        );
         let script_prefix = new_template.coinbase_prefix.to_vec();
         // Is ok to panic here cause condition will be always true when not in a test chain
         // (regtest ecc ecc)

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -5,7 +5,7 @@ use bitcoin::{
         script::Script,
         transaction::{OutPoint, Transaction, TxIn, TxOut},
     },
-    util::psbt::serialize::Serialize,
+    util::psbt::serialize::{Deserialize, Serialize},
 };
 pub use bitcoin::{
     secp256k1::SecretKey,
@@ -176,6 +176,15 @@ impl JobsCreators {
         if template.coinbase_tx_value_remaining != self.block_reward_staoshi {
             self.block_reward_staoshi = template.coinbase_tx_value_remaining;
             self.coinbase_outputs = self.new_outputs(template.coinbase_tx_value_remaining);
+        }
+
+        if template.coinbase_tx_outputs_count > 0 {
+            self.coinbase_outputs = self.new_outputs(template.coinbase_tx_value_remaining);
+
+            for output in template.coinbase_tx_outputs.inner_as_ref() {
+                self.coinbase_outputs
+                    .push(TxOut::deserialize(output.inner_as_ref()).unwrap());
+            }
         }
 
         let mut new_extended_jobs = HashMap::new();


### PR DESCRIPTION
Built on top of #336, the changes relevant to this PR begin at e688285.

This change allows the Pool to handle NewTemplates that contain Segwit inputs. The Pool can receive and process multiple coinbase_tx_outputs. This will enable the Template Provider to send the coinbase witness commitment (a TxOut) to the Pool and the Pool can submit work for valid Segwit blocks.

Things to consider:

- The Pool can theoretically calculate their own coinbase witness commitment using `DoubleSHA256(witness root hash | witness reserved value)`

- If we should/do need to send the coinbase witness commitment, maybe consider making this explicit for the additional outputs field and no other type of outputs are allowed?

- `WITNESS_RESERVE_VALUE` is currently hardcoded, there is a proposal in the spec for the TemplateProvider to send this value in a NewTemplate message

- Testing on Regtest, these changes now remove the `AcceptBlock FAILED (unexpected-witness, ContextualCheckBlock : unexpected witness data found)` error, but high hash errors still persist when attempting to validate a block with many transactions. I suspect it could be an issue with hardcoding the difficulty in the proxy or a bug in parsing coinbase_prefix/suffix not taking into account the extra 2 byte flag for segwit or it could be adding the work to the coinbase tx is buggy as reported in #317, further investigation required