### PR TITLE
Make the default false for test_only_share_withhold

### DIFF
--- a/roles/translator/src/proxy_config.rs
+++ b/roles/translator/src/proxy_config.rs
@@ -13,6 +13,7 @@ pub struct ProxyConfig {
     pub jn_config: Option<JnConfig>,
     pub downstream_difficulty_config: DownstreamDifficultyConfig,
     pub upstream_difficulty_config: UpstreamDifficultyConfig,
+    #[serde(default)]
     pub test_only_share_withhold: bool,
 }
 


### PR DESCRIPTION
Proxy users shouldn't be mucking with this test only flag so let's hide it by not including it in the example config and making the default false. Without this the tproxy panics using the default example config:
`
thread 'main' panicked at 'called Result::unwrap() on an Err value: BadTomlDeserialize(Error { inner: ErrorInner { kind: Custom, line: Some(45), col: 0, at: Some(1538), message: "missing field test_only_share_withhold", key: [] } })', roles/translator/src/main.rs:49:43`