### PR TITLE
Fixes tproxy when using WhatsMiner (or miner that uses mining.suggest_difficulty)

### DIFF
--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -88,6 +88,9 @@ pub trait IsServer<'a> {
         Self: std::marker::Sized,
     {
         match request {
+            methods::Client2Server::Suggest_Difficulty() => {
+                Ok(None)
+            }
             methods::Client2Server::Authorize(authorize) => {
                 let authorized = self.handle_authorize(&authorize);
                 if authorized {

--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -88,9 +88,7 @@ pub trait IsServer<'a> {
         Self: std::marker::Sized,
     {
         match request {
-            methods::Client2Server::Suggest_Difficulty() => {
-                Ok(None)
-            }
+            methods::Client2Server::SuggestDifficulty() => Ok(None),
             methods::Client2Server::Authorize(authorize) => {
                 let authorized = self.handle_authorize(&authorize);
                 if authorized {

--- a/protocols/v1/src/methods/mod.rs
+++ b/protocols/v1/src/methods/mod.rs
@@ -125,6 +125,7 @@ pub enum Method<'a> {
 
 #[derive(Debug)]
 pub enum Client2Server<'a> {
+    SuggestDifficulty(),
     Subscribe(client_to_server::Subscribe<'a>),
     Authorize(client_to_server::Authorize),
     ExtranonceSubscribe(client_to_server::ExtranonceSubscribe),
@@ -216,6 +217,9 @@ impl<'a> TryFrom<Message> for Method<'a> {
     fn try_from(msg: Message) -> Result<Self, MethodError<'a>> {
         match &msg {
             Message::StandardRequest(request) => match &request.method[..] {
+                "mining.suggest_difficulty" => {
+                    Ok(Method::Client2Server(Client2Server::SuggestDifficulty()))
+                }
                 "mining.subscribe" => {
                     let method = request
                         .clone()

--- a/protocols/v1/src/utils.rs
+++ b/protocols/v1/src/utils.rs
@@ -293,7 +293,6 @@ impl From<HexBytes> for String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck::{Arbitrary, Gen};
 
     #[quickcheck_macros::quickcheck]
     fn test_prev_hash(mut bytes: Vec<u8>) -> bool {

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -24,8 +24,7 @@ type Buffer = BufferPool<BufferFromSystemMemory>;
 #[cfg(feature = "noise_sv2")]
 use crate::error::Error;
 
-use crate::error::Result;
-use crate::Error::MissingBytes;
+use crate::{error::Result, Error::MissingBytes};
 #[cfg(feature = "noise_sv2")]
 use crate::{State, TransportMode};
 

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -21,12 +21,10 @@ use buffer_sv2::{Buffer as IsBuffer, BufferFromSystemMemory, BufferPool};
 #[cfg(feature = "with_buffer_pool")]
 type Buffer = BufferPool<BufferFromSystemMemory>;
 
-use crate::error::Result;
 #[cfg(feature = "noise_sv2")]
 use crate::error::Error;
 
-
-
+use crate::error::Result;
 use crate::Error::MissingBytes;
 #[cfg(feature = "noise_sv2")]
 use crate::{State, TransportMode};

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -21,7 +21,11 @@ use buffer_sv2::{Buffer as IsBuffer, BufferFromSystemMemory, BufferPool};
 #[cfg(feature = "with_buffer_pool")]
 type Buffer = BufferPool<BufferFromSystemMemory>;
 
-use crate::error::{Error, Result};
+use crate::error::Result;
+#[cfg(feature = "noise_sv2")]
+use crate::error::Error;
+
+
 
 use crate::Error::MissingBytes;
 #[cfg(feature = "noise_sv2")]

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -771,7 +771,8 @@ impl ChannelFactory {
 
         //if debug mode print share hash
         if tracing::log_enabled!(tracing::Level::DEBUG)
-            || tracing::level_enabled!(tracing::Level::TRACE) {
+            || tracing::level_enabled!(tracing::Level::TRACE)
+        {
             let mut print_hash = hash.clone();
             print_hash.reverse();
             debug!("Share Hash: {:?}", print_hash.to_vec().to_hex());

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -773,7 +773,7 @@ impl ChannelFactory {
         if tracing::level_enabled!(tracing::Level::DEBUG)
             || tracing::level_enabled!(tracing::Level::TRACE)
         {
-            let mut print_hash = hash.clone();
+            let mut print_hash = hash;
             print_hash.reverse();
             debug!("Share Hash: {:?}", print_hash.to_vec().to_hex());
         }

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -778,7 +778,6 @@ impl ChannelFactory {
             debug!("Share Hash: {:?}", print_hash.to_vec().to_hex());
         }
 
-
         let hash: Target = hash.into();
         if hash <= bitcoin_target {
             let coinbase = [coinbase_tx_prefix, &extranonce[..], coinbase_tx_suffix]

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -770,7 +770,7 @@ impl ChannelFactory {
         let hash = hash_.as_hash().into_inner();
 
         //if debug mode print share hash
-        if tracing::log_enabled!(tracing::Level::DEBUG)
+        if tracing::level_enabled!(tracing::Level::DEBUG)
             || tracing::level_enabled!(tracing::Level::TRACE)
         {
             let mut print_hash = hash.clone();

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -770,7 +770,8 @@ impl ChannelFactory {
         let hash = hash_.as_hash().into_inner();
 
         //if debug mode print share hash
-        if tracing::log_enabled!(tracing::Level::Debug) || tracing::level_enabled!(tracing::Level::TRACE) {
+        if tracing::log_enabled!(tracing::Level::DEBUG)
+            || tracing::level_enabled!(tracing::Level::TRACE) {
             let mut print_hash = hash.clone();
             print_hash.reverse();
             debug!("Share Hash: {:?}", print_hash.to_vec().to_hex());

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -18,10 +18,11 @@ use std::{collections::HashMap, convert::TryInto, sync::Arc};
 use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashFromTp};
 
 use bitcoin::{
-    hashes::{sha256d::Hash, Hash as Hash_},
+    hashes::{hex::ToHex, sha256d::Hash, Hash as Hash_},
     TxOut,
 };
-use tracing::error;
+
+use tracing::{debug, error};
 
 /// A stripped type of `SetCustomMiningJob` without the (`channel_id, `request_id` and `token`) fields
 pub struct PartialSetCustomMiningJob {
@@ -685,7 +686,7 @@ impl ChannelFactory {
     fn check_target(
         &mut self,
         m: Share,
-        bitcoin_target: mining_sv2::Target,
+        bitcoin_target: Target,
         template_id: Option<u64>,
         up_id: u32,
     ) -> Result<OnNewShare, Error> {
@@ -767,7 +768,15 @@ impl ChannelFactory {
         };
         let hash_ = header.block_hash();
         let hash = hash_.as_hash().into_inner();
-        tracing::debug!("Share Hash: {:?}", &hash);
+
+        //if debug mode print share hash
+        if tracing::log_enabled!(tracing::Level::Debug) || tracing::level_enabled!(tracing::Level::TRACE) {
+            let mut print_hash = hash.clone();
+            print_hash.reverse();
+            debug!("Share Hash: {:?}", print_hash.to_vec().to_hex());
+        }
+
+
         let hash: Target = hash.into();
         if hash <= bitcoin_target {
             let coinbase = [coinbase_tx_prefix, &extranonce[..], coinbase_tx_suffix]

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -170,9 +170,6 @@ use quickcheck::{Arbitrary, Gen};
 use alloc::vec;
 
 #[cfg(feature = "prop_test")]
-use core::cmp;
-
-#[cfg(feature = "prop_test")]
 impl Arbitrary for NewTemplate<'static> {
     fn arbitrary(g: &mut Gen) -> NewTemplate<'static> {
         let coinbase_tx_version = (u32::arbitrary(g) % 2) + 1;

--- a/roles/translator/proxy-config.toml
+++ b/roles/translator/proxy-config.toml
@@ -20,7 +20,7 @@ min_supported_version = 2
 # Max value: 16 (leaves 0 bytes for search space splitting of downstreams)
 # Max value for CGminer: 8
 # Min value: 2
-min_extranonce2_size = 16
+min_extranonce2_size = 8
 coinbase_reward_sat = 5_000_000_000
 
 # optional jn config, if set the tproxy start on JN mode


### PR DESCRIPTION
The whatsminer starts out with a mining.suggest_difficulty message which previously we errored on and dropped the connection. This change simply ignores the message which is sv1 spec compatible. Eventually we should implement the correct response to the message.

I also change the Share Hash output to a hex string so it's easier to look up on block explorer the block that gets confirmed.