### PR TITLE
Add coverage from message generator to coverage action

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,5 @@
-# Performs test coverage of project's libraries using cargo-tarpaulin and generates results using
-# codecov.io.
+# Performs test coverage of project's libraries using cargo-tarpaulin and the message-generator, 
+# and generates results using codecov.io.
 # The follow flags are used when executing cargo-tarpaulin:
 # -- features: Includes the code with the listed features. The following features result in a
 #    tarpaulin error and are NOT included: derive, alloc, arbitrary-derive, attributes, and
@@ -9,8 +9,9 @@
 # --exclude-files examples/*: Excludes all projects in examples directory (specifically added to
 #   ignore examples that that contain a lib.rs file like interop-cpp)
 # --timeout 120: If unresponsive for 120 seconds, action will fail
-# --fail-under 40: If code coverage is less than 40%, action will fail
+# --fail-under 30: If code coverage is less than 30%, action will fail
 # --out Xml: Required for codecov.io to generate coverage result
+# All message-generator test flags are in test/message-generator/cov/cov_test.json
 
 name: Test Coverage
 
@@ -21,8 +22,9 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
-    name: Test Coverage
+  tarpaulin-test:
+
+    name: Tarpaulin Test
     runs-on: ubuntu-latest
     container:
       image: xd009642/tarpaulin:develop-nightly
