### PR TITLE
Error: bitcoin consensus error

### DIFF
--- a/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
@@ -273,6 +273,15 @@ mod test {
 
             assert_eq!(deserialized, expected);
         }
+
+        #[test]
+        fn test_inner_as_ref() {
+            let mut input = [1, 2, 9];
+            let b: B064K = (&mut input[..]).try_into().unwrap();
+
+            let borrow = b.inner_as_ref();
+            assert_eq!(&borrow[..], &[1, 2, 9]);
+        }
     }
 
     mod test_seq0255_u256 {

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -109,6 +109,12 @@ impl<'a, T: 'a> Seq064K<'a, T> {
             Err(Error::SeqExceedsMaxSize)
         }
     }
+
+    /// Return a reference to the inner vector of T with the same lifetime
+    /// guarantees as the struct.
+    pub fn inner_as_ref(&'a self) -> &'a Vec<T> {
+        &self.0
+    }
 }
 
 impl<'a, T: GetSize> GetSize for Seq064K<'a, T> {

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -1,4 +1,5 @@
 use binary_sv2::Error as BinarySv2Error;
+use bitcoin::consensus::encode::Error as BitcoinEncodeError;
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug)]
@@ -8,6 +9,7 @@ pub enum Error {
     BadPayloadSize,
     ExpectedLen32(usize),
     BinarySv2Error(BinarySv2Error),
+    BitcoinEncodeError(BitcoinEncodeError),
     /// Errors if a `SendTo::RelaySameMessageSv1` request is made on a SV2-only application.
     CannotRelaySv1Message,
     NoGroupsFound,
@@ -34,6 +36,12 @@ impl From<BinarySv2Error> for Error {
     }
 }
 
+impl From<BitcoinEncodeError> for Error {
+    fn from(v: BitcoinEncodeError) -> Error {
+        Error::BitcoinEncodeError(v)
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use Error::*;
@@ -42,6 +50,11 @@ impl Display for Error {
             BinarySv2Error(v) => write!(
                 f,
                 "BinarySv2Error: error in serializing/deserilizing binary format {:?}",
+                v
+            ),
+            BitcoinEncodeError(v) => write!(
+                f,
+                "BitcoinEncodeError: error in the Rust Bitcoin encoder: {:?}",
                 v
             ),
             CannotRelaySv1Message => {

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -183,7 +183,7 @@ impl JobsCreators {
 
             for output in template.coinbase_tx_outputs.inner_as_ref() {
                 self.coinbase_outputs
-                    .push(TxOut::deserialize(output.inner_as_ref()).unwrap());
+                    .push(TxOut::deserialize(output.inner_as_ref())?);
             }
         }
 

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -19,6 +19,13 @@ const SCRIPT_PREFIX_LEN: usize = 4;
 const PREV_OUT_LEN: usize = 38;
 const EXTRANONCE_LEN: usize = 32;
 
+/// Hardcoded value if/when a spec change is approved to send this value from the
+/// TemplateProvider: https://github.com/stratum-mining/sv2-spec/pull/15
+///
+/// The WITNESS_RESERVE_VALUE is used to validate a witness commitment given:
+/// SHA256^2(witness_reserve_value, witness_root);
+const WITNESS_RESERVE_VALUE: [u8; 32] = [0x00; 32];
+
 /// Used by pool one for each group channel
 /// extended and standard channel not supported
 #[derive(Debug)]
@@ -114,7 +121,7 @@ impl JobCreator {
             previous_output: OutPoint::null(),
             script_sig: bip34_bytes.into(),
             sequence,
-            witness: vec![],
+            witness: vec![WITNESS_RESERVE_VALUE.to_vec()],
         };
         Transaction {
             version,

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -35,10 +35,6 @@ impl JobCreator {
         new_template: &mut NewTemplate,
         coinbase_outputs: &[TxOut],
     ) -> Result<NewExtendedMiningJob<'static>, Error> {
-        assert!(
-            new_template.coinbase_tx_outputs_count == 0,
-            "node provided outputs not supported yet"
-        );
         let script_prefix = new_template.coinbase_prefix.to_vec();
         // Is ok to panic here cause condition will be always true when not in a test chain
         // (regtest ecc ecc)

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -5,7 +5,7 @@ use bitcoin::{
         script::Script,
         transaction::{OutPoint, Transaction, TxIn, TxOut},
     },
-    util::psbt::serialize::Serialize,
+    util::psbt::serialize::{Deserialize, Serialize},
 };
 pub use bitcoin::{
     secp256k1::SecretKey,
@@ -176,6 +176,15 @@ impl JobsCreators {
         if template.coinbase_tx_value_remaining != self.block_reward_staoshi {
             self.block_reward_staoshi = template.coinbase_tx_value_remaining;
             self.coinbase_outputs = self.new_outputs(template.coinbase_tx_value_remaining);
+        }
+
+        if template.coinbase_tx_outputs_count > 0 {
+            self.coinbase_outputs = self.new_outputs(template.coinbase_tx_value_remaining);
+
+            for output in template.coinbase_tx_outputs.inner_as_ref() {
+                self.coinbase_outputs
+                    .push(TxOut::deserialize(output.inner_as_ref()).unwrap());
+            }
         }
 
         let mut new_extended_jobs = HashMap::new();


### PR DESCRIPTION
Built on top of #337, the changes relevant to this PR begin at 8cac5f0.

Optional - Add the Rust Bitcoin Encoding errors to the Error handling and remove the unwrap when deserializing B064K to TxOut.