### PR TITLE
TProxy: Downstream Kill Switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -807,15 +807,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-lite"
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -856,21 +856,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2062,6 +2062,7 @@ dependencies = [
  "codec_sv2",
  "error-handling",
  "framing_sv2",
+ "futures",
  "network_helpers",
  "once_cell",
  "roles_logic_sv2",

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -16,7 +16,6 @@ once_cell = "1.12.0"
 roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
-tokio = { version = "1", features = ["full"] }
 futures = "0.3.25"
 toml = { git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
 tracing = { version = "0.1" }

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -17,6 +17,7 @@ roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 tokio = { version = "1", features = ["full"] }
+futures = "0.3.25"
 toml = { git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -17,6 +17,7 @@ roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 futures = "0.3.25"
+tokio = { version = "1", features = ["full"] }
 toml = { git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/roles/translator/src/downstream_sv1/downstream.rs
+++ b/roles/translator/src/downstream_sv1/downstream.rs
@@ -119,7 +119,7 @@ impl Downstream {
                 select! {
                     res = messages.next().fuse() => {
                         if let Some(Ok(incoming)) = res {
-                            info!("Receiving from Mining Device: {:?}", &incoming);
+                            debug!("Receiving from Mining Device: {:?}", &incoming);
                             let incoming: json_rpc::Message = handle_result!(tx_status_reader, serde_json::from_str(&incoming));
                             // Handle what to do with message
                             let res = Self::handle_incoming_sv1(self_.clone(), incoming).await;
@@ -148,11 +148,11 @@ impl Downstream {
                         let to_send = match serde_json::to_string(&to_send) {
                             Ok(string) => format!("{}\n", string),
                             Err(_e) => {
-                                warn!("\nDownstream: Bad SV1 server message\n");
+                                debug!("\nDownstream: Bad SV1 server message\n");
                                 break;
                             }
                         };
-                        info!("Sending to Mining Device: {:?}", &to_send);
+                        debug!("Sending to Mining Device: {:?}", &to_send);
                         let res = (&*socket_writer_clone)
                                     .write_all(to_send.as_bytes())
                                     .await;
@@ -175,7 +175,7 @@ impl Downstream {
                 let is_a = match downstream.safe_lock(|d| !d.authorized_names.is_empty()) {
                     Ok(is_a) => is_a,
                     Err(_e) => {
-                        warn!("\nDownstream: Poison Lock - authorized_names\n");
+                        debug!("\nDownstream: Poison Lock - authorized_names\n");
                         break;
                     }
                 };
@@ -199,13 +199,13 @@ impl Downstream {
                             if let Err(_e) = downstream.clone().safe_lock(|s| {
                                 s.first_job_received = true;
                             }) {
-                                warn!("\nDownstream: Poison Lock - first_job_received\n");
+                                debug!("\nDownstream: Poison Lock - first_job_received\n");
                                 break;
                             }
                             first_sent = true;
                         }
                         None => {
-                            warn!("\nDownstream: last_notify never set\n");
+                            debug!("\nDownstream: last_notify never set\n");
                             break;
                         }
                     }
@@ -223,7 +223,7 @@ impl Downstream {
                 } else {
                     // timeout connection if miner does not send the authorize message after sending a subscribe
                     if timeout_timer.elapsed().as_secs() > SUBSCRIBE_TIMEOUT_SECS {
-                        warn!("Downstream: miner.subscribe/miner.authorize TIMOUT");
+                        debug!("Downstream: miner.subscribe/miner.authorize TIMOUT");
                         break;
                     }
                     task::sleep(std::time::Duration::from_secs(1)).await;

--- a/roles/translator/src/downstream_sv1/downstream.rs
+++ b/roles/translator/src/downstream_sv1/downstream.rs
@@ -9,7 +9,7 @@ use async_std::{
 use error_handling::handle_result;
 use futures::FutureExt;
 
-use super::{kill, SUBSCRIBE_TIMOUT_SECS};
+use super::{kill, SUBSCRIBE_TIMEOUT_SECS};
 
 use roles_logic_sv2::{
     bitcoin::util::uint::Uint256,
@@ -87,16 +87,27 @@ impl Downstream {
         }));
         let self_ = downstream.clone();
 
+        // The shutdown channel is used local to the `Downstream::new_downstream()` function.
+        // Each task is set broadcast a shutdown message at the end of their lifecycle with `kill()`, and each task has a receiver to listen
+        // for the shutdown message. When a shutdown message is received the task should `break` its loop. For any errors that should shut
+        // a task down, we should `break` out of the loop, so that the `kill` function can send the shutdown broadcast.
+        // EXTRA: The since all downstream tasks rely on receiving messages with a future (either TCP recv or Receiver<_>)
+        // we use the futures::select! macro to merge the receiving end of a task channels into a single loop within the task
         let (tx_shutdown, rx_shutdown): (Sender<bool>, Receiver<bool>) = async_channel::bounded(3);
 
+        let rx_shutdown_clone = rx_shutdown.clone();
+        let tx_shutdown_clone = tx_shutdown.clone();
         // Task to read from SV1 Mining Device Client socket via `socket_reader`. Depending on the
         // SV1 message received, a message response is sent directly back to the SV1 Downstream
         // role, or the message is sent upwards to the Bridge for translation into a SV2 message
         // and then sent to the SV2 Upstream role.
-        let rx_shutdown_clone = rx_shutdown.clone();
-        let tx_shutdown_clone = tx_shutdown.clone();
         let _socket_reader_task = task::spawn(async move {
             loop {
+                // ***TODO:  see https://github.com/stratum-mining/stratum/issues/399 ***
+                // Because the message readers return None while there is no data in the buffer/queue,
+                // this sleep is used to prevent infinite looping while no messages are being sent
+                // We are currently using 5msintervals since it allows many connections and a decent speed
+                // but we should find a better solution
                 task::sleep(std::time::Duration::from_millis(5)).await;
                 // Read message from SV1 Mining Device Client socket
                 let mut messages = BufReader::new(&*socket_reader).lines();
@@ -110,7 +121,7 @@ impl Downstream {
                             let incoming: json_rpc::Message = match serde_json::from_str(&incoming) {
                                 Ok(msg) => msg,
                                 Err(_e) => {
-                                    tracing::error!("\nBAD MESSAGE\n");
+                                    warn!("\nDownstream: Invalid SV1 client message\n");
                                     break;
                                 }
                             };
@@ -124,7 +135,7 @@ impl Downstream {
                 };
             }
             kill(&tx_shutdown_clone).await;
-            warn!("SHUTTING DOWN READER");
+            warn!("Downstream: Shutting down sv1 downstream reader");
         });
 
         let rx_shutdown_clone = rx_shutdown.clone();
@@ -140,6 +151,7 @@ impl Downstream {
                                 let to_send = match serde_json::to_string(&to_send) {
                                     Ok(string) => format!("{}\n", string),
                                     Err(_e) => {
+                                        warn!("\nDownstream: Bad SV1 server message\n");
                                         break;
                                     }
                                 };
@@ -148,11 +160,13 @@ impl Downstream {
                                     .write_all(to_send.as_bytes())
                                     .await;
                                 if let Err(_e) = res {
+                                    warn!("\nDownstream: Sv1 downstream connection failed\n");
                                     break
                                 }
                             }
                             Err(_e) => {
                                 // should this kill the downstream or just send a status update to the main thread?
+                                warn!("\nDownstream: Receiver outgoing message channel failed\n");
                                 break;
                             }
                         }
@@ -163,7 +177,7 @@ impl Downstream {
                 };
             }
             kill(&tx_shutdown_clone).await;
-            warn!("SHUTTING DOWN WRITER");
+            warn!("Downstream: Shutting down sv1 downstream writer");
         });
 
         let _notify_task = task::spawn(async move {
@@ -172,7 +186,10 @@ impl Downstream {
             loop {
                 let is_a = match downstream.safe_lock(|d| !d.authorized_names.is_empty()) {
                     Ok(is_a) => is_a,
-                    Err(_e) => break,
+                    Err(_e) => {
+                        warn!("\nDownstream: Poison Lock - authorized_names\n");
+                        break;
+                    }
                 };
                 if is_a && !first_sent && last_notify.is_some() {
                     let message =
@@ -185,6 +202,7 @@ impl Downstream {
                             {
                                 Ok(msg) => msg,
                                 Err(_e) => {
+                                    warn!("\nDownstream: Invalid sv1 notify message\n");
                                     break;
                                 }
                             };
@@ -193,11 +211,15 @@ impl Downstream {
                             if let Err(_e) = downstream.clone().safe_lock(|s| {
                                 s.first_job_received = true;
                             }) {
+                                warn!("\nDownstream: Poison Lock - first_job_received\n");
                                 break;
                             }
                             first_sent = true;
                         }
-                        None => break,
+                        None => {
+                            warn!("\nDownstream: last_notify never set\n");
+                            break;
+                        }
                     }
                 } else if is_a {
                     select! {
@@ -208,7 +230,7 @@ impl Downstream {
                                     {
                                         Ok(msg) => msg,
                                         Err(_e) => {
-                                            // should this kill the downstream connection or log a status to the main thread and continue
+                                            warn!("\nDownstream: Invalid sv1 notify message\n");
                                             break;
                                         }
                                     };
@@ -217,6 +239,7 @@ impl Downstream {
                                         .await;
                                 }
                                 Err(_e) => {
+                                    warn!("\nDownstream: Notify message channel failed\n");
                                     break;
                                 }
                             }
@@ -227,15 +250,15 @@ impl Downstream {
                     };
                 } else {
                     // timeout connection if miner does not send the authorize message after sending a subscribe
-                    if timeout_timer.elapsed().as_secs() > SUBSCRIBE_TIMOUT_SECS {
-                        warn!("miner.subscribe/miner.authorize TIMOUT");
+                    if timeout_timer.elapsed().as_secs() > SUBSCRIBE_TIMEOUT_SECS {
+                        warn!("Downstream: miner.subscribe/miner.authorize TIMOUT");
                         break;
                     }
                     task::sleep(std::time::Duration::from_secs(1)).await;
                 }
             }
             kill(&tx_shutdown).await;
-            warn!("SHUTTING DOWN NOTIFIER");
+            warn!("Downstream: Shutting down sv1 downstream job notifier");
         });
     }
 

--- a/roles/translator/src/downstream_sv1/downstream.rs
+++ b/roles/translator/src/downstream_sv1/downstream.rs
@@ -9,7 +9,7 @@ use async_std::{
 use error_handling::handle_result;
 use futures::FutureExt;
 
-use super::{kill, TaskIndex};
+use super::{kill, TaskIndex, SUBSCRIBE_TIMOUT_SECS};
 
 use roles_logic_sv2::{
     bitcoin::util::uint::Uint256,
@@ -88,7 +88,6 @@ impl Downstream {
         let self_ = downstream.clone();
 
         let (tx_shutdown, rx_shutdown): (Sender<bool>, Receiver<bool>) = async_channel::bounded(3);
-        let task_state = Arc::new(Mutex::new([true, true, true]));
 
         // Task to read from SV1 Mining Device Client socket via `socket_reader`. Depending on the
         // SV1 message received, a message response is sent directly back to the SV1 Downstream
@@ -96,8 +95,7 @@ impl Downstream {
         // and then sent to the SV2 Upstream role.
         let rx_shutdown_clone = rx_shutdown.clone();
         let tx_shutdown_clone = tx_shutdown.clone();
-        let task_state_clone = task_state.clone();
-        let socket_reader_task = task::spawn(async move {
+        let _socket_reader_task = task::spawn(async move {
             loop {
                 task::sleep(std::time::Duration::from_millis(5)).await;
                 // Read message from SV1 Mining Device Client socket
@@ -113,7 +111,6 @@ impl Downstream {
                                 Ok(msg) => msg,
                                 Err(_e) => {
                                     tracing::error!("\nBAD MESSAGE\n");
-                                    kill(&tx_shutdown_clone).await;
                                     break;
                                 }
                             };
@@ -128,15 +125,15 @@ impl Downstream {
 
                     
                 }
+                kill(&tx_shutdown_clone).await;
                 warn!("SHUTTING DOWN READER");
         });
 
         let rx_shutdown_clone = rx_shutdown.clone();
         let tx_shutdown_clone = tx_shutdown.clone();
-        let task_state_clone = task_state.clone();
         // Task to receive SV1 message responses to SV1 messages that do NOT need translation.
         // These response messages are sent directly to the SV1 Downstream role.
-        let socket_writer_task = task::spawn(async move {
+        let _socket_writer_task = task::spawn(async move {
             loop {
                 select! {
                     res = receiver_outgoing.recv().fuse() => {
@@ -145,7 +142,6 @@ impl Downstream {
                                 let to_send = match serde_json::to_string(&to_send) {
                                     Ok(string) => format!("{}\n", string),
                                     Err(_e) => {
-                                        kill(&tx_shutdown_clone).await;
                                         break;
                                     }
                                 };
@@ -154,13 +150,11 @@ impl Downstream {
                                     .write_all(to_send.as_bytes())
                                     .await;
                                 if let Err(_e) = res {
-                                    kill(&tx_shutdown_clone).await;
                                     break
                                 }
                             }
                             Err(_e) => {
                                 // should this kill the downstream or just send a status update to the main thread?
-                                kill(&tx_shutdown_clone).await;
                                 break;
                             }
                         }
@@ -171,14 +165,14 @@ impl Downstream {
                 }; 
                 
             }
+            kill(&tx_shutdown_clone).await;
             warn!("SHUTTING DOWN WRITER");
         });
 
         let downstream_clone = downstream.clone();
         let rx_shutdown_clone = rx_shutdown.clone();
-        let tx_shutdown_clone = tx_shutdown.clone();
-        let task_state_clone = task_state.clone();
-        let notify_task = task::spawn(async move {
+        let _notify_task = task::spawn(async move {
+            let timeout_timer = std::time::Instant::now();
             let mut first_sent = false;
             loop {
                 let is_a = if let Ok(is_a) =
@@ -186,7 +180,6 @@ impl Downstream {
                 {
                     is_a
                 } else {
-                    // kill(&tx_shutdown).await;
                     break;
                 };
 
@@ -201,8 +194,6 @@ impl Downstream {
                             {
                                 Ok(msg) => msg,
                                 Err(_e) => {
-                                    // should this kill the downstream connection or log a status to the main thread and continue
-                                    kill(&tx_shutdown).await;
                                     break;
                                 }
                             };
@@ -212,7 +203,6 @@ impl Downstream {
                             if let Err(_e) = downstream_clone.clone().safe_lock(|s| {
                                 s.first_job_received = true;
                             }) {
-                                // kill(&tx_shutdown).await;
                                 break;
                             }
                             first_sent = true;
@@ -220,7 +210,7 @@ impl Downstream {
                         None => break,
                     }
                 } else if is_a {
-                    kill(&tx_shutdown_clone).await;
+                    break
                     select! {
                         res = rx_sv1_notify.recv().fuse() => {
                             match res {
@@ -230,7 +220,6 @@ impl Downstream {
                                         Ok(msg) => msg,
                                         Err(_e) => {
                                             // should this kill the downstream connection or log a status to the main thread and continue
-                                            kill(&tx_shutdown).await;
                                             break;
                                         }
                                     };
@@ -240,7 +229,6 @@ impl Downstream {
                                     first_sent = true;
                                 }
                                 Err(_e) => {
-                                    kill(&tx_shutdown).await;
                                     break;
                                 }
                             }
@@ -250,31 +238,17 @@ impl Downstream {
                             }
                     };
                 } else {
+                    // timeout connection if miner does not send the authorize message after sending a subscribe
+                    if timeout_timer.elapsed().as_secs() > SUBSCRIBE_TIMOUT_SECS {
+                        warn!("miner.subscribe/miner.authorize TIMOUT");
+                        break;
+                    }
                     task::sleep(std::time::Duration::from_secs(1)).await;
                 }
             }
+            kill(&tx_shutdown).await;
             warn!("SHUTTING DOWN NOTIFIER");
         });
-
-        // task to monitor the state of the Downstream tasks so that they can all
-        // be shut down if one of them drops, and the miner connection can be dropped
-        // task::spawn(async move {
-        //     // let task_arr = [socket_reader_task, socket_writer_task, notify_task];
-        //     loop {
-        //         let all_tasks_running = task_state.safe_lock(|t| *t).unwrap_or({
-        //             // send poison lock info to main thread
-        //             [false, false, false]
-        //         });
-        //         // println!("\n ALL TASKS RUNNING: {:?}", all_tasks_running);
-        //         if all_tasks_running.contains(&false) {
-        //             // _socket_writer_notify.shutdown(std::net::Shutdown::Both);
-        //             tx_shutdown.send(true).await.unwrap();
-        //             break;
-        //         }
-        //         task::sleep(std::time::Duration::from_millis(100)).await;
-        //     }
-        //     warn!("\n DOWNSTREAM SHUTDOWN");
-        // });
 
     }
 

--- a/roles/translator/src/downstream_sv1/downstream.rs
+++ b/roles/translator/src/downstream_sv1/downstream.rs
@@ -71,7 +71,6 @@ impl Downstream {
         let (tx_outgoing, receiver_outgoing) = bounded(10);
 
         let socket_writer_clone = socket_writer.clone();
-        // let _socket_writer_set_difficulty_clone = socket_writer.clone();
         // Used to send SV1 `mining.notify` messages to the Downstreams
         let _socket_writer_notify = socket_writer;
 

--- a/roles/translator/src/downstream_sv1/mod.rs
+++ b/roles/translator/src/downstream_sv1/mod.rs
@@ -1,16 +1,8 @@
-use roles_logic_sv2::utils::Mutex;
-use std::sync::Arc;
 use v1::utils::HexU32Be;
 pub mod downstream;
 pub use downstream::Downstream;
 
 const SUBSCRIBE_TIMOUT_SECS: u64 = 10;
-
-pub enum TaskIndex {
-    SocketReader,
-    SocketWriter,
-    Notifier,
-}
 
 pub async fn kill(sender: &async_channel::Sender<bool>) {
     sender.send(true).await.unwrap();

--- a/roles/translator/src/downstream_sv1/mod.rs
+++ b/roles/translator/src/downstream_sv1/mod.rs
@@ -1,7 +1,18 @@
+use roles_logic_sv2::utils::Mutex;
+use std::sync::Arc;
 use v1::utils::HexU32Be;
-
 pub mod downstream;
 pub use downstream::Downstream;
+
+pub enum TaskIndex {
+    SocketReader,
+    SocketWriter,
+    Notifier,
+}
+
+pub async fn kill(sender: &async_channel::Sender<bool>) {
+    sender.send(true).await.unwrap();
+}
 
 pub fn new_subscription_id() -> String {
     "ae6812eb4cd7735a302a8a9dd95cf71f".into()

--- a/roles/translator/src/downstream_sv1/mod.rs
+++ b/roles/translator/src/downstream_sv1/mod.rs
@@ -4,6 +4,8 @@ use v1::utils::HexU32Be;
 pub mod downstream;
 pub use downstream::Downstream;
 
+const SUBSCRIBE_TIMOUT_SECS: u64 = 10;
+
 pub enum TaskIndex {
     SocketReader,
     SocketWriter,

--- a/roles/translator/src/downstream_sv1/mod.rs
+++ b/roles/translator/src/downstream_sv1/mod.rs
@@ -2,9 +2,18 @@ use v1::utils::HexU32Be;
 pub mod downstream;
 pub use downstream::Downstream;
 
-const SUBSCRIBE_TIMOUT_SECS: u64 = 10;
+/// This constant is used as a check to ensure clients
+/// do not send a mining.subscribe and never a mining.authorize
+/// since they will take up a tcp connection but never be allowed to
+/// receive jobs. Without the timeout the TProxy can be exploited by incoming
+/// `mining.subscribe` messages that init connections and take up compute
+const SUBSCRIBE_TIMEOUT_SECS: u64 = 10;
 
+/// This is just a wrapper function to send a message on the Downstream task shutdown channel
+/// it does not matter what message is sent because the receiving ends should shutdown on any message
 pub async fn kill(sender: &async_channel::Sender<bool>) {
+    // safe to unwrap since the only way this can fail is if all receiving channels are dropped
+    // meaning all tasks have already dropped
     sender.send(true).await.unwrap();
 }
 

--- a/roles/translator/src/error.rs
+++ b/roles/translator/src/error.rs
@@ -20,6 +20,7 @@ pub enum ChannelSendError<'a> {
     ),
     SetNewPrevHash(async_channel::SendError<roles_logic_sv2::mining_sv2::SetNewPrevHash<'a>>),
     Notify(async_channel::SendError<Notify<'a>>),
+    V1Message(async_channel::SendError<v1::Message>),
 }
 
 #[derive(Debug)]
@@ -51,6 +52,7 @@ pub enum Error<'a> {
     // PoisonLock(LockError<'a>),
     // Channel Receiver Error
     ChannelErrorReceiver(async_channel::RecvError),
+    TokioChannelErrorRecv(tokio::sync::broadcast::error::RecvError),
     // Channel Sender Errors
     ChannelErrorSender(ChannelSendError<'a>),
     Uint256Conversion(ParseLengthError),
@@ -76,6 +78,7 @@ impl<'a> fmt::Display for Error<'a> {
             UpstreamIncoming(ref e) => write!(f, "Upstream parse incoming error: `{:?}`", e),
             // PoisonLock(ref e) => write!(f, "Poison Lock error: `{:?}`", e),
             ChannelErrorReceiver(ref e) => write!(f, "Channel receive error: `{:?}`", e),
+            TokioChannelErrorRecv(ref e) => write!(f, "Channel receive error: `{:?}`", e),
             ChannelErrorSender(ref e) => write!(f, "Channel send error: `{:?}`", e),
             Uint256Conversion(ref e) => write!(f, "U256 Conversion Error: `{:?}`", e),
             SetDifficultyToMessage(ref e) => {
@@ -147,6 +150,12 @@ impl<'a> From<async_channel::RecvError> for Error<'a> {
     }
 }
 
+impl<'a> From<tokio::sync::broadcast::error::RecvError> for Error<'a> {
+    fn from(e: tokio::sync::broadcast::error::RecvError) -> Self {
+        Error::TokioChannelErrorRecv(e)
+    }
+}
+
 // *** LOCK ERRORS ***
 // impl<'a> From<PoisonError<MutexGuard<'a, proxy::Bridge>>> for Error<'a> {
 //     fn from(e: PoisonError<MutexGuard<'a, proxy::Bridge>>) -> Self {
@@ -186,6 +195,12 @@ impl<'a> From<async_channel::SendError<roles_logic_sv2::mining_sv2::SetNewPrevHa
 impl<'a> From<async_channel::SendError<Notify<'a>>> for Error<'a> {
     fn from(e: async_channel::SendError<Notify<'a>>) -> Self {
         Error::ChannelErrorSender(ChannelSendError::Notify(e))
+    }
+}
+
+impl<'a> From<async_channel::SendError<v1::Message>> for Error<'a> {
+    fn from(e: async_channel::SendError<v1::Message>) -> Self {
+        Error::ChannelErrorSender(ChannelSendError::V1Message(e))
     }
 }
 

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -12,12 +12,14 @@ use roles_logic_sv2::utils::Mutex;
 
 const SELF_EXTRNONCE_LEN: usize = 2;
 
-use async_channel::{bounded, unbounded, Receiver, Sender};
+use async_channel::{bounded, unbounded};
 use std::{
     net::{IpAddr, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
+
+use tokio::sync::broadcast;
 use v1::server_to_client;
 
 use crate::status::State;
@@ -70,10 +72,10 @@ async fn main() {
     let target = Arc::new(Mutex::new(vec![0; 32]));
 
     // Sender/Receiver to send SV1 `mining.notify` message from the `Bridge` to the `Downstream`
-    let (tx_sv1_notify, rx_sv1_notify): (
-        Sender<server_to_client::Notify>,
-        Receiver<server_to_client::Notify>,
-    ) = bounded(10);
+    let (tx_sv1_notify, _rx_sv1_notify): (
+        broadcast::Sender<server_to_client::Notify>,
+        broadcast::Receiver<server_to_client::Notify>,
+    ) = broadcast::channel(10);
 
     // Format `Upstream` connection address
     let upstream_addr = SocketAddr::new(
@@ -137,7 +139,7 @@ async fn main() {
         tx_sv2_submit_shares_ext,
         rx_sv2_set_new_prev_hash,
         rx_sv2_new_ext_mining_job,
-        tx_sv1_notify,
+        tx_sv1_notify.clone(),
         tx_status.clone(),
         extended_extranonce,
         target,
@@ -154,7 +156,7 @@ async fn main() {
     downstream_sv1::Downstream::accept_connections(
         downstream_addr,
         tx_sv1_submit,
-        rx_sv1_notify,
+        tx_sv1_notify,
         tx_status.clone(),
         b,
     );
@@ -166,7 +168,6 @@ async fn main() {
         match task_status.state {
             State::Shutdown(err) => {
                 error!("SHUTDOWN from: {}", err);
-                break;
             }
             State::Healthy(msg) => {
                 info!("HEALTHY message: {}", msg);

--- a/roles/translator/src/proxy/bridge.rs
+++ b/roles/translator/src/proxy/bridge.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use v1::{client_to_server::Submit, server_to_client};
 
-use crate::{error::Error, status::Status, ProxyResult};
+use crate::{error::Error, status, ProxyResult};
 use error_handling::{handle_result, ErrorBranch};
 use roles_logic_sv2::{channel_logic::channel_factory::OnNewShare, Error as RolesLogicError};
 use tracing::{debug, error, info};
@@ -40,7 +40,7 @@ pub struct Bridge {
     tx_sv1_notify: broadcast::Sender<server_to_client::Notify<'static>>,
     /// Allows the bridge the ability to communicate back to the main thread any status updates
     /// that would interest the main thread for error handling
-    tx_status: Sender<Status<'static>>,
+    tx_status: status::Sender,
     /// Unique sequential identifier of the submit within the channel.
     channel_sequence_id: Id,
     /// Stores the most recent SV1 `mining.notify` values to be sent to the `Downstream` upon
@@ -69,7 +69,7 @@ impl Bridge {
         rx_sv2_set_new_prev_hash: Receiver<SetNewPrevHash<'static>>,
         rx_sv2_new_ext_mining_job: Receiver<NewExtendedMiningJob<'static>>,
         tx_sv1_notify: broadcast::Sender<server_to_client::Notify<'static>>,
-        tx_status: Sender<Status<'static>>,
+        tx_status: status::Sender,
         extranonces: ExtendedExtranonce,
         target: Arc<Mutex<Vec<u8>>>,
     ) -> Self {
@@ -381,7 +381,7 @@ mod test {
                 rx_sv2_set_new_prev_hash,
                 rx_sv2_new_ext_mining_job,
                 tx_sv1_notify,
-                tx_status,
+                status::Sender::Bridge(tx_status),
                 extranonces,
                 Arc::new(Mutex::new(upstream_target)),
             )

--- a/roles/translator/src/proxy/bridge.rs
+++ b/roles/translator/src/proxy/bridge.rs
@@ -9,10 +9,11 @@ use roles_logic_sv2::{
     utils::{GroupId, Id, Mutex},
 };
 use std::sync::Arc;
+use tokio::sync::broadcast;
 use v1::{client_to_server::Submit, server_to_client};
 
 use crate::{error::Error, status::Status, ProxyResult};
-use error_handling::handle_result;
+use error_handling::{handle_result, ErrorBranch};
 use roles_logic_sv2::{channel_logic::channel_factory::OnNewShare, Error as RolesLogicError};
 use tracing::{debug, error, info};
 
@@ -36,7 +37,7 @@ pub struct Bridge {
     rx_sv2_new_ext_mining_job: Receiver<NewExtendedMiningJob<'static>>,
     /// Sends SV1 `mining.notify` message (translated from the SV2 `SetNewPrevHash` and
     /// `NewExtendedMiningJob` messages stored in the `NextMiningNotify`) to the `Downstream`.
-    tx_sv1_notify: Sender<server_to_client::Notify<'static>>,
+    tx_sv1_notify: broadcast::Sender<server_to_client::Notify<'static>>,
     /// Allows the bridge the ability to communicate back to the main thread any status updates
     /// that would interest the main thread for error handling
     tx_status: Sender<Status<'static>>,
@@ -67,7 +68,7 @@ impl Bridge {
         tx_sv2_submit_shares_ext: Sender<SubmitSharesExtended<'static>>,
         rx_sv2_set_new_prev_hash: Receiver<SetNewPrevHash<'static>>,
         rx_sv2_new_ext_mining_job: Receiver<NewExtendedMiningJob<'static>>,
-        tx_sv1_notify: Sender<server_to_client::Notify<'static>>,
+        tx_sv1_notify: broadcast::Sender<server_to_client::Notify<'static>>,
         tx_status: Sender<Status<'static>>,
         extranonces: ExtendedExtranonce,
         target: Arc<Mutex<Vec<u8>>>,
@@ -267,7 +268,7 @@ impl Bridge {
                         );
                         // Get the sender to send the mining.notify to the Downstream
                         let tx_sv1_notify = self_.safe_lock(|s| s.tx_sv1_notify.clone()).unwrap();
-                        tx_sv1_notify.send(notify.clone()).await.unwrap();
+                        tx_sv1_notify.send(notify.clone()).unwrap();
                         self_
                             .safe_lock(|s| {
                                 s.last_notify = Some(notify);
@@ -335,7 +336,7 @@ impl Bridge {
                     );
                     // Get the sender to send the mining.notify to the Downstream
                     let tx_sv1_notify = self_.safe_lock(|s| s.tx_sv1_notify.clone()).unwrap();
-                    tx_sv1_notify.send(notify.clone()).await.unwrap();
+                    tx_sv1_notify.send(notify.clone()).unwrap();
                     self_
                         .safe_lock(|s| {
                             s.last_notify = Some(notify);
@@ -366,7 +367,7 @@ mod test {
             let (tx_sv2_submit_shares_ext, _rx_sv2_submit_shares_ext) = bounded(1);
             let (_tx_sv2_set_new_prev_hash, rx_sv2_set_new_prev_hash) = bounded(1);
             let (_tx_sv2_new_ext_mining_job, rx_sv2_new_ext_mining_job) = bounded(1);
-            let (tx_sv1_notify, _rx_sv1_notify) = bounded(1);
+            let (tx_sv1_notify, _rx_sv1_notify) = broadcast::channel(1);
             let (tx_status, _rx_status) = bounded(1);
             let extranonces = ExtendedExtranonce::new(0..6, 6..8, 8..EXTRANONCE_LEN);
             let upstream_target = vec![

--- a/roles/translator/src/status.rs
+++ b/roles/translator/src/status.rs
@@ -11,11 +11,11 @@ pub struct Status<'a> {
     pub state: State<'a>,
 }
 
-// this is called by `error_handling::handle_result!`
-pub async fn handle_error(
+async fn send_status(
     sender: &async_channel::Sender<Status<'static>>,
     e: error::Error<'static>,
-) {
+    outcome: error_handling::ErrorBranch,
+) -> error_handling::ErrorBranch {
     match sender
         .send(Status {
             state: State::Shutdown(e),
@@ -24,11 +24,67 @@ pub async fn handle_error(
     {
         Ok(_) => {
             // implement error specific handling here instead of panicking
-            panic!("Error")
+            outcome
         }
-        Err(_e) => {
-            // implement error specific handling here instead of panicking
-            panic!("Error")
+        Err(_e) => outcome,
+    }
+}
+
+// this is called by `error_handling::handle_result!`
+pub async fn handle_error(
+    sender: &async_channel::Sender<Status<'static>>,
+    e: error::Error<'static>,
+) -> error_handling::ErrorBranch {
+    tracing::error!("Error: {:?}", &e);
+    match e {
+        Error::VecToSlice32(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors on bad CLI argument input.
+        Error::BadCliArgs => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors on bad `serde_json` serialize/deserialize.
+        Error::BadSerdeJson(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors on bad `toml` deserialize.
+        Error::BadTomlDeserialize(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
         }
+        // Errors from `binary_sv2` crate.
+        Error::BinarySv2(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors on bad noise handshake.
+        Error::CodecNoise(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors from `framing_sv2` crate.
+        Error::FramingSv2(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors on bad `TcpStream` connection.
+        Error::Io(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors on bad `String` to `int` conversion.
+        Error::ParseInt(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        // Errors from `roles_logic_sv2` crate.
+        Error::RolesSv2Logic(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        Error::UpstreamIncoming(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
+        // SV1 protocol library error
+        Error::V1Protocol(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
+        Error::SubprotocolMining(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
+        // Locking Errors
+        // PoisonLock(LockError<'a>),
+        // Channel Receiver Error
+        Error::ChannelErrorReceiver(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
+        Error::TokioChannelErrorRecv(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
+        // Channel Sender Errors
+        Error::ChannelErrorSender(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
+        Error::Uint256Conversion(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
+        Error::SetDifficultyToMessage(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
+        Error::Infallible(_) => send_status(sender, e, error_handling::ErrorBranch::Break).await,
     }
 }

--- a/roles/translator/src/upstream_sv2/upstream.rs
+++ b/roles/translator/src/upstream_sv2/upstream.rs
@@ -9,7 +9,7 @@ use async_channel::{Receiver, Sender};
 use async_std::{net::TcpStream, task};
 use binary_sv2::u256_from_int;
 use codec_sv2::{Frame, HandshakeRole, Initiator};
-use error_handling::handle_result;
+use error_handling::{handle_result, ErrorBranch};
 use network_helpers::Connection;
 use roles_logic_sv2::{
     bitcoin::BlockHash,

--- a/roles/translator/src/upstream_sv2/upstream.rs
+++ b/roles/translator/src/upstream_sv2/upstream.rs
@@ -1,7 +1,7 @@
 use crate::{
     downstream_sv1::Downstream,
     error::Error::{CodecNoise, UpstreamIncoming},
-    status::{State, Status},
+    status,
     upstream_sv2::{EitherFrame, Message, StdFrame, UpstreamConnection},
     ProxyResult,
 };
@@ -69,7 +69,7 @@ pub struct Upstream {
     tx_sv2_extranonce: Sender<ExtendedExtranonce>,
     /// This allows the upstream threads to be able to communicate back to the main thread its
     /// current status.
-    tx_status: Sender<Status<'static>>,
+    tx_status: status::Sender,
     /// The first `target` is received by the Upstream role in the SV2
     /// `OpenExtendedMiningChannelSuccess` message, then updated periodically via SV2 `SetTarget`
     /// messages. Passed to the `Downstream` on connection creation and sent to the Downstream role
@@ -95,7 +95,7 @@ impl Upstream {
         tx_sv2_new_ext_mining_job: Sender<NewExtendedMiningJob<'static>>,
         min_extranonce_size: u16,
         tx_sv2_extranonce: Sender<ExtendedExtranonce>,
-        tx_status: Sender<Status<'static>>,
+        tx_status: status::Sender,
         target: Arc<Mutex<Vec<u8>>>,
     ) -> ProxyResult<'static, Arc<Mutex<Self>>> {
         // Connect to the SV2 Upstream role retry connection every 5 seconds.
@@ -161,7 +161,7 @@ impl Upstream {
         let sv2_frame: StdFrame = Message::Common(setup_connection.into()).try_into()?;
         // Send the `SetupConnection` frame to the SV2 Upstream role
         // Only one Upstream role is supported, panics if multiple connections are encountered
-        connection.send(sv2_frame).await.unwrap();
+        connection.send(sv2_frame).await?;
 
         debug!("Sent SetupConnection to Upstream, waiting for response");
         // Wait for the SV2 Upstream to respond with either a `SetupConnectionSuccess` or a
@@ -324,8 +324,8 @@ impl Upstream {
                     // returns Ok(SendTo::None(None)) or Ok(SendTo::None(Some(m))), or returns Err
                     Ok(_) => panic!(),
                     Err(e) => {
-                        let status = Status {
-                            state: State::Shutdown(UpstreamIncoming(e)),
+                        let status = status::Status {
+                            state: status::State::UpstreamShutdown(UpstreamIncoming(e)),
                         };
                         error!(
                             "TERMINATING: Error handling pool role message: {:?}",

--- a/utils/error-handling/src/lib.rs
+++ b/utils/error-handling/src/lib.rs
@@ -25,9 +25,19 @@ macro_rules! handle_result {
             Ok(val) => val,
             Err(e) => {
                 // handle error
-                crate::status::handle_error(&$sender, e.into()).await;
-                continue;
+                let res = crate::status::handle_error(&$sender, e.into()).await;
+                match res {
+                    ErrorBranch::Break => break,
+                    ErrorBranch::Continue => continue,
+                    ErrorBranch::Return => return,
+                }
             }
         }
     };
+}
+
+pub enum ErrorBranch {
+    Break,
+    Continue,
+    Return,
 }


### PR DESCRIPTION

closes https://github.com/stratum-mining/stratum/issues/412 ,
but we should still make the conversion completely to tokio and remove dependencies on `futures` and `async_std` and `async_channel`. `async_channel` and `async_std` are required for the `network_helpers` as well, so we would need to make changes there as well

!This should be merged after https://github.com/stratum-mining/stratum/pull/395. After I will rebase and fix conflicts!

NOTE: The shutdown timeout was added since clients that send `mining.subscribe` and never send `mining.authorize` after would result in the TCP connection to never be shutdown since `is_authorized` is a condition on the two notify task conditional branches that sends data to the client. Once is authorized is set, every incoming `Notify` message will attempt to send on the client connection and shutdown if it is closed. Q: Should we move `SHUTDOWN_TIMEOUT_SECS` to the `proxy-config.toml`?


My py script for testing:

```
import json
import socket
import sys
import time


TPROXY_URL = "http://0.0.0.0:34255"

miner_subscribe = {"id": 1, "method": "mining.subscribe", "params": ["cpuminer/2.5.1"]}
miner_authorize = {"id": 2, "method": "mining.authorize", "params": ["", ""]}

NUM_MINERS = 1000
HOST, PORT = "0.0.0.0", 34255

miners: list[socket.socket] = []
for idx, miner in enumerate(range(NUM_MINERS)):
    # Create a socket (SOCK_STREAM means a TCP socket)
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
        
        # Connect to server and send data
        sock.connect((HOST, PORT))
        

        # send miner.subscribe message
        sock.sendall(bytes(json.dumps(miner_subscribe) + "\n", "utf-8"))
        subscribe_recv = str(sock.recv(1024), "utf-8")

        # send miner.subscribe message
        # sock.sendall(bytes(json.dumps(miner_authorize) + "\n", "utf-8"))
        # authorize_recv = str(sock.recv(1024), "utf-8")
        print(f'MINER: {idx}')
        # miners.append(sock)
        # time.sleep(2)
```