### PR TITLE
Translator proxy test

### DIFF
--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq0255.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq0255.rs
@@ -264,7 +264,15 @@ impl<'a> From<Seq0255<'a, u32>> for Vec<u32> {
         if let Some(inner) = v.data {
             inner
         } else {
-            panic!()
+            let data = v.seq.unwrap().data;
+            if data.len() % 4 != 0 {
+                panic!("{:?}", data);
+            };
+            let mut res = vec![];
+            for v in data.chunks_exact(4) {
+                res.push(u32::from_le_bytes([v[0], v[1], v[2], v[3]]));
+            }
+            res
         }
     }
 }

--- a/test/config/tproxy-config.toml
+++ b/test/config/tproxy-config.toml
@@ -1,0 +1,21 @@
+# Braiins Pool Upstream Connection
+# upstream_authority_pubkey = "u95GEReVMjK6k5YqiSFNqqTnKU4ypU2Wm8awa6tmbmDmk1bWt"
+# upstream_address = "18.196.32.109"
+# upstream_port = 3336
+
+# Local SRI Pool Upstream Connection
+upstream_address = "127.0.0.1"
+upstream_port = 34254
+upstream_authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
+
+# Local Mining Device Downstream Connection
+downstream_address = "0.0.0.0"
+downstream_port = 34255
+
+# Version support
+max_supported_version = 2
+min_supported_version = 2
+
+# Minimum extranonce2 size
+min_extranonce2_size = 16
+coinbase_reward_sat = 5_000_000_000

--- a/test/config/tproxy-config.toml
+++ b/test/config/tproxy-config.toml
@@ -19,3 +19,18 @@ min_supported_version = 2
 # Minimum extranonce2 size
 min_extranonce2_size = 16
 coinbase_reward_sat = 5_000_000_000
+
+# Difficulty params
+[downstream_difficulty_config]
+# hashes/s of the weakest miner that will be connecting
+min_individual_miner_hashrate=5_000_000.0
+# minimum number of shares needed before a mining.set_difficulty is sent for updating targets
+miner_num_submits_before_update=5
+# target number of shares per minute the miner should be sending
+shares_per_minute = 6.0
+
+[upstream_difficulty_config]
+# interval in seconds to elapse before updating channel hashrate with the pool
+channel_diff_update_interval = 60
+# estimated accumulated hashrate of all downstream miners
+channel_nominal_hashrate = 5_000_000.0

--- a/test/message-generator/test/translation-proxy.json
+++ b/test/message-generator/test/translation-proxy.json
@@ -1,0 +1,90 @@
+{
+    "doc": [
+        "This test does",
+        "Runs a translator proxy",
+        "Waits that receives SetupConnection message",
+        "Reply with .Success"
+    ],
+    "common_messages": [
+    ],
+    "mining_messages": [
+    ],
+    "frame_builders": [
+        {
+            "type": "automatic",
+            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_tproxy"
+        },
+        {
+            "type": "automatic",
+            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_tproxy"
+        }
+    ],
+    "actions": [
+        {
+            "message_ids": [],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x00"
+                }
+            ],
+            "actiondoc": "This action checks that a Setupconnection message is received"
+        },
+        {
+            "message_ids": ["setup_connection_success_tproxy"],
+            "role": "server",
+            "results": [
+            ]
+        },
+        {
+            "message_ids": [],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x13"
+                }
+            ],
+            "actiondoc": "Checks that OpenExtendedMiningChannel is received" 
+        }
+    ],
+    "setup_commands": [
+       {
+            "command": "cargo",
+            "args": [
+                        "run",
+                        "-p",
+                        "translator_sv2",
+                        "--",
+                        "-c",
+                        "./test/config/tproxy-config.toml"
+
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "2mtranslator_sv2",
+                            "output_location": "StdOut",
+                            "condition": true
+                        }
+                    ],
+                    "timer_secs": 60,
+                    "warn_no_panic": false
+                }
+            }
+       }
+    ],
+    "execution_commands": [
+    ],
+    "cleanup_commands": [
+    ],
+    "role": "server",
+    "upstream": {
+        "ip": "127.0.0.1",
+        "port": 34254,
+        "pub_key": "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL",
+        "secret_key": "2Z1FZug7mZNyM63ggkm37r4oKQ29khLjAvEx43rGkFN47RcJ2t"
+    }
+}


### PR DESCRIPTION
This PR introduces a very small test about translation proxy.

The change a line 267 of
`protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq0255.rs`
was necessary to deserialize noise handshake message. 
In the new implementation of from trait, Seq0255<u8> is serialized into a Vec<u8> also in the case that it is of the form 
{
   seq = Some(something),
   data = None
}
In this case, the only part that needed to be serialized is something.data, that is an array of u8.
