### PR TITLE
Add modularity for messages MG

### DIFF
--- a/test/message-generator/messages/common_messages.json
+++ b/test/message-generator/messages/common_messages.json
@@ -1,0 +1,28 @@
+{
+    "common_messages": [
+        {
+            "message": {
+                "type": "SetupConnection",
+                "protocol": 0,
+                "min_version": 2,
+                "max_version": 2,
+                "flags": 1,
+                "endpoint_host": "",
+                "endpoint_port": 0,
+                "vendor": "",
+                "hardware_version": "",
+                "firmware": "",
+                "device_id": ""
+            },
+            "id": "setup_connection_mining_hom"
+        },
+        {
+            "message": {
+                "type": "SetupConnectionSuccess",
+                "flags": 0,
+                "used_version": 2
+            },
+            "id": "setup_connection_success_flag_0"
+        }
+    ]
+}

--- a/test/message-generator/mock/template-provider-mock0.json
+++ b/test/message-generator/mock/template-provider-mock0.json
@@ -6,16 +6,6 @@
         "Sends setup_connection_success",
         "Start listen that message 0x00 arrives, without dieing"
     ],
-    "common_messages": [
-        {
-            "message": {
-                "type": "SetupConnectionSuccess",
-                "flags": 0,
-                "used_version": 2
-            },
-            "id": "setup_connection_success"
-        }
-    ],
     "template_distribution_messages": [
         {
             "message": {
@@ -49,7 +39,7 @@
     "frame_builders": [
         {
             "type": "automatic",
-            "message_id": "setup_connection_success"
+            "message_id": "../../../../test/message-generator/messages/common_messages.json::setup_connection_success_flag_0"
         },
         {
             "type": "automatic",
@@ -73,7 +63,7 @@
             ]
         },
         {
-            "message_ids": ["setup_connection_success","new_template","set_new_prev_hash"],
+            "message_ids": ["setup_connection_success_flag_0","new_template","set_new_prev_hash"],
             "role": "server",
             "results": [
                 {

--- a/utils/message-generator/src/parser/sv2_messages.rs
+++ b/utils/message-generator/src/parser/sv2_messages.rs
@@ -5,15 +5,16 @@ use roles_logic_sv2::{
 };
 use std::collections::HashMap;
 
-/// Prende un path e un id se a `path` c'e' un file lo carica come stringa e prova a trasformarlo
-/// in `TestMessageParser` poi con into_map trasforma il `TestMessageParser` in 
-/// HashMap (id -> AnyMessage)e prova a prendere il valore che corrisponde ad id
+/// It takes a path and an id. If at `path` there is a file, then it loads it and tries to 
+/// transform it in `TestmessageParser`. Therefore, with into_map, trasforms the
+/// `TestMessageParser` in HashMap (id -> AnyMessage) and tries to take the value that corresponds
+/// to id
 pub fn message_from_path(path: & Vec<String>) -> AnyMessage<'static> {
     let id = path[1].clone();
     let path = path[0].clone();
     let messages = load_str!(&path);
     // Pa
-    let parsed = dbg!(TestMessageParser::from_str(messages));
+    let parsed = TestMessageParser::from_str(messages);
     parsed.into_map().get(&id).expect("There is no value matching the id {:?}").clone()
 }
 
@@ -172,7 +173,7 @@ mod test {
             }
         "#;
 
-        let v: TestMessageParser = dbg!(serde_json::from_str(data).unwrap());
+        let v: TestMessageParser = serde_json::from_str(data).unwrap();
         match v.common_messages.unwrap()[0].message {
             CommonMessages::SetupConnectionSuccess(m) => {
                 assert!(m.used_version == 2);
@@ -219,7 +220,7 @@ mod test {
             }
         "#;
 
-        let v: TestMessageParser = dbg!(serde_json::from_str(data).unwrap());
+        let v: TestMessageParser = serde_json::from_str(data).unwrap();
         let v = v.into_map();
         match v.get("setup_connection").unwrap() {
             AnyMessage::Common(

--- a/utils/message-generator/src/parser/sv2_messages.rs
+++ b/utils/message-generator/src/parser/sv2_messages.rs
@@ -5,6 +5,49 @@ use roles_logic_sv2::{
 };
 use std::collections::HashMap;
 
+/// Prende un path e un id se a `path` c'e' un file lo carica come stringa e prova a trasformarlo
+/// in `TestMessageParser` poi con into_map trasforma il `TestMessageParser` in 
+/// HashMap (id -> AnyMessage)e prova a prendere il valore che corrisponde ad id
+pub fn message_from_path(path: & Vec<String>) -> AnyMessage<'static> {
+    let id = path[1].clone();
+    let path = path[0].clone();
+    let messages = load_str!(&path);
+    // Pa
+    let parsed = dbg!(TestMessageParser::from_str(messages));
+    parsed.into_map().get(&id).expect("There is no value matching the id {:?}").clone()
+}
+
+/// This parses a json object that may or may not (and in this case field is None) have a value
+/// with a particular key. While parsing the file below, the mining_message filed is None
+/// 
+//        {
+//            "common_messages": [
+//                {
+//                    "message": {
+//                        "type": "SetupConnection",
+//                        "protocol": 0,
+//                        "min_version": 2,
+//                        "max_version": 2,
+//                        "flags": 1,
+//                        "endpoint_host": "",
+//                        "endpoint_port": 0,
+//                        "vendor": "",
+//                        "hardware_version": "",
+//                        "firmware": "",
+//                        "device_id": ""
+//                    },
+//                    "id": "setup_connection_mining_hom"
+//                },
+//                {
+//                    "message": {
+//                        "type": "SetupConnectionSuccess",
+//                        "flags": 0,
+//                        "used_version": 2
+//                    },
+//                    "id": "setup_connection_success_flag_0"
+//                }
+//            ]
+//        }
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestMessageParser<'a> {
     #[serde(borrow)]
@@ -16,7 +59,18 @@ pub struct TestMessageParser<'a> {
     #[serde(borrow)]
     template_distribution_messages: Option<Vec<TemplateDistributionMessage<'a>>>,
 }
-
+/// This is not the same CommonMessages as the SRI, but the fiel message is. This structure is
+/// needed because we use the id as a key to retrieve the message; this key is not part of the SRI
+/// type CommonMessage<'a>
+///
+//                      {
+//Defines an SRI messag     "message": {
+//                              "type": "SetupConnectionSuccess",
+//                              "flags": 0,
+//                              "used_version": 2
+//                          },
+//This is contained         "id": "setup_connection_success_flag_0"
+//field "id"            }
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CommonMessage<'a> {
     #[serde(borrow)]


### PR DESCRIPTION
Through the function message_from_path it is now possible to separate part of tests in different test module. This is applied to the mock of the template provider, where the common messages are moved to /tests/message-generator/messages/common_messages.json.
Also, some documentation is added.