### PR TITLE
Updated SRI codebase to work with fixed TP, Fix minor issues

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -697,28 +697,7 @@ impl ChannelFactory {
                 upstream_target, ..
             } => upstream_target.clone(),
         };
-        let _last_job_id = self
-            .last_valid_job
-            .as_ref()
-            .ok_or(Error::ShareDoNotMatchAnyJob)?
-            .0
-            .job_id;
-        // *** TODO: uncomment below after mining proxy job management is fixed
-        // if m.get_job_id() < last_job_id {
-        //     let error = SubmitSharesError {
-        //         channel_id: m.get_channel_id(),
-        //         sequence_number: m.get_sequence_number(),
-        //         // Infallible unwrap we already know the len of the error code (is a
-        //         // static string)
-        //         error_code: SubmitSharesError::stale_share_error_code()
-        //             .to_string()
-        //             .try_into()
-        //             .unwrap(),
-        //     };
-        //     return Ok(OnNewShare::SendErrorDownstream(error));
-        // } else if m.get_job_id() > last_job_id {
-        //     return Err(Error::JobNotUpdated(m.get_job_id(), last_job_id));
-        // }
+
         let (downstream_target, extranonce) = self
             .get_channel_specific_mining_info(&m)
             .ok_or(Error::ShareDoNotMatchAnyChannel)?;
@@ -1212,21 +1191,30 @@ impl ProxyExtendedChannelFactory {
     }
     /// Called only when a new template is received by a Template Provider when job negotiation is used.
     /// It creates a new custom job and calls [`ChannelFactory::on_new_extended_mining_job`]
