### PR TITLE
Fix: Share Hash Calcs and Other Bugs

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -779,9 +779,6 @@ impl ChannelFactory {
         println!("COINBASE SUFFIX: {:?}\n", &coinbase_tx_suffix);
         println!("EXTRANONCE: {:?}\n", &extranonce);
 
-        
-        
-
         if hash <= bitcoin_target {
             let coinbase = [coinbase_tx_prefix, &extranonce[..], coinbase_tx_suffix]
                 .concat()

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -698,27 +698,28 @@ impl ChannelFactory {
                 upstream_target, ..
             } => upstream_target.clone(),
         };
-        let last_job_id = self
+        let _last_job_id = self
             .last_valid_job
             .as_ref()
             .ok_or(Error::ShareDoNotMatchAnyJob)?
             .0
             .job_id;
-        if m.get_job_id() < last_job_id {
-            let error = SubmitSharesError {
-                channel_id: m.get_channel_id(),
-                sequence_number: m.get_sequence_number(),
-                // Infallible unwrap we already know the len of the error code (is a
-                // static string)
-                error_code: SubmitSharesError::stale_share_error_code()
-                    .to_string()
-                    .try_into()
-                    .unwrap(),
-            };
-            return Ok(OnNewShare::SendErrorDownstream(error));
-        } else if m.get_job_id() > last_job_id {
-            return Err(Error::JobNotUpdated(m.get_job_id(), last_job_id));
-        }
+        // *** TODO: uncomment below after mining proxy job management is fixed
+        // if m.get_job_id() < last_job_id {
+        //     let error = SubmitSharesError {
+        //         channel_id: m.get_channel_id(),
+        //         sequence_number: m.get_sequence_number(),
+        //         // Infallible unwrap we already know the len of the error code (is a
+        //         // static string)
+        //         error_code: SubmitSharesError::stale_share_error_code()
+        //             .to_string()
+        //             .try_into()
+        //             .unwrap(),
+        //     };
+        //     return Ok(OnNewShare::SendErrorDownstream(error));
+        // } else if m.get_job_id() > last_job_id {
+        //     return Err(Error::JobNotUpdated(m.get_job_id(), last_job_id));
+        // }
         let (downstream_target, extranonce) = self
             .get_channel_specific_mining_info(&m)
             .ok_or(Error::ShareDoNotMatchAnyChannel)?;

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -246,7 +246,7 @@ impl ChannelFactory {
                 .safe_lock(|ids| ids.new_channel_id(extended_channels_group))
                 .unwrap();
             self.channel_to_group_id.insert(channel_id, 0);
-            let target = crate::utils::hash_rate_to_target_le(hash_rate, self.share_per_min);
+            let target = crate::utils::hash_rate_to_target(hash_rate, self.share_per_min);
             let extranonce = self
                 .extranonces
                 .next_extended(max_extranonce_size as usize)?;
@@ -291,7 +291,7 @@ impl ChannelFactory {
         let hom_group_id = 0;
         let mut result = vec![];
         let channel_id = id;
-        let target = crate::utils::hash_rate_to_target_le(downstream_hash_rate, self.share_per_min);
+        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
         let extranonce = self
             .extranonces
             .next_standard()
@@ -334,7 +334,7 @@ impl ChannelFactory {
             .safe_lock(|ids| ids.new_channel_id(group_id))
             .unwrap();
         let complete_id = GroupId::into_complete_id(group_id, channel_id);
-        let target = crate::utils::hash_rate_to_target_le(downstream_hash_rate, self.share_per_min);
+        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
         let extranonce = self
             .extranonces
             .next_standard()
@@ -1416,7 +1416,7 @@ impl ExtendedChannelKind {
 mod test {
     use super::*;
     use binary_sv2::{Seq0255, B064K, U256};
-    use bitcoin::{hash_types::WPubkeyHash, PublicKey};
+    use bitcoin::{hash_types::WPubkeyHash, PublicKey, TxOut};
     use mining_sv2::OpenStandardMiningChannel;
 
     const BLOCK_REWARD: u64 = 2_000_000_000;
@@ -1502,10 +1502,6 @@ mod test {
             .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
             .collect()
     }
-
-    use bitcoin::TxOut;
-    use quickcheck::{Arbitrary, Gen};
-    use rand::Rng;
 
     #[test]
     fn test_complete_mining_round() {

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -768,17 +768,6 @@ impl ChannelFactory {
         println!("\nSHARE HASH: {:?}", &hash);
         let hash: Target = hash.into();
 
-        // let upstream_target_u256: binary_sv2::U256 = upstream_target.clone().into();
-        // println!("UPSTREAM TARGET: {:?}", &upstream_target_u256.to_vec());
-
-        // let downstream_target_u256: binary_sv2::U256 = downstream_target.clone().into();
-        // println!("DOWNSTREAM TARGET: {:?}", &downstream_target_u256.to_vec());
-        // println!("HEADER: {:?}\n", &header);
-        // println!("SHARE: {:?}\n", &m);
-        // println!("COINBASE PREFIX: {:?}\n", &coinbase_tx_prefix);
-        // println!("COINBASE SUFFIX: {:?}\n", &coinbase_tx_suffix);
-        // println!("EXTRANONCE: {:?}\n", &extranonce);
-
         if hash <= bitcoin_target {
             let coinbase = [coinbase_tx_prefix, &extranonce[..], coinbase_tx_suffix]
                 .concat()

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -768,16 +768,16 @@ impl ChannelFactory {
         println!("\nSHARE HASH: {:?}", &hash);
         let hash: Target = hash.into();
 
-        let upstream_target_u256: binary_sv2::U256 = upstream_target.clone().into();
-        println!("UPSTREAM TARGET: {:?}", &upstream_target_u256.to_vec());
+        // let upstream_target_u256: binary_sv2::U256 = upstream_target.clone().into();
+        // println!("UPSTREAM TARGET: {:?}", &upstream_target_u256.to_vec());
 
-        let downstream_target_u256: binary_sv2::U256 = downstream_target.clone().into();
-        println!("DOWNSTREAM TARGET: {:?}", &downstream_target_u256.to_vec());
-        println!("HEADER: {:?}\n", &header);
-        println!("SHARE: {:?}\n", &m);
-        println!("COINBASE PREFIX: {:?}\n", &coinbase_tx_prefix);
-        println!("COINBASE SUFFIX: {:?}\n", &coinbase_tx_suffix);
-        println!("EXTRANONCE: {:?}\n", &extranonce);
+        // let downstream_target_u256: binary_sv2::U256 = downstream_target.clone().into();
+        // println!("DOWNSTREAM TARGET: {:?}", &downstream_target_u256.to_vec());
+        // println!("HEADER: {:?}\n", &header);
+        // println!("SHARE: {:?}\n", &m);
+        // println!("COINBASE PREFIX: {:?}\n", &coinbase_tx_prefix);
+        // println!("COINBASE SUFFIX: {:?}\n", &coinbase_tx_suffix);
+        // println!("EXTRANONCE: {:?}\n", &extranonce);
 
         if hash <= bitcoin_target {
             let coinbase = [coinbase_tx_prefix, &extranonce[..], coinbase_tx_suffix]

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -768,6 +768,20 @@ impl ChannelFactory {
         println!("\nSHARE HASH: {:?}", &hash);
         let hash: Target = hash.into();
 
+        let upstream_target_u256: binary_sv2::U256 = upstream_target.clone().into();
+        println!("UPSTREAM TARGET: {:?}", &upstream_target_u256.to_vec());
+
+        let downstream_target_u256: binary_sv2::U256 = downstream_target.clone().into();
+        println!("DOWNSTREAM TARGET: {:?}", &downstream_target_u256.to_vec());
+        println!("HEADER: {:?}\n", &header);
+        println!("SHARE: {:?}\n", &m);
+        println!("COINBASE PREFIX: {:?}\n", &coinbase_tx_prefix);
+        println!("COINBASE SUFFIX: {:?}\n", &coinbase_tx_suffix);
+        println!("EXTRANONCE: {:?}\n", &extranonce);
+
+        
+        
+
         if hash <= bitcoin_target {
             let coinbase = [coinbase_tx_prefix, &extranonce[..], coinbase_tx_suffix]
                 .concat()

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -246,7 +246,7 @@ impl ChannelFactory {
                 .safe_lock(|ids| ids.new_channel_id(extended_channels_group))
                 .unwrap();
             self.channel_to_group_id.insert(channel_id, 0);
-            let target = crate::utils::hash_rate_to_target(hash_rate, self.share_per_min);
+            let target = crate::utils::hash_rate_to_target_le(hash_rate, self.share_per_min);
             let extranonce = self
                 .extranonces
                 .next_extended(max_extranonce_size as usize)?;
@@ -291,7 +291,7 @@ impl ChannelFactory {
         let hom_group_id = 0;
         let mut result = vec![];
         let channel_id = id;
-        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
+        let target = crate::utils::hash_rate_to_target_le(downstream_hash_rate, self.share_per_min);
         let extranonce = self
             .extranonces
             .next_standard()
@@ -334,7 +334,7 @@ impl ChannelFactory {
             .safe_lock(|ids| ids.new_channel_id(group_id))
             .unwrap();
         let complete_id = GroupId::into_complete_id(group_id, channel_id);
-        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
+        let target = crate::utils::hash_rate_to_target_le(downstream_hash_rate, self.share_per_min);
         let extranonce = self
             .extranonces
             .next_standard()

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -246,7 +246,7 @@ impl ChannelFactory {
                 .safe_lock(|ids| ids.new_channel_id(extended_channels_group))
                 .unwrap();
             self.channel_to_group_id.insert(channel_id, 0);
-            let target = crate::utils::hash_rate_to_target_le(hash_rate, self.share_per_min);
+            let target = crate::utils::hash_rate_to_target(hash_rate, self.share_per_min);
             let extranonce = self
                 .extranonces
                 .next_extended(max_extranonce_size as usize)?;
@@ -297,7 +297,7 @@ impl ChannelFactory {
         let hom_group_id = 0;
         let mut result = vec![];
         let channel_id = id;
-        let target = crate::utils::hash_rate_to_target_le(downstream_hash_rate, self.share_per_min);
+        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
         let extranonce = self
             .extranonces
             .next_standard()
@@ -340,7 +340,7 @@ impl ChannelFactory {
             .safe_lock(|ids| ids.new_channel_id(group_id))
             .unwrap();
         let complete_id = GroupId::into_complete_id(group_id, channel_id);
-        let target = crate::utils::hash_rate_to_target_le(downstream_hash_rate, self.share_per_min);
+        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
         let extranonce = self
             .extranonces
             .next_standard()
@@ -680,6 +680,8 @@ impl ChannelFactory {
 
     // If there is job creator, bitcoin_target is retrieved from there. If not, it is set to 0.
     // If there is a job creator we pass the correct template id. If not, we pass `None`
+    // allow comparison chain because clippy wants to make job management assertion into a match clause
+    #[allow(clippy::comparison_chain)]
     fn check_target(
         &mut self,
         m: Share,
@@ -696,29 +698,27 @@ impl ChannelFactory {
                 upstream_target, ..
             } => upstream_target.clone(),
         };
-        let _last_job_id = self
+        let last_job_id = self
             .last_valid_job
             .as_ref()
             .ok_or(Error::ShareDoNotMatchAnyJob)?
             .0
             .job_id;
-        // *** TODO: uncomment code below when job management gets fixed
-        // if m.get_job_id() < last_job_id {
-        //     println!("JOB ID: {:?}", last_job_id);
-        //     let error = SubmitSharesError {
-        //         channel_id: m.get_channel_id(),
-        //         sequence_number: m.get_sequence_number(),
-        //         // Infallible unwrap we already know the len of the error code (is a
-        //         // static string)
-        //         error_code: SubmitSharesError::stale_share_error_code()
-        //             .to_string()
-        //             .try_into()
-        //             .unwrap(),
-        //     };
-        //     return Ok(OnNewShare::SendErrorDownstream(error));
-        // } else if m.get_job_id() > last_job_id {
-        //     return Err(Error::JobNotUpdated)
-        // }
+        if m.get_job_id() < last_job_id {
+            let error = SubmitSharesError {
+                channel_id: m.get_channel_id(),
+                sequence_number: m.get_sequence_number(),
+                // Infallible unwrap we already know the len of the error code (is a
+                // static string)
+                error_code: SubmitSharesError::stale_share_error_code()
+                    .to_string()
+                    .try_into()
+                    .unwrap(),
+            };
+            return Ok(OnNewShare::SendErrorDownstream(error));
+        } else if m.get_job_id() > last_job_id {
+            return Err(Error::JobNotUpdated(m.get_job_id(), last_job_id));
+        }
         let (downstream_target, extranonce) = self
             .get_channel_specific_mining_info(&m)
             .ok_or(Error::ShareDoNotMatchAnyChannel)?;
@@ -772,7 +772,10 @@ impl ChannelFactory {
         let hash_ = header.block_hash();
         let hash = hash_.as_hash().into_inner();
         let hash: Target = hash.into();
-
+        println!(
+            "BITCOIN TARGET: {:?}",
+            binary_sv2::U256::from(bitcoin_target.clone()).inner_as_ref()
+        );
         if hash <= bitcoin_target {
             let coinbase = [coinbase_tx_prefix, &extranonce[..], coinbase_tx_suffix]
                 .concat()
@@ -1165,7 +1168,6 @@ impl ProxyExtendedChannelFactory {
         m: &SetNewPrevHashFromTp<'static>,
     ) -> Result<Option<PartialSetCustomMiningJob>, Error> {
         if let Some(job_creator) = self.job_creator.as_mut() {
-            // since we have staged phash 0 is no longer reserved and 1 is the default
             let job_id = job_creator.on_new_prev_hash(m).unwrap_or(0);
             let new_prev_hash = StagedPhash {
                 job_id,
@@ -1536,7 +1538,7 @@ mod test {
         );
 
         // Build a NewTemplate
-        let mut new_template = NewTemplate {
+        let new_template = NewTemplate {
             template_id: 10,
             future_template: true,
             version: VERSION,
@@ -1551,7 +1553,7 @@ mod test {
         };
 
         // "Send" the NewTemplate to the channel
-        let _ = channel.on_new_template(&mut new_template);
+        let _ = channel.on_new_template(&mut (new_template.clone()));
 
         // Build a PrevHash
         let mut p_hash = decode_hex(PREV_HASH).unwrap();
@@ -1610,6 +1612,12 @@ mod test {
                 _ => panic!(),
             }
         };
+        // make sure job management in channel factory is updated
+        (0..job_id - 1).for_each(|_| {
+            channel.job_creator.reset_new_templates(None);
+            let _ = channel.on_new_template(&mut (new_template.clone()));
+            let _ = channel.on_new_prev_hash_from_tp(&prev_hash);
+        });
 
         // Build the success share
         let share = SubmitSharesStandard {

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -46,6 +46,7 @@ pub enum Error {
     InvalidExtranonceSize(u16, u16),
     PoisonLock(String),
     InvalidBip34Bytes(Vec<u8>),
+    JobNotUpdated,
 }
 
 impl From<BinarySv2Error> for Error {
@@ -126,6 +127,7 @@ impl Display for Error {
             NoTemplateForId => write!(f, "Impossible a template for the required job id"),
             PoisonLock(e) => write!(f, "Poison lock: {}", e),
             InvalidBip34Bytes(e) => write!(f, "Invalid Bip34 bytes {:?}", e),
+            JobNotUpdated => write!(f, "Channel Factory did not update job")
         }
     }
 }

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -46,7 +46,8 @@ pub enum Error {
     InvalidExtranonceSize(u16, u16),
     PoisonLock(String),
     InvalidBip34Bytes(Vec<u8>),
-    JobNotUpdated,
+    // (downstream_job_id, upstream_job_id)
+    JobNotUpdated(u32, u32),
 }
 
 impl From<BinarySv2Error> for Error {
@@ -127,7 +128,7 @@ impl Display for Error {
             NoTemplateForId => write!(f, "Impossible a template for the required job id"),
             PoisonLock(e) => write!(f, "Poison lock: {}", e),
             InvalidBip34Bytes(e) => write!(f, "Invalid Bip34 bytes {:?}", e),
-            JobNotUpdated => write!(f, "Channel Factory did not update job")
+            JobNotUpdated(ds_job_id, us_job_id) => write!(f, "Channel Factory did not update job: Downstream job id = {}, Upstream job id = {}", ds_job_id, us_job_id)
         }
     }
 }

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -164,6 +164,10 @@ fn new_extended_job(
         extranonce_len,
     );
 
+    println!("COINBASE: {:?}", coinbase.serialize());
+
+    // let stripped_tx = StrippedCoinbaseTx::from_coinbase(coinbase);
+
     let new_extended_mining_job: NewExtendedMiningJob<'static> = NewExtendedMiningJob {
         channel_id: 0,
         job_id,
@@ -195,6 +199,9 @@ fn coinbase_tx_prefix(
         0 => 0,
         _ => 2,
     };
+    // remove segwit bytes
+    // encoded.splice(4..segwit_bytes, vec![]);
+    // remove marker and flag 4 bytes total after the tx version
     let index = 4    // tx version
         + segwit_bytes
         + 1  // number of inputs TODO can be also 3
@@ -220,6 +227,7 @@ fn coinbase_tx_suffix(
         0 => 0,
         _ => 2,
     };
+    println!("COINBASE SERIALIZED: {:?}", &encoded);
     let r = encoded[4    // tx version
         + segwit_bytes
         + 1  // number of inputs TODO can be also 3

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -109,7 +109,6 @@ impl JobsCreators {
             .collect();
         match template.len() {
             0 => {
-                println!("ON NEW PREV HASH: {:?}", "None");
                 self.reset_new_templates(None);
                 None
             }
@@ -164,10 +163,6 @@ fn new_extended_job(
         extranonce_len,
     );
 
-    println!("COINBASE: {:?}", coinbase.serialize());
-
-    // let stripped_tx = StrippedCoinbaseTx::from_coinbase(coinbase);
-
     let new_extended_mining_job: NewExtendedMiningJob<'static> = NewExtendedMiningJob {
         channel_id: 0,
         job_id,
@@ -199,9 +194,6 @@ fn coinbase_tx_prefix(
         0 => 0,
         _ => 2,
     };
-    // remove segwit bytes
-    // encoded.splice(4..segwit_bytes, vec![]);
-    // remove marker and flag 4 bytes total after the tx version
     let index = 4    // tx version
         + segwit_bytes
         + 1  // number of inputs TODO can be also 3
@@ -227,7 +219,6 @@ fn coinbase_tx_suffix(
         0 => 0,
         _ => 2,
     };
-    println!("COINBASE SERIALIZED: {:?}", &encoded);
     let r = encoded[4    // tx version
         + segwit_bytes
         + 1  // number of inputs TODO can be also 3

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -1,13 +1,15 @@
 //! The job creator module provides logic to create extended mining jobs given a template from
 //! a template provider as well as logic to clean up old templates when new blocks are mined
-use crate::{utils::Id, Error};
+use crate::{errors, utils::Id, Error};
 use binary_sv2::B064K;
 use bitcoin::{
     blockdata::transaction::{OutPoint, Transaction, TxIn, TxOut},
-    util::psbt::serialize::Serialize,
+    util::psbt::serialize::{Deserialize, Serialize},
 };
 pub use bitcoin::{
+    consensus::{deserialize, serialize, Decodable, Encodable},
     hash_types::{PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash},
+    hashes::Hash,
     secp256k1::SecretKey,
     util::ecdsa::PrivateKey,
 };
@@ -25,8 +27,6 @@ pub struct JobsCreators {
     last_target: mining_sv2::Target,
     extranonce_len: u8,
 }
-
-use bitcoin::consensus::Decodable;
 
 /// Transform the byte array `coinbase_outputs` in a vector of TxOut
 /// It assumes the data to be valid data and does not do any kind of check
@@ -297,11 +297,124 @@ fn coinbase(
     }
 }
 
+/// Helper type to strip a segwit data from the coinbase_tx_prefix and coinbase_tx_suffix
+/// to ensure miners are hashing with the correct coinbase
+pub fn extended_job_to_non_segwit(
+    job: NewExtendedMiningJob<'static>,
+    full_extranonce_len: usize,
+) -> Result<NewExtendedMiningJob<'static>, Error> {
+    let mut encoded = job.coinbase_tx_prefix.to_vec();
+    // just add empty extranonce space so it can be deserialized. The real extranonce
+    // should be inserted based on the miner's shares
+    let extranonce = vec![0_u8; full_extranonce_len];
+    encoded.extend_from_slice(&extranonce[..]);
+    encoded.extend_from_slice(job.coinbase_tx_suffix.inner_as_ref());
+    let coinbase = Transaction::deserialize(&encoded).map_err(|_| Error::InvalidCoinbase)?;
+    let stripped_tx = StrippedCoinbaseTx::from_coinbase(coinbase, full_extranonce_len)?;
+
+    Ok(NewExtendedMiningJob {
+        channel_id: job.channel_id,
+        job_id: job.job_id,
+        future_job: job.future_job,
+        version: job.version,
+        version_rolling_allowed: job.version_rolling_allowed,
+        merkle_path: job.merkle_path,
+        coinbase_tx_prefix: stripped_tx.into_coinbase_tx_prefix()?,
+        coinbase_tx_suffix: stripped_tx.into_coinbase_tx_suffix()?,
+    })
+}
+/// Helper type to strip a segwit data from the coinbase_tx_prefix and coinbase_tx_suffix
+/// to ensure miners are hashing with the correct coinbase
+struct StrippedCoinbaseTx {
+    version: u32,
+    inputs: Vec<Vec<u8>>,
+    outputs: Vec<Vec<u8>>,
+    lock_time: u32,
+    // helper field
+    bip141_bytes_len: usize,
+}
+
+impl StrippedCoinbaseTx {
+    /// create
+    fn from_coinbase(tx: Transaction, full_extranonce_len: usize) -> Result<Self, Error> {
+        let bip141_bytes_len = tx
+            .input
+            .last()
+            .ok_or(Error::BadPayloadSize)?
+            .script_sig
+            .len()
+            - full_extranonce_len;
+        Ok(Self {
+            version: tx.version as u32,
+            inputs: tx
+                .input
+                .iter()
+                .map(|txin| {
+                    let mut ser: Vec<u8> = vec![];
+                    ser.extend_from_slice(&txin.previous_output.txid);
+                    ser.extend_from_slice(&txin.previous_output.vout.to_le_bytes());
+                    ser.push(txin.script_sig.len() as u8);
+                    ser.extend_from_slice(txin.script_sig.as_bytes());
+                    ser.extend_from_slice(&txin.sequence.to_le_bytes());
+                    ser
+                })
+                .collect(),
+            outputs: tx.output.iter().map(|o| o.serialize()).collect(),
+            lock_time: tx.lock_time,
+            bip141_bytes_len,
+        })
+    }
+
+    /// the coinbase tx prefix is the LE bytes concatenation of the tx version and all
+    /// of the tx inputs minus the 32 bytes after the bip34 bytes in the script
+    /// and the last input's sequence (used as the first entry in the coinbase tx suffix).
+    /// The last 32 bytes after the bip34 bytes in the script will be used to allow extranonce
+    /// space for the miner. We remove the bip141 marker and flag since it is only used for
+    /// computing the `wtxid` and the legacy `txid` is what is used for computing the merkle root
+    // clippy allow because we dont want to consume self
+    #[allow(clippy::wrong_self_convention)]
+    fn into_coinbase_tx_prefix(&self) -> Result<B064K<'static>, errors::Error> {
+        let mut inputs = self.inputs.clone();
+        let last_input = inputs.last_mut().ok_or(Error::BadPayloadSize)?;
+        let new_last_input_len =
+        32 // outpoint
+        + 4 // vout
+        + 1 // script length byte -> TODO can be also 3 (based on TODO in `coinbase_tx_prefix()`)
+        + self.bip141_bytes_len // space for bip34 bytes
+        ;
+        last_input.truncate(new_last_input_len);
+        let mut prefix: Vec<u8> = vec![];
+        prefix.extend_from_slice(&self.version.to_le_bytes());
+        prefix.push(self.inputs.len() as u8);
+        prefix.extend_from_slice(&inputs.concat());
+        prefix.try_into().map_err(Error::BinarySv2Error)
+    }
+
+    /// This coinbase tx suffix is the sequence of the last tx input plus
+    /// the serialized tx outputs and the lock time. Note we do not use the witnesses
+    /// (placed between txouts and lock time) since it is only used for
+    /// computing the `wtxid` and the legacy `txid` is what is used for computing the merkle root
+    // clippy allow because we dont want to consume self
+    #[allow(clippy::wrong_self_convention)]
+    fn into_coinbase_tx_suffix(&self) -> Result<B064K<'static>, errors::Error> {
+        let mut suffix: Vec<u8> = vec![];
+        let last_input = self.inputs.last().ok_or(Error::BadPayloadSize)?;
+        // only take the last intput's sequence u32 (bytes after the extranonce space)
+        let last_input_sequence = &last_input[last_input.len() - 4..];
+        suffix.extend_from_slice(last_input_sequence);
+        suffix.push(self.outputs.len() as u8);
+        suffix.extend_from_slice(&self.outputs.concat());
+        suffix.extend_from_slice(&self.lock_time.to_le_bytes());
+        suffix.try_into().map_err(Error::BinarySv2Error)
+    }
+}
+
 // Test
 #[cfg(test)]
 
 pub mod tests {
     use super::*;
+    use crate::utils::merkle_root_from_path;
     #[cfg(feature = "prop_test")]
     use binary_sv2::u256_from_int;
     use bitcoin::{secp256k1::Secp256k1, util::ecdsa::PublicKey, Network};
@@ -509,5 +622,36 @@ pub mod tests {
         let outs = tx_outputs_to_costum_scripts(&encoded[..]);
         assert!(&outs[0] == &tx1);
         assert!(outs[1] == tx2);
+    }
+
+    // test that witness stripped tx id matches that of the txid of the coinbase
+    #[test]
+    fn stripped_tx_id() {
+        let encoded: &[u8] = &[
+            2, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 36, 2, 107, 22, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255,
+            255, 255, 2, 0, 0, 0, 0, 0, 0, 0, 0, 67, 65, 4, 70, 109, 127, 202, 229, 99, 229, 203,
+            9, 160, 209, 135, 11, 181, 128, 52, 72, 4, 97, 120, 121, 161, 73, 73, 207, 34, 40, 95,
+            27, 174, 63, 39, 103, 40, 23, 108, 60, 100, 49, 248, 238, 218, 69, 56, 220, 55, 200,
+            101, 226, 120, 79, 58, 158, 119, 208, 68, 243, 62, 64, 119, 151, 225, 39, 138, 172, 0,
+            0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209, 222,
+            253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180, 139,
+            235, 216, 54, 151, 78, 140, 249, 1, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let coinbase = Transaction::deserialize(encoded).unwrap();
+        let stripped = StrippedCoinbaseTx::from_coinbase(coinbase.clone(), 32).unwrap();
+        let prefix = stripped.into_coinbase_tx_prefix().unwrap().to_vec();
+        let suffix = stripped.into_coinbase_tx_suffix().unwrap().to_vec();
+        let extranonce = &[0_u8; 32];
+        let path: &[binary_sv2::U256] = &[];
+        let stripped_merkle_root =
+            merkle_root_from_path(&prefix[..], &suffix[..], extranonce, path).unwrap();
+        let og_merkle_root = coinbase.txid().to_vec();
+        assert!(
+            stripped_merkle_root == og_merkle_root,
+            "stripped tx hash is not the same as bitcoin crate"
+        );
     }
 }

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -109,6 +109,7 @@ impl JobsCreators {
             .collect();
         match template.len() {
             0 => {
+                println!("ON NEW PREV HASH: {:?}", "None");
                 self.reset_new_templates(None);
                 None
             }

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -201,6 +201,7 @@ pub fn hash_rate_from_target(target: U256<'static>, share_per_min: f32) -> f32 {
 
     let mut target_arr: [u8; 32] = [0; 32];
     target_arr.as_mut().copy_from_slice(target.inner_as_ref());
+    target_arr.reverse();
     let mut target_plus_1 = bitcoin::util::uint::Uint256::from_be_bytes(target_arr);
     target_plus_1.increment();
 
@@ -738,11 +739,11 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut successes = 0;
 
-        let hr = 10.01; // 10 h/s
+        let hr = 10.0; // 10 h/s
         let hrs = hr * 60.0; // number of hashes in 1 minute
-        let mut target = hash_rate_to_target(hr, 1.0);
-        let target =
-            bitcoin::util::uint::Uint256::from_be_slice(&target.inner_as_mut()[..]).unwrap();
+        let mut target = hash_rate_to_target(hr, 1.0).to_vec();
+        target.reverse();
+        let target = bitcoin::util::uint::Uint256::from_be_slice(&target[..]).unwrap();
 
         let mut i: i64 = 0;
         let mut results = vec![];

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -113,7 +113,7 @@ pub fn merkle_root_from_path<T: AsRef<[u8]>>(
         }
     };
 
-    let coinbase_id: [u8; 32] = match coinbase.txid().as_hash().to_vec().try_into() {
+    let coinbase_id: [u8; 32] = match coinbase.txid().to_vec().try_into() {
         Ok(id) => id,
         Err(_e) => return None,
     };
@@ -189,8 +189,9 @@ pub fn hash_rate_to_target(h: f32, share_per_min: f32) -> U256<'static> {
     let numerator = two_to_256_minus_one - h_times_s;
     let denominator = h_times_s_plus_one;
     let target = numerator / denominator;
-    let target = target.to_be_bytes();
-    U256::<'static>::from(target)
+    let mut target_be = target.to_be_bytes();
+    target_be.reverse();
+    U256::<'static>::from(target_be)
 }
 
 /// this function utilizes the equation used in [`hash_rate_to_target`], but

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -173,7 +173,7 @@ fn reduce_path<T: AsRef<[u8]>>(coinbase_id: [u8; 32], path: &[T]) -> [u8; 32] {
 /// [3] https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution
 /// bdiff: 0x00000000ffff0000000000000000000000000000000000000000000000000000
 /// https://en.bitcoin.it/wiki/Difficulty#How_soon_might_I_expect_to_generate_a_block.3F
-pub fn hash_rate_to_target(h: f32, share_per_min: f32) -> U256<'static> {
+fn _hash_rate_to_target(h: f32, share_per_min: f32) -> [u8; 32] {
     // if we want 5 shares per minute, this means that s=60/5=12 seconds interval between shares
     let s: f32 = 60_f32 / share_per_min;
     let h_times_s = (h * s) as u128;
@@ -735,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_rate_to_target() {
+    fn test_hash_rate_to_target_be() {
         let mut rng = rand::thread_rng();
         let mut successes = 0;
 

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -173,7 +173,7 @@ fn reduce_path<T: AsRef<[u8]>>(coinbase_id: [u8; 32], path: &[T]) -> [u8; 32] {
 /// [3] https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution
 /// bdiff: 0x00000000ffff0000000000000000000000000000000000000000000000000000
 /// https://en.bitcoin.it/wiki/Difficulty#How_soon_might_I_expect_to_generate_a_block.3F
-fn _hash_rate_to_target(h: f32, share_per_min: f32) -> [u8; 32] {
+pub fn hash_rate_to_target(h: f32, share_per_min: f32) -> U256<'static> {
     // if we want 5 shares per minute, this means that s=60/5=12 seconds interval between shares
     let s: f32 = 60_f32 / share_per_min;
     let h_times_s = (h * s) as u128;
@@ -735,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_rate_to_target_be() {
+    fn test_hash_rate_to_target() {
         let mut rng = rand::thread_rng();
         let mut successes = 0;
 

--- a/protocols/v2/subprotocols/mining/src/new_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/new_mining_job.rs
@@ -118,7 +118,6 @@ impl<'d> GetSize for NewMiningJob<'d> {
 mod tests {
     use super::*;
     use crate::tests::from_arbitrary_vec_to_array;
-    use binary_sv2::GetSize;
     use core::convert::TryFrom;
     use quickcheck_macros;
 

--- a/roles/translator/conf/tproxy-config-local.toml
+++ b/roles/translator/conf/tproxy-config-local.toml
@@ -32,7 +32,7 @@ min_individual_miner_hashrate=5_000_000.0
 # minimum number of shares needed before a mining.set_difficulty is sent for updating targets
 miner_num_submits_before_update=5
 # target number of shares per minute the miner should be sending
-shares_per_minute = 6.0
+shares_per_minute = 1.0
 
 [upstream_difficulty_config]
 # interval in seconds to elapse before updating channel hashrate with the pool

--- a/roles/translator/proxy-config.toml
+++ b/roles/translator/proxy-config.toml
@@ -21,9 +21,9 @@ min_extranonce2_size = 16
 coinbase_reward_sat = 5_000_000_000
 
 # optional jn config, if set the tproxy start on JN mode
-[jn_config]
-jn_address = "127.0.0.1:34264"
-tp_address = "127.0.0.1:8442"
+# [jn_config]
+# jn_address = "127.0.0.1:34264"
+# tp_address = "127.0.0.1:8442"
 
 # Difficulty params
 [downstream_difficulty_config]

--- a/roles/translator/src/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/downstream_sv1/diff_management.rs
@@ -229,9 +229,9 @@ mod test {
     #[tokio::test]
     async fn test_diff_management() {
         let downstream_conf = DownstreamDifficultyConfig {
-            min_individual_miner_hashrate: 0.0,  // updated below
-            miner_num_submits_before_update: 15, // update after 5 submits
-            shares_per_minute: 100.0,            // 10 shares per minute
+            min_individual_miner_hashrate: 0.0,   // updated below
+            miner_num_submits_before_update: 150, // update after 5 submits
+            shares_per_minute: 1000.0,            // 10 shares per minute
             submits_since_last_update: 0,
             timestamp_of_last_update: 0, // updated below
         };
@@ -275,7 +275,9 @@ mod test {
         let mut elapsed = std::time::Duration::from_secs(0);
         let downstream = Arc::new(Mutex::new(downstream));
         Downstream::init_difficulty_management(downstream.clone()).unwrap();
-        let mut target = initial_target;
+        let mut target = initial_target.to_vec();
+        target.reverse();
+        let mut target: U256 = target.try_into().unwrap();
         let mut count = 0;
         while elapsed <= total_run_time {
             // start hashing util a target is met and submit to
@@ -322,7 +324,7 @@ mod test {
 
     fn mock_mine(target: Target) -> U256<'static> {
         let mut share: Target = [255_u8; 32].into();
-        while shares_is_gt(share.clone().into(), target.clone().into()) {
+        while share > target {
             share = gen_share();
         }
         share.into()
@@ -352,13 +354,6 @@ mod test {
         let head = u128::from_be_bytes(v[0..16].try_into().unwrap());
         let tail = u128::from_be_bytes(v[16..32].try_into().unwrap());
         Target::new(head, tail)
-    }
-
-    fn shares_is_gt(share: U256<'static>, target: U256<'static>) -> bool {
-        let a = share.inner_as_ref();
-        let b = target.inner_as_ref();
-        u128::from_be_bytes(a[0..16].try_into().unwrap())
-            > u128::from_be_bytes(b[0..16].try_into().unwrap())
     }
 
     fn gen_share() -> Target {

--- a/roles/translator/src/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/downstream_sv1/diff_management.rs
@@ -126,7 +126,9 @@ impl Downstream {
 
     /// Converts target received by the `SetTarget` SV2 message from the Upstream role into the
     /// difficulty for the Downstream role sent via the SV1 `mining.set_difficulty` message.
-    pub(super) fn difficulty_from_target(target: Vec<u8>) -> ProxyResult<'static, f64> {
+    pub(super) fn difficulty_from_target(mut target: Vec<u8>) -> ProxyResult<'static, f64> {
+        // reverse because target is LE and this function relies on BE
+        target.reverse();
         let target = target.as_slice();
 
         // If received target is 0, return 0
@@ -243,6 +245,7 @@ mod test {
         let (tx_outgoing, _rx_outgoing) = unbounded();
         // create Downstream instance
         let mut downstream = Downstream::new(
+            1,
             vec![],
             vec![],
             None,

--- a/roles/translator/src/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/downstream_sv1/diff_management.rs
@@ -230,8 +230,8 @@ mod test {
     async fn test_diff_management() {
         let downstream_conf = DownstreamDifficultyConfig {
             min_individual_miner_hashrate: 0.0,   // updated below
-            miner_num_submits_before_update: 150, // update after 5 submits
-            shares_per_minute: 1000.0,            // 10 shares per minute
+            miner_num_submits_before_update: 150, // update after 150 submits
+            shares_per_minute: 1000.0,            // 1000 shares per minute
             submits_since_last_update: 0,
             timestamp_of_last_update: 0, // updated below
         };

--- a/roles/translator/src/downstream_sv1/mod.rs
+++ b/roles/translator/src/downstream_sv1/mod.rs
@@ -1,4 +1,4 @@
-use v1::utils::HexU32Be;
+use v1::{client_to_server::Submit, utils::HexU32Be};
 pub mod diff_management;
 pub mod downstream;
 pub use downstream::Downstream;
@@ -9,6 +9,12 @@ pub use downstream::Downstream;
 /// receive jobs. Without the timeout the TProxy can be exploited by incoming
 /// `mining.subscribe` messages that init connections and take up compute
 const SUBSCRIBE_TIMEOUT_SECS: u64 = 10;
+
+pub struct SubmitShareWithChannelId {
+    pub channel_id: u32,
+    pub share: Submit<'static>,
+    pub extranonce: Vec<u8>,
+}
 
 /// This is just a wrapper function to send a message on the Downstream task shutdown channel
 /// it does not matter what message is sent because the receiving ends should shutdown on any message

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -210,7 +210,6 @@ async fn main() {
     // Receive the extranonce information from the Upstream role to send to the Downstream role
     // once it connects also used to initialize the bridge
     let (extended_extranonce, up_id) = rx_sv2_extranonce.recv().await.unwrap();
-
     loop {
         let target: [u8; 32] = target.safe_lock(|t| t.clone()).unwrap().try_into().unwrap();
         if target != [0; 32] {

--- a/roles/translator/src/proxy/bridge.rs
+++ b/roles/translator/src/proxy/bridge.rs
@@ -74,6 +74,7 @@ pub struct Bridge {
     request_ids: Id,
     channel_extranonce_len: usize,
     solution_sender: Option<Sender<SubmitSolution<'static>>>,
+    channel_extranonce_len: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -145,6 +146,7 @@ impl Bridge {
             pool_output_is_set: false,
             channel_extranonce_len,
             solution_sender,
+            channel_extranonce_len,
         }));
         match upstream_kind {
             UpstreamKind::Standard => (),
@@ -662,12 +664,13 @@ impl Bridge {
     /// `SetNewPrevHash` `job_id`, an error has occurred on the Upstream pool role and the
     /// connection will close.
     fn handle_new_extended_mining_job(self_: Arc<Mutex<Self>>) {
-        let (tx_sv1_notify, rx_sv2_new_ext_mining_job, tx_status) = self_
+        let (tx_sv1_notify, rx_sv2_new_ext_mining_job, tx_status, extended_extranonce_len) = self_
             .safe_lock(|s| {
                 (
                     s.tx_sv1_notify.clone(),
                     s.rx_sv2_new_ext_mining_job.clone(),
                     s.tx_status.clone(),
+                    s.channel_extranonce_len,
                 )
             })
             .unwrap();

--- a/roles/translator/src/proxy/bridge.rs
+++ b/roles/translator/src/proxy/bridge.rs
@@ -72,7 +72,6 @@ pub struct Bridge {
     first_ph_received: bool,
     pool_output_is_set: bool,
     request_ids: Id,
-    channel_extranonce_len: usize,
     solution_sender: Option<Sender<SubmitSolution<'static>>>,
     channel_extranonce_len: usize,
     last_job_id: u32,
@@ -145,7 +144,6 @@ impl Bridge {
             first_ph_received: false,
             request_ids: Id::new(),
             pool_output_is_set: false,
-            channel_extranonce_len,
             solution_sender,
             channel_extranonce_len,
             last_job_id: 0,
@@ -678,13 +676,12 @@ impl Bridge {
     /// `SetNewPrevHash` `job_id`, an error has occurred on the Upstream pool role and the
     /// connection will close.
     fn handle_new_extended_mining_job(self_: Arc<Mutex<Self>>) {
-        let (tx_sv1_notify, rx_sv2_new_ext_mining_job, tx_status, _extended_extranonce_len) = self_
+        let (tx_sv1_notify, rx_sv2_new_ext_mining_job, tx_status) = self_
             .safe_lock(|s| {
                 (
                     s.tx_sv1_notify.clone(),
                     s.rx_sv2_new_ext_mining_job.clone(),
                     s.tx_status.clone(),
-                    s.channel_extranonce_len,
                 )
             })
             .unwrap();

--- a/roles/translator/src/proxy/next_mining_notify.rs
+++ b/roles/translator/src/proxy/next_mining_notify.rs
@@ -13,7 +13,7 @@ pub fn create_notify(
     new_job: NewExtendedMiningJob<'static>,
 ) -> server_to_client::Notify<'static> {
     // Make sure that SetNewPrevHash + NewExtendedMiningJob is matching (not future)
-    let job_id = new_prev_hash.job_id.to_string();
+    let job_id = new_job.job_id.to_string();
 
     // U256<'static> -> MerkleLeaf
     let prev_hash = PrevHash(new_prev_hash.prev_hash.clone());

--- a/roles/translator/src/upstream_sv2/upstream.rs
+++ b/roles/translator/src/upstream_sv2/upstream.rs
@@ -40,6 +40,7 @@ use tracing::{debug, error, info, warn};
 /// USED to make sure that if a future new_temnplate and a set_new_prev_hash are received together
 /// the future new_temnplate is always handled before the set new prev hash.
 pub static IS_NEW_TEMPLATE_HANDLED: AtomicBool = AtomicBool::new(true);
+pub static IS_NEW_JOB_HANDLED: AtomicBool = AtomicBool::new(true);
 /// Represents the currently active `prevhash` of the mining job being worked on OR being submitted
 /// from the Downstream role.
 #[derive(Debug, Clone)]
@@ -766,7 +767,8 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
         &mut self,
         m: roles_logic_sv2::mining_sv2::NewExtendedMiningJob,
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, RolesLogicError> {
-        debug!("Received NewExtendedMiningJob: {:?}", &m);
+        IS_NEW_JOB_HANDLED.store(false, std::sync::atomic::Ordering::SeqCst);
+
         info!("Is future job: {}\n", &m.future_job);
         if self.is_work_selection_enabled() {
             Ok(SendTo::None(None))

--- a/roles/v2/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/v2/pool/src/lib/mining_pool/message_handler.rs
@@ -187,11 +187,7 @@ impl ParseDownstreamMiningMessages<(), NullDownstreamMiningSelector, NoRouting> 
             },
             Err(e) => {
                 error!("{:?}",e);
-                match e {
-                    // remove when Job management is fixed
-                    Error::JobNotUpdated => Ok(SendTo::None(None)),
-                    _ => todo!()
-                }
+                todo!();
             }
         }
     }

--- a/roles/v2/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/v2/pool/src/lib/mining_pool/message_handler.rs
@@ -187,7 +187,11 @@ impl ParseDownstreamMiningMessages<(), NullDownstreamMiningSelector, NoRouting> 
             },
             Err(e) => {
                 error!("{:?}",e);
-                todo!();
+                match e {
+                    // remove when Job management is fixed
+                    Error::JobNotUpdated => Ok(SendTo::None(None)),
+                    _ => todo!()
+                }
             }
         }
     }

--- a/roles/v2/pool/src/lib/template_receiver/mod.rs
+++ b/roles/v2/pool/src/lib/template_receiver/mod.rs
@@ -143,6 +143,7 @@ impl TemplateRx {
     async fn on_new_solution(self_: Arc<Mutex<Self>>, rx: Receiver<SubmitSolution<'static>>) {
         let status_tx = self_.safe_lock(|s| s.status_tx.clone()).unwrap();
         while let Ok(solution) = rx.recv().await {
+            info!("Sending Solution to TP: {:?}", &solution);
             let sv2_frame_res: Result<StdFrame, _> =
                 PoolMessages::TemplateDistribution(TemplateDistribution::SubmitSolution(solution))
                     .try_into();

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -481,6 +481,7 @@ impl Miner {
             bits: set_new_prev_hash.nbits,
             nonce: 0,
         };
+        println!("HEADER: {:?}", &header);
         self.header = Some(header);
     }
     pub fn next_share(&mut self) -> Result<(), ()> {

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -1,9 +1,6 @@
 use async_std::net::TcpStream;
 use bitcoin::{
-    blockdata::block::BlockHeader,
-    hash_types::{BlockHash, TxMerkleNode},
-    hashes::{sha256d::Hash as DHash, Hash},
-    util::uint::Uint256,
+    blockdata::block::BlockHeader, hash_types::BlockHash, hashes::Hash, util::uint::Uint256,
 };
 use network_helpers::PlainConnection;
 use roles_logic_sv2::utils::Id;
@@ -149,7 +146,8 @@ fn open_channel() -> OpenStandardMiningChannel<'static> {
     OpenStandardMiningChannel {
         request_id: id.into(),
         user_identity,
-        nominal_hash_rate: 5.4,
+        // keep at a value that actually tests the device since regtest target is so low
+        nominal_hash_rate: 100.0,
         max_target: u256_from_int(567_u64),
     }
 }
@@ -456,7 +454,9 @@ impl Miner {
         }
     }
 
-    fn new_target(&mut self, target: Vec<u8>) {
+    fn new_target(&mut self, mut target: Vec<u8>) {
+        // target is sent in LE and comparisons in this file are done in BE
+        target.reverse();
         self.target = Some(Uint256::from_be_bytes(target.try_into().unwrap()));
     }
 
@@ -464,13 +464,14 @@ impl Miner {
         self.job_id = Some(new_job.job_id);
         self.version = Some(new_job.version);
         let prev_hash: [u8; 32] = set_new_prev_hash.prev_hash.to_vec().try_into().unwrap();
-        let prev_hash = DHash::from_inner(prev_hash);
+        let prev_hash = Hash::from_inner(prev_hash);
         let merkle_root: [u8; 32] = new_job.merkle_root.to_vec().try_into().unwrap();
-        let merkle_root = DHash::from_inner(merkle_root);
+        let merkle_root = Hash::from_inner(merkle_root);
+        // fields need to be added as BE and the are converted to LE in the background before hashing
         let header = BlockHeader {
             version: new_job.version as i32,
             prev_blockhash: BlockHash::from_hash(prev_hash),
-            merkle_root: TxMerkleNode::from_hash(merkle_root),
+            merkle_root,
             time: std::time::SystemTime::now()
                 .duration_since(
                     std::time::SystemTime::UNIX_EPOCH - std::time::Duration::from_secs(60),
@@ -480,6 +481,7 @@ impl Miner {
             bits: set_new_prev_hash.nbits,
             nonce: 0,
         };
+        println!("HEADER: {:?}", &header);
         self.header = Some(header);
     }
     pub fn next_share(&mut self) -> Result<(), ()> {

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -481,7 +481,6 @@ impl Miner {
             bits: set_new_prev_hash.nbits,
             nonce: 0,
         };
-        println!("HEADER: {:?}", &header);
         self.header = Some(header);
     }
     pub fn next_share(&mut self) -> Result<(), ()> {

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -147,7 +147,7 @@ fn open_channel() -> OpenStandardMiningChannel<'static> {
         request_id: id.into(),
         user_identity,
         // keep at a value that actually tests the device since regtest target is so low
-        nominal_hash_rate: 100.0,
+        nominal_hash_rate: 5.4, // change back to 100.0 so the test is valid
         max_target: u256_from_int(567_u64),
     }
 }


### PR DESCRIPTION
## Bugs fixed by this PR:

### 1.  Changes BE target in `SetTarget` to LE
### 2. Handles downstream extranonce1 tracking in the Tproxy:
before this, we were creating a new "channel" for each downstream connection in the TProxy for easier tracking, but we were opening every channel with channel_id 1, which caused each share submission to check shares with the wrong extranonce. Now we are storing a separate channel_id for each connection in the `Downstream` struct, and a new wrapper type `SubmitSharesWithId` was added that gets sent to the `Bridge` so it can properly look up the correct channel.
### 3. Segwit support for miners without Segwit support:
According to BIP-141 the txid is the same for segwit and legacy transactions because the txid remains as the SHA256d hash of the serialized legacy transaction (excludes segwit the specific fields `marker`, `flag` and `witness` data). The shares created by a cpuminer would not match that of the miner because we were sending segwit data in the `coinbase_tx_prefix` and `coinbase_tx_suffix`, and the cpuminer would just hash what it was given without checks. To fix this, a helper function was added `extended_job_to_non_segwit()` that removes the segwit data in a `NewExtendedMiningJob`. Currently this conversion is only done in the TProxy but if this data is sent to a miner with segwit support, it should still produce the same hashes. Note: The pool still submits the coinbase tx with segwit data included to the Template Provider regardless if the miner is hashing the stripped coinbase or not.

Note: if testing with local instances of the roles, you will notice that after a few jobs arrive, the shares start to fail checks. This is because job management is out of whack and should be fixed in another issue
