### PR TITLE
Pool: Fix coinbase height bug

### DIFF
--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -109,6 +109,12 @@ impl<'a, T: 'a> Seq064K<'a, T> {
             Err(Error::SeqExceedsMaxSize)
         }
     }
+
+    /// Return a reference to the inner vector of T with the same lifetime
+    /// guarantees as the struct.
+    pub fn inner_as_ref(&'a self) -> &'a Vec<T> {
+        &self.0
+    }
 }
 
 impl<'a, T: GetSize> GetSize for Seq064K<'a, T> {

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -311,7 +311,7 @@ mod test {
     impl<'a> CoinbaseTestHarness<'a> {
         /// Test the prefix and suffix are sliced correctly.
         fn test_coinbase_prefix_suffix(&self) {
-            let cb_tx: Transaction = deserialize(&self.cb_bytes).unwrap();
+            let cb_tx: Transaction = deserialize(self.cb_bytes).unwrap();
 
             let segwit_flag = if self.segwit { SEGWIT_FLAG_LEN } else { 0 };
 
@@ -319,8 +319,8 @@ mod test {
             let cb_prefix =
                 JobCreator::coinbase_tx_prefix(&cb_tx, self.block_height_len, self.segwit).unwrap();
             assert_eq!(
-                &self.cb_bytes[0..CB_PREFIX_LEN + segwit_flag + self.block_height_len],
-                &cb_prefix.inner_as_ref()[..]
+                self.cb_bytes[0..CB_PREFIX_LEN + segwit_flag + self.block_height_len],
+                cb_prefix.inner_as_ref()[..]
             );
 
             // The coinbase suffix should be sliced from the sequence number (after
@@ -330,8 +330,8 @@ mod test {
 
             let cb_suffix = JobCreator::coinbase_tx_suffix(&cb_tx, self.segwit).unwrap();
             assert_eq!(
-                &self.cb_bytes[CB_PREFIX_LEN + segwit_flag + script_sig_len..],
-                &cb_suffix.inner_as_ref()[..]
+                self.cb_bytes[CB_PREFIX_LEN + segwit_flag + script_sig_len..],
+                cb_suffix.inner_as_ref()[..]
             );
 
             // Explicity test for the expected end of prefix bytes and beginning

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -19,6 +19,13 @@ const SCRIPT_PREFIX_LEN: usize = 4;
 const PREV_OUT_LEN: usize = 38;
 const EXTRANONCE_LEN: usize = 32;
 
+/// Hardcoded value if/when a spec change is approved to send this value from the
+/// TemplateProvider: https://github.com/stratum-mining/sv2-spec/pull/15
+///
+/// The WITNESS_RESERVE_VALUE is used to validate a witness commitment given:
+/// SHA256^2(witness_reserve_value, witness_root);
+const WITNESS_RESERVE_VALUE: [u8; 32] = [0x00; 32];
+
 /// Used by pool one for each group channel
 /// extended and standard channel not supported
 #[derive(Debug)]
@@ -114,7 +121,7 @@ impl JobCreator {
             previous_output: OutPoint::null(),
             script_sig: bip34_bytes.into(),
             sequence,
-            witness: vec![],
+            witness: vec![WITNESS_RESERVE_VALUE.to_vec()],
         };
         Transaction {
             version,

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -35,10 +35,6 @@ impl JobCreator {
         new_template: &mut NewTemplate,
         coinbase_outputs: &[TxOut],
     ) -> Result<NewExtendedMiningJob<'static>, Error> {
-        assert!(
-            new_template.coinbase_tx_outputs_count == 0,
-            "node provided outputs not supported yet"
-        );
         let script_prefix = new_template.coinbase_prefix.to_vec();
         // Is ok to panic here cause condition will be always true when not in a test chain
         // (regtest ecc ecc)

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -5,7 +5,7 @@ use bitcoin::{
         script::Script,
         transaction::{OutPoint, Transaction, TxIn, TxOut},
     },
-    util::psbt::serialize::Serialize,
+    util::psbt::serialize::{Deserialize, Serialize},
 };
 pub use bitcoin::{
     secp256k1::SecretKey,
@@ -176,6 +176,15 @@ impl JobsCreators {
         if template.coinbase_tx_value_remaining != self.block_reward_staoshi {
             self.block_reward_staoshi = template.coinbase_tx_value_remaining;
             self.coinbase_outputs = self.new_outputs(template.coinbase_tx_value_remaining);
+        }
+
+        if template.coinbase_tx_outputs_count > 0 {
+            self.coinbase_outputs = self.new_outputs(template.coinbase_tx_value_remaining);
+
+            for output in template.coinbase_tx_outputs.inner_as_ref() {
+                self.coinbase_outputs
+                    .push(TxOut::deserialize(output.inner_as_ref()).unwrap());
+            }
         }
 
         let mut new_extended_jobs = HashMap::new();


### PR DESCRIPTION
fixes #340, the changes relevant to this PR begin at 220e7f3

This PR fixes a bug where the `JobCreator` malforms a serialized coinbase transaction by slicing off by one in the coinbase prefix and suffix when handling segwit blocks.

This also adds changes to `job_creator.rs` to be able to handle coinbase transactions with different extranonce lengths but still allows the pool to use it's hardcoded 32 byte extranonce length.

Tests are added to show the parsing of real onchain coinbase transactions.
