### PR TITLE
used shrink for prop tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Expectations for Implementing Prop Tests with Shrink in Arbitrary in Rust
+
+Prop tests in Rust are used to verify the behavior of a program by generating random inputs and checking the output. The implementation of shrink in arbitrary is a key part of these tests. The following expectations should be met to ensure effective and consistent prop tests:
+
+## Fast and High Coverage
+
+- Run quickly and generate a large number of test cases for coverage
+
+## Repeatable and Deterministic
+
+- Be repeatable and deterministic
+
+## Comprehensive
+
+- Cover a wide range of inputs and edge cases
+
+## Use Shrink in Arbitrary
+
+- Use shrink in arbitrary to find the smallest input that produces an incorrect result
+
+## Readable and Maintainable
+
+- Be readable and maintainable with clear documentation
+
+## Follow Established Shrink Pattern
+
+- Follow the established shrink pattern in arbitrary that has been implemented
+
+In summary, prop tests with shrink in arbitrary should meet these criteria to ensure their effectiveness and consistency in verifying the behavior of the program.

--- a/protocols/v1/src/methods/client_to_server.rs
+++ b/protocols/v1/src/methods/client_to_server.rs
@@ -79,6 +79,21 @@ impl Arbitrary for Authorize {
             id: String::arbitrary(g),
         }
     }
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let value = self.clone().0;
+        match value.template_id {
+            0 => empty_shrinker(),
+            _ => {
+                let mut shrinked_ids: Vec<NewTemplate> = vec![];
+                for id in 0..value.template_id {
+                    let mut shrinked_value = value.clone();
+                    shrinked_value.template_id = id;
+                    shrinked_ids.push(shrinked_value);
+                }
+                Box::new(shrinked_ids.into_iter().map(|x| RandomNewTemplate(x)))
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -239,6 +254,22 @@ impl Arbitrary for Submit<'static> {
             nonce: HexU32Be(u32::arbitrary(g)),
             version_bits: bits,
             id: String::arbitrary(g),
+        }
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let value = self.clone().0;
+        match value.template_id {
+            0 => empty_shrinker(),
+            _ => {
+                let mut shrinked_ids: Vec<NewTemplate> = vec![];
+                for id in 0..value.template_id {
+                    let mut shrinked_value = value.clone();
+                    shrinked_value.template_id = id;
+                    shrinked_ids.push(shrinked_value);
+                }
+                Box::new(shrinked_ids.into_iter().map(|x| RandomNewTemplate(x)))
+            }
         }
     }
 }

--- a/protocols/v1/src/tempCodeRunnerFile.rs
+++ b/protocols/v1/src/tempCodeRunnerFile.rs
@@ -1,0 +1,1 @@
+Arbitrary


### PR DESCRIPTION
1.  Implemented `shrink` while implementing `Arbitrary`.
2. Added `CONTRIBUTING.md` file so that people continue to use this pattern.