### PR TITLE
Hot fix for mg action

### DIFF
--- a/message-generator-tests.sh
+++ b/message-generator-tests.sh
@@ -5,5 +5,5 @@ cd $message_generator_dir
 
 for entry in `ls $search_dir`; do
     echo $entry
-    cargo run -- ../$search_dir$entry
+    cargo run -- ../$search_dir$entry || { echo 'mg test failed' ; exit 1; }
 done

--- a/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
@@ -10,3 +10,4 @@ listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
+coinbase_reward_sat = 5_000_000_000

--- a/test/config/proxy-config-test-multiple-upstreams-extended.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended.toml
@@ -11,3 +11,4 @@ listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
+coinbase_reward_sat = 5_000_000_000

--- a/test/config/proxy-config-test-multiple-upstreams-extended.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended.toml
@@ -1,4 +1,3 @@
-
 upstreams = [
     { channel_kind = "Extended",  address = "127.0.0.1", port = 34254, pub_key = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"},
     { channel_kind = "Extended",  address = "127.0.0.1", port = 44254, pub_key = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"},

--- a/test/config/proxy-config-test-multiple-upstreams.toml
+++ b/test/config/proxy-config-test-multiple-upstreams.toml
@@ -11,3 +11,4 @@ listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
+coinbase_reward_sat = 5_000_000_000

--- a/test/config/proxy-config-test-multiple-upstreams.toml
+++ b/test/config/proxy-config-test-multiple-upstreams.toml
@@ -1,4 +1,3 @@
-
 upstreams = [
     { channel_kind = "Group",  address = "127.0.0.1", port = 34254, pub_key = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"},
     { channel_kind = "Group",  address = "127.0.0.1", port = 44254, pub_key = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"},

--- a/utils/message-generator/test.json
+++ b/utils/message-generator/test.json
@@ -109,7 +109,7 @@
                         "pool",
                         "--",
                         "-c",
-                        "./roles/v2/pool/pool-config.toml"
+                        "./test/config/pool-config-sri-tp.toml"
             ],
             "conditions": {
                 "WithConditions": {


### PR DESCRIPTION
Adds a quick patch to force the MG Github Action to fail if any one of the tests panics.

Also fixes a few configs to match new requirements.