@@ -35,7 +37,62 @@ jobs:
         run: |
           cargo +nightly tarpaulin --verbose --features prop_test noise_sv2 fuzz with_buffer_pool async_std debug tokio with_tokio derive_codec_sv2 binary_codec_sv2 default core --lib --exclude-files examples/*,utils/message-generator/* --timeout 120 --fail-under 30 --out Xml
 
+      - name: Archive Tarpaulin code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: tarpaulin-coverage-report
+          path: cobertura.xml
+
+  message-generator-test:
+    needs: tarpaulin-test
+
+    name: MG Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.60.0
+          override: true
+          components: llvm-tools-preview
+
+      - name: Log data from rustc
+        run: rustc -Vv
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run mg codecov tests
+        run: sh ./mg-codecov-tests.sh
+
+      - name: Open file
+        run: head -n 20 target/cobertura.xml | cat
+
+      - name: Archive MG code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: mg-coverage-report
+          path: target/cobertura.xml
+
+  codecov:
+    needs: message-generator-test
+
+    name: Codecov Upload
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v3
+
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2
         with:
+          files: ./tarpaulin-coverage-report/cobertura.xml,./mg-coverage-report/cobertura.xml
           fail_ci_if_error: true

--- a/mg-codecov-tests.sh
+++ b/mg-codecov-tests.sh
@@ -1,0 +1,5 @@
+message_generator_dir="./utils/message-generator/"
+
+cd $message_generator_dir
+
+cargo run -- ../../../test/message-generator/cov/cov_test.json

--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 serde_sv2 = {version = "0.1.0", path = "../serde-sv2", optional = true}
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true }
 binary_codec_sv2 = {version = "0.1.*", path = "../no-serde-sv2/codec", optional = true}
-derive_codec_sv2 = {version = "0.1.1", path = "../no-serde-sv2/derive_codec", optional = true}
+derive_codec_sv2 = {version = "0.1.2", path = "../no-serde-sv2/derive_codec", optional = true}
 tracing = {version = "0.1"}
 
 [features]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.57.0"
+channel = "1.60.0"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
@@ -10,3 +10,4 @@ listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
+coinbase_reward_sat = 5_000_000_000

--- a/test/config/proxy-config-test-multiple-upstreams-extended.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended.toml
@@ -11,3 +11,4 @@ listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
+coinbase_reward_sat = 5_000_000_000

--- a/test/config/proxy-config-test-multiple-upstreams.toml
+++ b/test/config/proxy-config-test-multiple-upstreams.toml
@@ -11,3 +11,4 @@ listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
+coinbase_reward_sat = 5_000_000_000

--- a/test/message-generator/cov/cov_test.json
+++ b/test/message-generator/cov/cov_test.json
@@ -1,0 +1,197 @@
+{
+    "doc": [
+        "What this test does:",
+        "1) launch SRI pool with llvm-cov arguments(no report - see cargo-llvm-cov for options)",
+        "2) send SetupConnection to the pool",
+        "3) check that SetupConnectionSuccess is received",
+        "4) send OpenStandardMiningChannel with request id 89",
+        "5) check that NewExtendedJob is received",
+        "6) check that NewPrevHash is received",
+        "7) check that OpenStandardMiningChannelSuccess with request 89 is received",
+        "8) kill pool role to allow report to be generated",
+        "9) generate report with what to ignore and where to output the report(see cargo-llvm-cov for options)"
+    ],
+    "common_messages": [
+        {
+            "message": {
+                "type": "SetupConnection",
+                "protocol": 0,
+                "min_version": 2,
+                "max_version": 2,
+                "flags": 0,
+                "endpoint_host": "",
+                "endpoint_port": 0,
+                "vendor": "",
+                "hardware_version": "",
+                "firmware": "",
+                "device_id": ""
+            },
+            "id": "setup_connection"
+        },
+        {
+            "message": {
+                "type": "SetupConnectionSuccess",
+                "flags": 0,
+                "used_version": 2
+            },
+            "id": "setup_connection_success"
+        }
+    ],
+    "mining_messages": [
+        {
+            "message": {
+                "type": "OpenStandardMiningChannel",
+                "request_id": 89,
+                "user_identity": "",
+                "nominal_hash_rate": 10,
+                "max_target": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+            },
+            "id": "open_standard_mining_channel"
+        },
+        {
+            "message": {
+                "type": "SubmitSharesStandard",
+                "channel_id": 1,
+                "sequence_number": 0,
+                "job_id": 0,
+                "nonce": 174,
+                "ntime": 1671116742,
+                "version": 536870912
+            },
+            "id": "submit_shares"
+        }
+    ],
+    "frame_builders": [
+        {
+            "type": "automatic",
+            "message_id": "setup_connection_success"
+        },
+        {
+            "type": "automatic",
+            "message_id": "setup_connection"
+        },
+        {
+            "type": "automatic",
+            "message_id": "open_standard_mining_channel"
+        },
+        {
+            "type": "automatic",
+            "message_id": "submit_shares"
+        }
+    ],
+    "actions": [
+        {
+            "message_ids": ["setup_connection"],
+            "role": "client",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x01"
+                }
+            ],
+            "actiondoc": ""
+        },
+        {
+            "message_ids": ["open_standard_mining_channel"],
+            "role": "client",
+            "results": [
+                {
+                    "type": "match_message_field",
+                    "value": [
+                        "MiningProtocol",
+                        "OpenStandardMiningChannelSuccess",
+                        "request_id",
+                        {"U32": 89}
+                    ]
+                },
+                {
+                    "type": "match_message_type",
+                    "value": "0x20"
+                },
+                {
+                    "type": "match_message_type",
+                    "value": "0x1f"
+                }
+            ],
+            "actiondoc": ""
+        },
+        {
+            "message_ids": ["submit_shares"],
+            "role": "client",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x1c"
+                }
+             ],
+            "actiondoc": "This action sends the message SubmitSharesStandard to the pool and checks that the pool replies with SubmitSharesStandard.Success"
+        }
+    ],
+    "setup_commands": [
+        {
+            "command": "cargo",
+            "args": [   "llvm-cov",
+                        "--no-report",
+                        "run",
+                        "-p",
+                        "pool",
+                        "--",
+                        "-c",
+                        "./test/config/pool-config-sri-tp.toml"
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "Listening for encrypted connection on: 0.0.0.0:34254",
+                            "output_location": "StdOut",
+                            "condition": true
+                        }
+                    ],
+                    "timer_secs": 240,
+                    "warn_no_panic": false
+                }
+            }
+        }
+    ],
+    "execution_commands": [
+    ],
+    "cleanup_commands": [
+        {
+            "command": "pkill",
+            "args":  ["pool", "-SIGINT"],
+            "conditions": "None"
+        },
+        {
+            "command": "cargo",
+            "args": [
+                    "llvm-cov",
+                    "--ignore-filename-regex",
+                    "utils/|experimental/|protocols/",
+                    "--cobertura",
+                    "--output-path",
+                    "target/cobertura.xml",
+                    "report"
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "Finished report saved to ",
+                            "output_location": "StdErr",
+                            "condition": true
+                        }
+                    ],
+                    "timer_secs": 60,
+                    "warn_no_panic": false
+                }
+            }
+        }
+    ],
+    "role": "client",
+    "downstream": {
+        "ip": "0.0.0.0",
+        "port": 34254,
+        "pub_key": "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
+    }
+}

--- a/utils/message-generator/README.md
+++ b/utils/message-generator/README.md
@@ -291,3 +291,51 @@ anything is written in StdErr
 2. `port`: a string with the port address
 3. `pub_key`: optional if present accept noise connection if no plain connection
 3. `secret_key`: optional if present accept noise connection if no plain connection
+
+## Using Message Generator to produce test coverage with llvm-cov
+
+Information on installation and use of llvm-cov found here: https://crates.io/crates/cargo-llvm-cov/0.1.13
+More information on underlying dependancies here: https://doc.rust-lang.org/rustc/instrument-coverage.html
+
+### Including code coverage in command
+
+Example of llvm-cov code coverage run with pool setup_command
+llvm-cov requires a minimum of rustc 1.60.0 and LLVM 13.0.0
+
+```json
+        {
+            "command": "cargo",
+            "args": [
+                        "llvm-cov",
+                        "--no-report",
+                        "run",
+                        "-p",
+                        "pool",
+                        "--",
+                        "-c",
+                        "./roles/v2/pool/pool-config.toml"
+            ],
+            "conditions": {...} 
+        },
+```
+
+`"--no-report"` caches the results in the background until the end of the test.  It also allows you collect coverage data from other processes in parallel by adding `"llv-cov --no-report"`, and all report data is reflected in the final report. 
+
+To generate the report, execute the `llvm-cov report` command in the cleanup_commands.  This example adds an output file path(from project root), the output file name and type, and paths to ignore in the report.
+
+```json
+    "cleanup_commands": [
+        {
+            "command": "cargo",
+            "args": [
+                        "llvm-cov",
+                        "--ignore-filename-regex",
+                        "utils/|experimental/|protocols/",
+                        "--output-path",
+                        "target/tmp/pool_translator_cov.txt",
+                        "report"
+            ],
+            "conditions": "None"
+        }
+    ]
+```


### PR DESCRIPTION
This change:

1.) Adds a new Message Generator test to test/message-generator/cov for generating a coverage report
2.) Runs this test in .github/workflows/coverage.yaml to generate report, and upload it to codecov with the existing tarpaulin report
3.) Includes information on the cargo-llvm-cov package in the Message Generator README