+    #[allow(clippy::type_complexity)]
     pub fn on_new_template(
         &mut self,
         m: &mut NewTemplate<'static>,
     ) -> Result<
         (
+            // downstream job_id -> downstream message (newextjob or newjob)
             HashMap<u32, Mining<'static>>,
+            // PartialSetCustomMiningJob to send to the pool
             Option<PartialSetCustomMiningJob>,
+            // job_id registered in the channel, the one that SetNewPrevHash refer to
+            u32,
         ),
         Error,
     > {
         if let (Some(job_creator), Some(pool_coinbase_outputs)) = (
             self.job_creator.as_mut(),
-            self.pool_coinbase_outputs.as_ref(),
+            self.pool_coinbase_outputs.as_mut(),
         ) {
+            if let Some(last_pool_coinbase_output) = pool_coinbase_outputs.last_mut() {
+                last_pool_coinbase_output.value = m.coinbase_tx_value_remaining;
+            }
             let new_job = job_creator.on_new_template(m, true, pool_coinbase_outputs.clone())?;
+            let id = new_job.job_id;
             if !new_job.is_future() && self.inner.last_prev_hash.is_some() {
                 let prev_hash = self.last_prev_hash().unwrap();
                 let min_ntime = self.last_min_ntime().unwrap();
@@ -1250,13 +1238,14 @@ impl ProxyExtendedChannelFactory {
                 return Ok((
                     self.inner.on_new_extended_mining_job(new_job)?,
                     Some(custom_mining_job),
+                    id,
                 ));
             } else if new_job.is_future() {
                 self.inner
                     .future_templates
                     .insert(new_job.job_id, m.clone());
             }
-            Ok((self.inner.on_new_extended_mining_job(new_job)?, None))
+            Ok((self.inner.on_new_extended_mining_job(new_job)?, None, id))
         } else {
             panic!("Either channel factory has no job creator or pool_coinbase_outputs are not yet set")
         }

--- a/roles/translator/proxy-config.toml
+++ b/roles/translator/proxy-config.toml
@@ -21,7 +21,6 @@ min_supported_version = 2
 # Max value for CGminer: 8
 # Min value: 2
 min_extranonce2_size = 8
-coinbase_reward_sat = 5_000_000_000
 
 # optional jn config, if set the tproxy start on JN mode
 [jn_config]
@@ -41,4 +40,5 @@ shares_per_minute = 6.0
 # interval in seconds to elapse before updating channel hashrate with the pool
 channel_diff_update_interval = 60
 # estimated accumulated hashrate of all downstream miners
-channel_nominal_hashrate = 5_000_000.0
+channel_nominal_hashrate = 500.0
+

--- a/roles/translator/src/proxy/next_mining_notify.rs
+++ b/roles/translator/src/proxy/next_mining_notify.rs
@@ -12,6 +12,9 @@ pub fn create_notify(
     new_prev_hash: SetNewPrevHash<'static>,
     new_job: NewExtendedMiningJob<'static>,
 ) -> server_to_client::Notify<'static> {
+    // ATTENTION do not remove it if the tproxy have job negotiation capabilities. When we have the
+    // standalone JN and we have removed JN from tproxy we can safly delete the below line
+    let new_job = roles_logic_sv2::job_creator::extended_job_to_non_segwit(new_job, 32).unwrap();
     // Make sure that SetNewPrevHash + NewExtendedMiningJob is matching (not future)
     let job_id = new_job.job_id.to_string();
 

--- a/roles/translator/src/proxy_config.rs
+++ b/roles/translator/src/proxy_config.rs
@@ -11,7 +11,6 @@ pub struct ProxyConfig {
     pub min_supported_version: u16,
     pub min_extranonce2_size: u16,
     pub jn_config: Option<JnConfig>,
-    pub coinbase_reward_sat: u64,
     pub downstream_difficulty_config: DownstreamDifficultyConfig,
     pub upstream_difficulty_config: UpstreamDifficultyConfig,
 }

--- a/roles/v2/mining-proxy/proxy-config.toml
+++ b/roles/v2/mining-proxy/proxy-config.toml
@@ -8,5 +8,8 @@ listen_address = "127.0.0.1"
 listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
-downstream_share_per_minute = 10
+downstream_share_per_minute = 60
 coinbase_reward_sat = 5_000_000_000
+# This value is used by the proxy to communicate to the pool the expected hash rate when we open an
+# extended channel, based on it the pool will set a target for the channel
+expected_total_downstream_hr = 10_000

--- a/roles/v2/mining-proxy/src/main.rs
+++ b/roles/v2/mining-proxy/src/main.rs
@@ -139,6 +139,7 @@ pub struct Config {
     max_supported_version: u16,
     min_supported_version: u16,
     downstream_share_per_minute: f32,
+    expected_total_downstream_hr: f32,
 }
 pub async fn initialize_r_logic(
     upstreams: &[UpstreamMiningValues],
@@ -171,6 +172,7 @@ pub async fn initialize_r_logic(
             config.downstream_share_per_minute,
             None,
             None,
+            config.expected_total_downstream_hr,
         )));
 
         match upstream_.channel_kind {

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -23,7 +23,7 @@ async fn main() {
     //task::spawn(async move { connect(socket, 11070).await });
     //task::spawn(async move { connect(socket, 7040).await });
     println!("start");
-    connect(socket, 5000).await
+    connect(socket, 0).await
 }
 
 use async_channel::{Receiver, Sender};
@@ -146,8 +146,7 @@ fn open_channel() -> OpenStandardMiningChannel<'static> {
     OpenStandardMiningChannel {
         request_id: id.into(),
         user_identity,
-        // keep at a value that actually tests the device since regtest target is so low
-        nominal_hash_rate: 5.4, // change back to 100.0 so the test is valid
+        nominal_hash_rate: 100_000.0, // use 1000 or 10000 to test group channels
         max_target: u256_from_int(567_u64),
     }
 }
@@ -490,8 +489,8 @@ impl Miner {
         let hash = Uint256::from_be_bytes(hash);
         if hash < *self.target.as_ref().ok_or(())? {
             println!(
-                "Found share with nonce: {}, for target: {:?}",
-                header.nonce, self.target
+                "Found share with nonce: {}, for target: {:?}, with hash: {:?}",
+                header.nonce, self.target, hash,
             );
             Ok(())
         } else {

--- a/roles/v2/test-utils/mining-device/src/main.rs
+++ b/roles/v2/test-utils/mining-device/src/main.rs
@@ -146,7 +146,7 @@ fn open_channel() -> OpenStandardMiningChannel<'static> {
     OpenStandardMiningChannel {
         request_id: id.into(),
         user_identity,
-        nominal_hash_rate: 100_000.0, // use 1000 or 10000 to test group channels
+        nominal_hash_rate: 1000.0, // use 1000 or 10000 to test group channels
         max_target: u256_from_int(567_u64),
     }
 }

--- a/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
@@ -11,3 +11,4 @@ max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
 coinbase_reward_sat = 5_000_000_000
+expected_total_downstream_hr = 10_000

--- a/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended-jn.toml
@@ -9,6 +9,6 @@ listen_address = "127.0.0.1"
 listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
-downstream_share_per_minute = 10
+downstream_share_per_minute = 100
 coinbase_reward_sat = 5_000_000_000
 expected_total_downstream_hr = 10_000

--- a/test/config/proxy-config-test-multiple-upstreams-extended.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended.toml
@@ -12,3 +12,4 @@ max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
 coinbase_reward_sat = 5_000_000_000
+expected_total_downstream_hr = 10_000

--- a/test/config/proxy-config-test-multiple-upstreams-extended.toml
+++ b/test/config/proxy-config-test-multiple-upstreams-extended.toml
@@ -10,6 +10,6 @@ listen_address = "127.0.0.1"
 listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
-downstream_share_per_minute = 10
+downstream_share_per_minute = 100
 coinbase_reward_sat = 5_000_000_000
 expected_total_downstream_hr = 10_000

--- a/test/config/proxy-config-test-multiple-upstreams.toml
+++ b/test/config/proxy-config-test-multiple-upstreams.toml
@@ -12,3 +12,4 @@ max_supported_version = 2
 min_supported_version = 2
 downstream_share_per_minute = 10
 coinbase_reward_sat = 5_000_000_000
+expected_total_downstream_hr = 10_000

--- a/test/config/proxy-config-test-multiple-upstreams.toml
+++ b/test/config/proxy-config-test-multiple-upstreams.toml
@@ -10,6 +10,6 @@ listen_address = "127.0.0.1"
 listen_mining_port = 34255
 max_supported_version = 2
 min_supported_version = 2
-downstream_share_per_minute = 10
+downstream_share_per_minute = 100
 coinbase_reward_sat = 5_000_000_000
 expected_total_downstream_hr = 10_000

--- a/test/config/tproxy-config-no-jn-sv1-cpu-md.toml
+++ b/test/config/tproxy-config-no-jn-sv1-cpu-md.toml
@@ -35,7 +35,7 @@ min_individual_miner_hashrate=100_000.0
 # minimum number of shares needed before a mining.set_difficulty is sent for updating targets
 miner_num_submits_before_update=5
 # target number of shares per minute the miner should be sending
-shares_per_minute = 10.0
+shares_per_minute = 100.0
 
 [upstream_difficulty_config]
 # interval in seconds to elapse before updating channel hashrate with the pool

--- a/test/message-generator/test/pool-sri-test-extended_0.json
+++ b/test/message-generator/test/pool-sri-test-extended_0.json
@@ -59,14 +59,14 @@
                 },
                 {
                     "type": "match_message_type",
-                    "value": "0x20"
+                    "value": "0x1f"
                 },
                 {
                     "type": "match_message_type",
-                    "value": "0x1f"
+                    "value": "0x20"
                 }
             ],
-            "actiondoc":  "This action opens an ExtendedMiningChannel and checks that are received a .Success, SetNewPrevHash and NewExtendedMiningJob"
+            "actiondoc":  "This action opens an ExtendedMiningChannel and checks that are received a .Success, NewExtendedMiningJob and SetNewPrevHash"
        }
     ],
     "setup_commands": [


### PR DESCRIPTION
TP has been fixed so that SNPH and NEMJ messages order is no more inverted, this updated the SRI codebase to work with the new TP. Also fix JN issues in the tproxy and the minig-prox.