### PR TITLE
Update .codecov.yaml

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,3 +2,20 @@ coverage:
   status:
     project: off
     patch:   off
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+  # Add retry logic
+  - |
+    if [ "$?" != "0" ]; then
+      retries=0
+      until [ "$retries" -ge 5 ]
+      do
+        sleep 10
+        bash <(curl -s https://codecov.io/bash)
+        if [ "$?" = "0" ]; then
+          break
+        fi
+        retries=$((retries+1))
+      done
+    fi


### PR DESCRIPTION
This script will attempt to upload the coverage data using the Codecov Bash uploader, and if it fails (indicated by a non-zero exit status), it will retry up to 5 times with a 10 second delay between each attempt. If the upload is successful at any point during the retry loop, the loop will be terminated early.