### PR TITLE
Pool Fix: Merkle Root Failed to be Calculated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ version = "0.1.2"
 dependencies = [
  "buffer_sv2",
  "quickcheck 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck_macros 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
@@ -12,6 +12,10 @@ license = "MIT"
 quickcheck = {version = "1.0.0", optional = true}
 buffer_sv2 = {path = "../../../../../utils/buffer", optional=true}
 
+[dev-dependencies]
+quickcheck = "1"
+quickcheck_macros = "1"
+
 
 [features]
 no_std = []

--- a/roles/v2/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/v2/pool/src/lib/mining_pool/message_handler.rs
@@ -198,7 +198,7 @@ impl ParseDownstreamMiningMessages<(), NullDownstreamMiningSelector, NoRouting> 
         let channel_id = self.channel_ids.next();
         let mut partial_job = crate::lib::mining_pool::Job::new(
             u256_to_uint_256(target.clone()),
-            extended.clone().to_vec(),
+            U256::from(extended.clone()).to_vec(),
         );
         let mut extended = extended.to_vec();
         extended.resize(16, 0);


### PR DESCRIPTION
This PR was created in regards to https://github.com/stratum-mining/stratum/issues/317. The changes were made assuming the `extranonce` parameter in the function `merkle_root_from_path()` in `/protocols/v2/roles-logic-sv2/src/utils.rs` must be exactly 32 bytes, since this has consistently worked for me over the past couple weeks.

Question before approving/merging: 
Does the extranonce field always have to be 32 bytes or is the correct length dependent on the coinbase tx suffix/prefix?  

Note: If you want to look deeper into the issue, the main logic of `Transaction::deserialize()` in the `bitcoin` crate is here https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/src/blockdata/transaction.rs#L991

# To Recreate:
1. start bitcoind
2. generate blocks with bitcoin-cli
3. run the pool
4. run the TProxy
5. check the pool logs for this error 

![image](https://user-images.githubusercontent.com/105945999/207126727-356a8d06-ed00-476f-a40d-df740e8209db.png)
