### PR TITLE
Mg stateful tests

### DIFF
--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b032.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b032.rs
@@ -86,15 +86,19 @@ impl<'b> Serialize for B032<'b> {
         let len = self.0.len();
         let inner = self.0.as_ref();
 
-        // tuple is: (byte array len, byte array)
-        let tuple = (len, &inner);
+        if serializer.is_human_readable() {
+            serializer.serialize_bytes(inner)
+        } else {
+            // tuple is: (byte array len, byte array)
+            let tuple = (len, &inner);
 
-        let tuple_len = 2;
-        let mut seq = serializer.serialize_tuple(tuple_len)?;
+            let tuple_len = 2;
+            let mut seq = serializer.serialize_tuple(tuple_len)?;
 
-        seq.serialize_element(&tuple.0)?;
-        seq.serialize_element(tuple.1)?;
-        seq.end()
+            seq.serialize_element(&tuple.0)?;
+            seq.serialize_element(tuple.1)?;
+            seq.end()
+        }
     }
 }
 

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
@@ -431,6 +431,47 @@ impl<'s> Seq064K<'s, B064K<'s>> {
         }
     }
 }
+impl<'s> Seq064K<'s, B016M<'s>> {
+    pub fn into_static(self) -> Seq064K<'static, B016M<'static>> {
+        if let Some(inner) = self.data {
+            let inner = inner.clone();
+            let data: Vec<B016M<'static>> = inner.into_iter().map(|i| i.into_static()).collect();
+            Seq064K {
+                seq: None,
+                data: Some(data),
+            }
+        } else {
+            panic!()
+        }
+    }
+}
+impl<'s> Seq064K<'s, u32> {
+    pub fn into_static(self) -> Seq064K<'static, u32> {
+        if let Some(inner) = self.data {
+            Seq064K {
+                seq: None,
+                data: Some(inner),
+            }
+        } else {
+            panic!()
+        }
+    }
+}
+impl<'s> Seq064K<'s, ShortTxId<'s>> {
+    pub fn into_static(self) -> Seq064K<'static, ShortTxId<'static>> {
+        if let Some(inner) = self.data {
+            let inner = inner.clone();
+            let data: Vec<ShortTxId<'static>> =
+                inner.into_iter().map(|i| i.into_static()).collect();
+            Seq064K {
+                seq: None,
+                data: Some(data),
+            }
+        } else {
+            panic!()
+        }
+    }
+}
 
 impl<'de, 's, T: Clone + Serialize + Deserialize<'de> + TryFromBSlice<'s>> Seq064K<'s, T> {
     pub fn into_inner(self) -> Vec<T> {

--- a/protocols/v2/binary-sv2/serde-sv2/src/ser.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/ser.rs
@@ -51,6 +51,10 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
     type SerializeStruct = Self;
     type SerializeStructVariant = Self;
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     #[inline]
     fn serialize_bool(self, v: bool) -> Result<()> {
         match v {

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -30,3 +30,4 @@ hex = "0.4.3"
 
 [features]
 test_only_allow_unencrypted = []
+MG_reject_auth = []

--- a/test/config/tproxy-config-no-jd-sv1-cpu-md.toml
+++ b/test/config/tproxy-config-no-jd-sv1-cpu-md.toml
@@ -27,6 +27,11 @@ min_supported_version = 2
 min_extranonce2_size = 8
 coinbase_reward_sat = 5_000_000_000
 
+# optional jn config, if set the tproxy start on JN mode
+#[jn_config]
+#jn_address = "127.0.0.1:34264"
+#tp_address = "127.0.0.1:8442"
+
 # Difficulty params
 [downstream_difficulty_config]
 # hashes/s of the weakest miner that will be connecting

--- a/test/message-generator/test/pool-sri-test-close-channel.json
+++ b/test/message-generator/test/pool-sri-test-close-channel.json
@@ -86,7 +86,6 @@
                 "--",
                 "-c",
                 "./test/config/tproxy-config-no-jd-sv1-cpu-md.toml"
-
             ],
             "conditions": {
                 "WithConditions": {

--- a/test/message-generator/test/translation-proxy.json
+++ b/test/message-generator/test/translation-proxy.json
@@ -17,12 +17,13 @@
         {
             "message": {
                 "type": "OpenExtendedMiningChannelSuccess",
-                "request_id": 0,
+                "request_id": 666666,
                 "channel_id": 1,
                 "target": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255],
                 "extranonce_size": 16,
                 "extranonce_prefix": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
             },
+            "replace_fields": [["request_id","variable_name"]],
             "id": "open_extended_mining_channel_success"
         },
         {
@@ -92,14 +93,14 @@
             "role": "server",
             "results": [
                 {
-                    "type": "match_message_field",
+                    "type": "get_message_field",
                     "value": [
                         "MiningProtocol",
                         "OpenExtendedMiningChannel",
                         [
                             [
                                 "request_id",
-                                {"U32": 0}
+                                "variable_name"
                             ]
                         ]
                     ]
@@ -137,7 +138,6 @@
                         "--",
                         "-c",
                         "./test/config/tproxy-config-no-jd-sv1-cpu-md.toml"
-
             ],
             "conditions": {
                 "WithConditions": {

--- a/utils/message-generator/Cargo.lock
+++ b/utils/message-generator/Cargo.lock
@@ -12,13 +12,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
 ]
@@ -29,9 +39,9 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead",
+ "aead 0.4.3",
  "aes",
- "cipher",
+ "cipher 0.3.0",
  "ctr",
  "ghash",
  "subtle",
@@ -175,9 +185,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -186,10 +207,23 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
+ "aead 0.4.3",
+ "chacha20 0.8.2",
+ "cipher 0.3.0",
+ "poly1305 0.7.2",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -200,6 +234,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -263,6 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -272,14 +318,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -344,7 +390,7 @@ name = "ed25519-dalek"
 version = "1.0.1"
 source = "git+https://github.com/dalek-cryptography/ed25519-dalek?branch=develop#913e76fcc01f504d3d20516aa951840c44cb5046"
 dependencies = [
- "curve25519-dalek 3.2.1",
+ "curve25519-dalek 3.2.0",
  "ed25519",
  "rand",
  "serde",
@@ -430,6 +476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -631,7 +686,18 @@ checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -643,7 +709,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.1",
 ]
 
 [[package]]
@@ -735,6 +801,7 @@ version = "0.1.0"
 dependencies = [
  "binary_sv2",
  "bitcoin",
+ "chacha20poly1305 0.10.1",
  "common_messages_sv2",
  "const_sv2",
  "framing_sv2",
@@ -902,7 +969,7 @@ checksum = "12ba5f4d4ff12bdb6a169ed51b7c48c0e0ac4b0b4b31012b2571e97d78d3201d"
 dependencies = [
  "aes-gcm",
  "blake2",
- "chacha20poly1305",
+ "chacha20poly1305 0.9.1",
  "curve25519-dalek 4.0.0-rc.0",
  "rand_core 0.6.4",
  "rustc_version",
@@ -1032,6 +1099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1231,6 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/utils/message-generator/src/into_static.rs
+++ b/utils/message-generator/src/into_static.rs
@@ -1,13 +1,35 @@
-use roles_logic_sv2::{parsers::{AnyMessage, PoolMessages, CommonMessages, IsSv2Message, self}, common_messages_sv2::{SetupConnection, ChannelEndpointChanged, SetupConnectionError, SetupConnectionSuccess}, mining_sv2::{CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannel, OpenExtendedMiningChannelSuccess, OpenMiningChannelError, OpenStandardMiningChannel, OpenStandardMiningChannelSuccess, Reconnect, SetCustomMiningJob, SetCustomMiningJobError, SetCustomMiningJobSuccess, SetExtranoncePrefix, SetGroupChannel, SetNewPrevHash as MiningSetNewPrevHash, SetTarget, SubmitSharesError, SubmitSharesExtended, SubmitSharesStandard, SubmitSharesSuccess, UpdateChannel, UpdateChannelError}, job_negotiation_sv2::{AllocateMiningJobToken, AllocateMiningJobTokenSuccess, CommitMiningJob, CommitMiningJobSuccess}, template_distribution_sv2::{CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, RequestTransactionDataError, RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution}};
+use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
+use roles_logic_sv2::{
+    common_messages_sv2::{
+        ChannelEndpointChanged, SetupConnection, SetupConnectionError, SetupConnectionSuccess,
+    },
+    job_declaration_sv2::{
+        AllocateMiningJobToken, AllocateMiningJobTokenSuccess, CommitMiningJob,
+        CommitMiningJobSuccess,
+    },
+    mining_sv2::{
+        CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannel,
+        OpenExtendedMiningChannelSuccess, OpenMiningChannelError, OpenStandardMiningChannel,
+        OpenStandardMiningChannelSuccess, Reconnect, SetCustomMiningJob, SetCustomMiningJobError,
+        SetCustomMiningJobSuccess, SetExtranoncePrefix, SetGroupChannel,
+        SetNewPrevHash as MiningSetNewPrevHash, SetTarget, SubmitSharesError, SubmitSharesExtended,
+        SubmitSharesStandard, SubmitSharesSuccess, UpdateChannel, UpdateChannelError,
+    },
+    parsers::{self, AnyMessage, CommonMessages, IsSv2Message, PoolMessages},
+    template_distribution_sv2::{
+        CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, RequestTransactionDataError,
+        RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution,
+    },
+};
 
 pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
     match m {
         PoolMessages::Common(m) => match m {
-            CommonMessages::ChannelEndpointChanged(m) => {
-                PoolMessages::Common(CommonMessages::ChannelEndpointChanged(ChannelEndpointChanged {
+            CommonMessages::ChannelEndpointChanged(m) => PoolMessages::Common(
+                CommonMessages::ChannelEndpointChanged(ChannelEndpointChanged {
                     channel_id: m.channel_id,
-                }))
-            },
+                }),
+            ),
             CommonMessages::SetupConnection(m) => {
                 let m = SetupConnection {
                     protocol: m.protocol,
@@ -22,21 +44,21 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     device_id: m.device_id.into_static(),
                 };
                 PoolMessages::Common(CommonMessages::SetupConnection(m))
-            },
+            }
             CommonMessages::SetupConnectionError(m) => {
-                let m = SetupConnectionError{
+                let m = SetupConnectionError {
                     flags: m.flags,
                     error_code: m.error_code.into_static(),
                 };
                 PoolMessages::Common(CommonMessages::SetupConnectionError(m))
-            },
+            }
             CommonMessages::SetupConnectionSuccess(m) => {
                 let m = SetupConnectionSuccess {
                     used_version: m.used_version,
                     flags: m.flags,
                 };
                 PoolMessages::Common(CommonMessages::SetupConnectionSuccess(m))
-            },
+            }
         },
         PoolMessages::Mining(m) => match m {
             parsers::Mining::CloseChannel(m) => {
@@ -45,7 +67,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     reason_code: m.reason_code.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::CloseChannel(m))
-            },
+            }
             parsers::Mining::NewExtendedMiningJob(m) => {
                 let m = NewExtendedMiningJob {
                     channel_id: m.channel_id,
@@ -58,7 +80,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     coinbase_tx_suffix: m.coinbase_tx_suffix.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::NewExtendedMiningJob(m))
-            },
+            }
             parsers::Mining::NewMiningJob(m) => {
                 let m = NewMiningJob {
                     channel_id: m.channel_id,
@@ -68,7 +90,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     merkle_root: m.merkle_root.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::NewMiningJob(m))
-            },
+            }
             parsers::Mining::OpenExtendedMiningChannel(m) => {
                 let m = OpenExtendedMiningChannel {
                     request_id: m.request_id,
@@ -78,7 +100,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     min_extranonce_size: m.min_extranonce_size,
                 };
                 PoolMessages::Mining(parsers::Mining::OpenExtendedMiningChannel(m))
-            },
+            }
             parsers::Mining::OpenExtendedMiningChannelSuccess(m) => {
                 let m = OpenExtendedMiningChannelSuccess {
                     request_id: m.request_id,
@@ -88,14 +110,14 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     extranonce_prefix: m.extranonce_prefix.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::OpenExtendedMiningChannelSuccess(m))
-            },
+            }
             parsers::Mining::OpenMiningChannelError(m) => {
                 let m = OpenMiningChannelError {
                     request_id: m.request_id,
                     error_code: m.error_code.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::OpenMiningChannelError(m))
-            },
+            }
             parsers::Mining::OpenStandardMiningChannel(m) => {
                 let m = OpenStandardMiningChannel {
                     request_id: m.request_id,
@@ -104,7 +126,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     max_target: m.max_target.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::OpenStandardMiningChannel(m))
-            },
+            }
             parsers::Mining::OpenStandardMiningChannelSuccess(m) => {
                 let m = OpenStandardMiningChannelSuccess {
                     request_id: m.request_id,
@@ -114,14 +136,14 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     group_channel_id: m.group_channel_id,
                 };
                 PoolMessages::Mining(parsers::Mining::OpenStandardMiningChannelSuccess(m))
-            },
+            }
             parsers::Mining::Reconnect(m) => {
                 let m = Reconnect {
                     new_host: m.new_host.into_static(),
                     new_port: m.new_port,
                 };
                 PoolMessages::Mining(parsers::Mining::Reconnect(m))
-            },
+            }
             parsers::Mining::SetCustomMiningJob(m) => {
                 let m = SetCustomMiningJob {
                     channel_id: m.channel_id,
@@ -142,7 +164,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     future_job: m.future_job,
                 };
                 PoolMessages::Mining(parsers::Mining::SetCustomMiningJob(m))
-            },
+            }
             parsers::Mining::SetCustomMiningJobError(m) => {
                 let m = SetCustomMiningJobError {
                     channel_id: m.channel_id,
@@ -150,7 +172,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     error_code: m.error_code.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::SetCustomMiningJobError(m))
-            },
+            }
             parsers::Mining::SetCustomMiningJobSuccess(m) => {
                 let m = SetCustomMiningJobSuccess {
                     channel_id: m.channel_id,
@@ -158,21 +180,21 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     job_id: m.job_id,
                 };
                 PoolMessages::Mining(parsers::Mining::SetCustomMiningJobSuccess(m))
-            },
+            }
             parsers::Mining::SetExtranoncePrefix(m) => {
                 let m = SetExtranoncePrefix {
                     channel_id: m.channel_id,
                     extranonce_prefix: m.extranonce_prefix.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::SetExtranoncePrefix(m))
-            },
+            }
             parsers::Mining::SetGroupChannel(m) => {
                 let m = SetGroupChannel {
                     group_channel_id: m.group_channel_id,
                     channel_ids: m.channel_ids.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::SetGroupChannel(m))
-            },
+            }
             parsers::Mining::SetNewPrevHash(m) => {
                 let m = MiningSetNewPrevHash {
                     channel_id: m.channel_id,
@@ -182,14 +204,14 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     nbits: m.nbits,
                 };
                 PoolMessages::Mining(parsers::Mining::SetNewPrevHash(m))
-            },
+            }
             parsers::Mining::SetTarget(m) => {
                 let m = SetTarget {
                     channel_id: m.channel_id,
                     maximum_target: m.maximum_target.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::SetTarget(m))
-            },
+            }
             parsers::Mining::SubmitSharesError(m) => {
                 let m = SubmitSharesError {
                     channel_id: m.channel_id,
@@ -197,7 +219,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     error_code: m.error_code.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::SubmitSharesError(m))
-            },
+            }
             parsers::Mining::SubmitSharesExtended(m) => {
                 let m = SubmitSharesExtended {
                     channel_id: m.channel_id,
@@ -209,7 +231,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     extranonce: m.extranonce.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::SubmitSharesExtended(m))
-            },
+            }
             parsers::Mining::SubmitSharesStandard(m) => {
                 let m = SubmitSharesStandard {
                     channel_id: m.channel_id,
@@ -220,7 +242,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     version: m.version,
                 };
                 PoolMessages::Mining(parsers::Mining::SubmitSharesStandard(m))
-            },
+            }
             parsers::Mining::SubmitSharesSuccess(m) => {
                 let m = SubmitSharesSuccess {
                     channel_id: m.channel_id,
@@ -229,32 +251,32 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     new_shares_sum: m.new_shares_sum,
                 };
                 PoolMessages::Mining(parsers::Mining::SubmitSharesSuccess(m))
-            },
+            }
             parsers::Mining::UpdateChannel(m) => {
                 let m = UpdateChannel {
-                   channel_id: m.channel_id,
+                    channel_id: m.channel_id,
                     nominal_hash_rate: m.nominal_hash_rate,
                     maximum_target: m.maximum_target.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::UpdateChannel(m))
-            },
+            }
             parsers::Mining::UpdateChannelError(m) => {
                 let m = UpdateChannelError {
                     channel_id: m.channel_id,
                     error_code: m.error_code.into_static(),
                 };
                 PoolMessages::Mining(parsers::Mining::UpdateChannelError(m))
-            },
+            }
         },
-        PoolMessages::JobNegotiation(m) => match m {
-            parsers::JobNegotiation::AllocateMiningJobToken(m) => {
+        PoolMessages::JobDeclaration(m) => match m {
+            parsers::JobDeclaration::AllocateMiningJobToken(m) => {
                 let m = AllocateMiningJobToken {
                     user_identifier: m.user_identifier.into_static(),
                     request_id: m.request_id,
                 };
-                PoolMessages::JobNegotiation(parsers::JobNegotiation::AllocateMiningJobToken(m))
-            },
-            parsers::JobNegotiation::AllocateMiningJobTokenSuccess(m) => {
+                PoolMessages::JobDeclaration(parsers::JobDeclaration::AllocateMiningJobToken(m))
+            }
+            parsers::JobDeclaration::AllocateMiningJobTokenSuccess(m) => {
                 let m = AllocateMiningJobTokenSuccess {
                     request_id: m.request_id,
                     mining_job_token: m.mining_job_token.into_static(),
@@ -262,9 +284,11 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     coinbase_output: m.coinbase_output.into_static(),
                     async_mining_allowed: m.async_mining_allowed,
                 };
-                PoolMessages::JobNegotiation(parsers::JobNegotiation::AllocateMiningJobTokenSuccess(m))
-            },
-            parsers::JobNegotiation::CommitMiningJob(m) => {
+                PoolMessages::JobDeclaration(
+                    parsers::JobDeclaration::AllocateMiningJobTokenSuccess(m),
+                )
+            }
+            parsers::JobDeclaration::CommitMiningJob(m) => {
                 let m = CommitMiningJob {
                     request_id: m.request_id,
                     mining_job_token: m.mining_job_token.into_static(),
@@ -280,24 +304,27 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     tx_short_hash_list: m.tx_short_hash_list.into_static(),
                     tx_hash_list_hash: m.tx_hash_list_hash.into_static(),
                     excess_data: m.excess_data.into_static(),
+                    merkle_path: m.merkle_path.into_static(),
                 };
-                PoolMessages::JobNegotiation(parsers::JobNegotiation::CommitMiningJob(m))
-            },
-            parsers::JobNegotiation::CommitMiningJobSuccess(m) => {
+                PoolMessages::JobDeclaration(parsers::JobDeclaration::CommitMiningJob(m))
+            }
+            parsers::JobDeclaration::CommitMiningJobSuccess(m) => {
                 let m = CommitMiningJobSuccess {
                     request_id: m.request_id,
                     new_mining_job_token: m.new_mining_job_token.into_static(),
                 };
-                PoolMessages::JobNegotiation(parsers::JobNegotiation::CommitMiningJobSuccess(m))
-            },
+                PoolMessages::JobDeclaration(parsers::JobDeclaration::CommitMiningJobSuccess(m))
+            }
         },
         PoolMessages::TemplateDistribution(m) => match m {
             parsers::TemplateDistribution::CoinbaseOutputDataSize(m) => {
                 let m = CoinbaseOutputDataSize {
                     coinbase_output_max_additional_size: m.coinbase_output_max_additional_size,
                 };
-                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::CoinbaseOutputDataSize(m))
-            },
+                PoolMessages::TemplateDistribution(
+                    parsers::TemplateDistribution::CoinbaseOutputDataSize(m),
+                )
+            }
             parsers::TemplateDistribution::NewTemplate(m) => {
                 let m = NewTemplate {
                     template_id: m.template_id,
@@ -313,28 +340,34 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     merkle_path: m.merkle_path.into_static(),
                 };
                 PoolMessages::TemplateDistribution(parsers::TemplateDistribution::NewTemplate(m))
-            },
+            }
             parsers::TemplateDistribution::RequestTransactionData(m) => {
                 let m = RequestTransactionData {
                     template_id: m.template_id,
                 };
-                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::RequestTransactionData(m))
-            },
+                PoolMessages::TemplateDistribution(
+                    parsers::TemplateDistribution::RequestTransactionData(m),
+                )
+            }
             parsers::TemplateDistribution::RequestTransactionDataError(m) => {
                 let m = RequestTransactionDataError {
                     template_id: m.template_id,
                     error_code: m.error_code.into_static(),
                 };
-                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::RequestTransactionDataError(m))
-            },
+                PoolMessages::TemplateDistribution(
+                    parsers::TemplateDistribution::RequestTransactionDataError(m),
+                )
+            }
             parsers::TemplateDistribution::RequestTransactionDataSuccess(m) => {
                 let m = RequestTransactionDataSuccess {
                     template_id: m.template_id,
                     excess_data: m.excess_data.into_static(),
                     transaction_list: m.transaction_list.into_static(), // TODO! DA RIVEDERE!
                 };
-                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::RequestTransactionDataSuccess(m))
-            },
+                PoolMessages::TemplateDistribution(
+                    parsers::TemplateDistribution::RequestTransactionDataSuccess(m),
+                )
+            }
             parsers::TemplateDistribution::SetNewPrevHash(m) => {
                 let m = roles_logic_sv2::template_distribution_sv2::SetNewPrevHash {
                     template_id: m.template_id,
@@ -344,7 +377,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     target: m.target.into_static(),
                 };
                 PoolMessages::TemplateDistribution(parsers::TemplateDistribution::SetNewPrevHash(m))
-            },
+            }
             parsers::TemplateDistribution::SubmitSolution(m) => {
                 let m = SubmitSolution {
                     template_id: m.template_id,
@@ -354,7 +387,7 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     coinbase_tx: m.coinbase_tx.into_static(),
                 };
                 PoolMessages::TemplateDistribution(parsers::TemplateDistribution::SubmitSolution(m))
-            },
+            }
         },
     }
 }

--- a/utils/message-generator/src/into_static.rs
+++ b/utils/message-generator/src/into_static.rs
@@ -1,0 +1,360 @@
+use roles_logic_sv2::{parsers::{AnyMessage, PoolMessages, CommonMessages, IsSv2Message, self}, common_messages_sv2::{SetupConnection, ChannelEndpointChanged, SetupConnectionError, SetupConnectionSuccess}, mining_sv2::{CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannel, OpenExtendedMiningChannelSuccess, OpenMiningChannelError, OpenStandardMiningChannel, OpenStandardMiningChannelSuccess, Reconnect, SetCustomMiningJob, SetCustomMiningJobError, SetCustomMiningJobSuccess, SetExtranoncePrefix, SetGroupChannel, SetNewPrevHash as MiningSetNewPrevHash, SetTarget, SubmitSharesError, SubmitSharesExtended, SubmitSharesStandard, SubmitSharesSuccess, UpdateChannel, UpdateChannelError}, job_negotiation_sv2::{AllocateMiningJobToken, AllocateMiningJobTokenSuccess, CommitMiningJob, CommitMiningJobSuccess}, template_distribution_sv2::{CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, RequestTransactionDataError, RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution}};
+
+pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
+    match m {
+        PoolMessages::Common(m) => match m {
+            CommonMessages::ChannelEndpointChanged(m) => {
+                PoolMessages::Common(CommonMessages::ChannelEndpointChanged(ChannelEndpointChanged {
+                    channel_id: m.channel_id,
+                }))
+            },
+            CommonMessages::SetupConnection(m) => {
+                let m = SetupConnection {
+                    protocol: m.protocol,
+                    min_version: m.min_version,
+                    max_version: m.max_version,
+                    flags: m.flags,
+                    endpoint_host: m.endpoint_host.into_static(),
+                    endpoint_port: m.endpoint_port,
+                    vendor: m.vendor.into_static(),
+                    hardware_version: m.hardware_version.into_static(),
+                    firmware: m.firmware.into_static(),
+                    device_id: m.device_id.into_static(),
+                };
+                PoolMessages::Common(CommonMessages::SetupConnection(m))
+            },
+            CommonMessages::SetupConnectionError(m) => {
+                let m = SetupConnectionError{
+                    flags: m.flags,
+                    error_code: m.error_code.into_static(),
+                };
+                PoolMessages::Common(CommonMessages::SetupConnectionError(m))
+            },
+            CommonMessages::SetupConnectionSuccess(m) => {
+                let m = SetupConnectionSuccess {
+                    used_version: m.used_version,
+                    flags: m.flags,
+                };
+                PoolMessages::Common(CommonMessages::SetupConnectionSuccess(m))
+            },
+        },
+        PoolMessages::Mining(m) => match m {
+            parsers::Mining::CloseChannel(m) => {
+                let m = CloseChannel {
+                    channel_id: m.channel_id,
+                    reason_code: m.reason_code.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::CloseChannel(m))
+            },
+            parsers::Mining::NewExtendedMiningJob(m) => {
+                let m = NewExtendedMiningJob {
+                    channel_id: m.channel_id,
+                    job_id: m.job_id,
+                    min_ntime: m.min_ntime.into_static(),
+                    version: m.version,
+                    version_rolling_allowed: m.version_rolling_allowed,
+                    merkle_path: m.merkle_path.into_static(),
+                    coinbase_tx_prefix: m.coinbase_tx_prefix.into_static(),
+                    coinbase_tx_suffix: m.coinbase_tx_suffix.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::NewExtendedMiningJob(m))
+            },
+            parsers::Mining::NewMiningJob(m) => {
+                let m = NewMiningJob {
+                    channel_id: m.channel_id,
+                    job_id: m.job_id,
+                    min_ntime: m.min_ntime.into_static(),
+                    version: m.version,
+                    merkle_root: m.merkle_root.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::NewMiningJob(m))
+            },
+            parsers::Mining::OpenExtendedMiningChannel(m) => {
+                let m = OpenExtendedMiningChannel {
+                    request_id: m.request_id,
+                    user_identity: m.user_identity.into_static(),
+                    nominal_hash_rate: m.nominal_hash_rate,
+                    max_target: m.max_target.into_static(),
+                    min_extranonce_size: m.min_extranonce_size,
+                };
+                PoolMessages::Mining(parsers::Mining::OpenExtendedMiningChannel(m))
+            },
+            parsers::Mining::OpenExtendedMiningChannelSuccess(m) => {
+                let m = OpenExtendedMiningChannelSuccess {
+                    request_id: m.request_id,
+                    channel_id: m.channel_id,
+                    target: m.target.into_static(),
+                    extranonce_size: m.extranonce_size,
+                    extranonce_prefix: m.extranonce_prefix.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::OpenExtendedMiningChannelSuccess(m))
+            },
+            parsers::Mining::OpenMiningChannelError(m) => {
+                let m = OpenMiningChannelError {
+                    request_id: m.request_id,
+                    error_code: m.error_code.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::OpenMiningChannelError(m))
+            },
+            parsers::Mining::OpenStandardMiningChannel(m) => {
+                let m = OpenStandardMiningChannel {
+                    request_id: m.request_id,
+                    user_identity: m.user_identity.into_static(),
+                    nominal_hash_rate: m.nominal_hash_rate,
+                    max_target: m.max_target.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::OpenStandardMiningChannel(m))
+            },
+            parsers::Mining::OpenStandardMiningChannelSuccess(m) => {
+                let m = OpenStandardMiningChannelSuccess {
+                    request_id: m.request_id,
+                    channel_id: m.channel_id,
+                    target: m.target.into_static(),
+                    extranonce_prefix: m.extranonce_prefix.into_static(),
+                    group_channel_id: m.group_channel_id,
+                };
+                PoolMessages::Mining(parsers::Mining::OpenStandardMiningChannelSuccess(m))
+            },
+            parsers::Mining::Reconnect(m) => {
+                let m = Reconnect {
+                    new_host: m.new_host.into_static(),
+                    new_port: m.new_port,
+                };
+                PoolMessages::Mining(parsers::Mining::Reconnect(m))
+            },
+            parsers::Mining::SetCustomMiningJob(m) => {
+                let m = SetCustomMiningJob {
+                    channel_id: m.channel_id,
+                    request_id: m.request_id,
+                    token: m.token.into_static(),
+                    version: m.version,
+                    prev_hash: m.prev_hash.into_static(),
+                    min_ntime: m.min_ntime,
+                    nbits: m.nbits,
+                    coinbase_tx_version: m.coinbase_tx_version,
+                    coinbase_prefix: m.coinbase_prefix.into_static(),
+                    coinbase_tx_input_n_sequence: m.coinbase_tx_input_n_sequence,
+                    coinbase_tx_value_remaining: m.coinbase_tx_value_remaining,
+                    coinbase_tx_outputs: m.coinbase_tx_outputs.into_static(),
+                    coinbase_tx_locktime: m.coinbase_tx_locktime,
+                    merkle_path: m.merkle_path.into_static(),
+                    extranonce_size: m.extranonce_size,
+                    future_job: m.future_job,
+                };
+                PoolMessages::Mining(parsers::Mining::SetCustomMiningJob(m))
+            },
+            parsers::Mining::SetCustomMiningJobError(m) => {
+                let m = SetCustomMiningJobError {
+                    channel_id: m.channel_id,
+                    request_id: m.request_id,
+                    error_code: m.error_code.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::SetCustomMiningJobError(m))
+            },
+            parsers::Mining::SetCustomMiningJobSuccess(m) => {
+                let m = SetCustomMiningJobSuccess {
+                    channel_id: m.channel_id,
+                    request_id: m.request_id,
+                    job_id: m.job_id,
+                };
+                PoolMessages::Mining(parsers::Mining::SetCustomMiningJobSuccess(m))
+            },
+            parsers::Mining::SetExtranoncePrefix(m) => {
+                let m = SetExtranoncePrefix {
+                    channel_id: m.channel_id,
+                    extranonce_prefix: m.extranonce_prefix.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::SetExtranoncePrefix(m))
+            },
+            parsers::Mining::SetGroupChannel(m) => {
+                let m = SetGroupChannel {
+                    group_channel_id: m.group_channel_id,
+                    channel_ids: m.channel_ids.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::SetGroupChannel(m))
+            },
+            parsers::Mining::SetNewPrevHash(m) => {
+                let m = MiningSetNewPrevHash {
+                    channel_id: m.channel_id,
+                    job_id: m.job_id,
+                    prev_hash: m.prev_hash.into_static(),
+                    min_ntime: m.min_ntime,
+                    nbits: m.nbits,
+                };
+                PoolMessages::Mining(parsers::Mining::SetNewPrevHash(m))
+            },
+            parsers::Mining::SetTarget(m) => {
+                let m = SetTarget {
+                    channel_id: m.channel_id,
+                    maximum_target: m.maximum_target.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::SetTarget(m))
+            },
+            parsers::Mining::SubmitSharesError(m) => {
+                let m = SubmitSharesError {
+                    channel_id: m.channel_id,
+                    sequence_number: m.sequence_number,
+                    error_code: m.error_code.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::SubmitSharesError(m))
+            },
+            parsers::Mining::SubmitSharesExtended(m) => {
+                let m = SubmitSharesExtended {
+                    channel_id: m.channel_id,
+                    sequence_number: m.sequence_number,
+                    job_id: m.job_id,
+                    nonce: m.nonce,
+                    ntime: m.ntime,
+                    version: m.version,
+                    extranonce: m.extranonce.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::SubmitSharesExtended(m))
+            },
+            parsers::Mining::SubmitSharesStandard(m) => {
+                let m = SubmitSharesStandard {
+                    channel_id: m.channel_id,
+                    sequence_number: m.sequence_number,
+                    job_id: m.job_id,
+                    nonce: m.nonce,
+                    ntime: m.ntime,
+                    version: m.version,
+                };
+                PoolMessages::Mining(parsers::Mining::SubmitSharesStandard(m))
+            },
+            parsers::Mining::SubmitSharesSuccess(m) => {
+                let m = SubmitSharesSuccess {
+                    channel_id: m.channel_id,
+                    last_sequence_number: m.last_sequence_number,
+                    new_submits_accepted_count: m.new_submits_accepted_count,
+                    new_shares_sum: m.new_shares_sum,
+                };
+                PoolMessages::Mining(parsers::Mining::SubmitSharesSuccess(m))
+            },
+            parsers::Mining::UpdateChannel(m) => {
+                let m = UpdateChannel {
+                   channel_id: m.channel_id,
+                    nominal_hash_rate: m.nominal_hash_rate,
+                    maximum_target: m.maximum_target.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::UpdateChannel(m))
+            },
+            parsers::Mining::UpdateChannelError(m) => {
+                let m = UpdateChannelError {
+                    channel_id: m.channel_id,
+                    error_code: m.error_code.into_static(),
+                };
+                PoolMessages::Mining(parsers::Mining::UpdateChannelError(m))
+            },
+        },
+        PoolMessages::JobNegotiation(m) => match m {
+            parsers::JobNegotiation::AllocateMiningJobToken(m) => {
+                let m = AllocateMiningJobToken {
+                    user_identifier: m.user_identifier.into_static(),
+                    request_id: m.request_id,
+                };
+                PoolMessages::JobNegotiation(parsers::JobNegotiation::AllocateMiningJobToken(m))
+            },
+            parsers::JobNegotiation::AllocateMiningJobTokenSuccess(m) => {
+                let m = AllocateMiningJobTokenSuccess {
+                    request_id: m.request_id,
+                    mining_job_token: m.mining_job_token.into_static(),
+                    coinbase_output_max_additional_size: m.coinbase_output_max_additional_size,
+                    coinbase_output: m.coinbase_output.into_static(),
+                    async_mining_allowed: m.async_mining_allowed,
+                };
+                PoolMessages::JobNegotiation(parsers::JobNegotiation::AllocateMiningJobTokenSuccess(m))
+            },
+            parsers::JobNegotiation::CommitMiningJob(m) => {
+                let m = CommitMiningJob {
+                    request_id: m.request_id,
+                    mining_job_token: m.mining_job_token.into_static(),
+                    version: m.version,
+                    coninbase_tx_version: m.coninbase_tx_version,
+                    coninbase_prefix: m.coninbase_prefix.into_static(),
+                    coninbase_tx_input_nsequence: m.coninbase_tx_input_nsequence,
+                    coninbase_tx_value_remaining: m.coninbase_tx_value_remaining,
+                    coinbase_tx_outputs: m.coinbase_tx_outputs.into_static(),
+                    coinbase_tx_locktime: m.coinbase_tx_locktime,
+                    min_extranonce_size: m.min_extranonce_size,
+                    tx_short_hash_nonce: m.tx_short_hash_nonce,
+                    tx_short_hash_list: m.tx_short_hash_list.into_static(),
+                    tx_hash_list_hash: m.tx_hash_list_hash.into_static(),
+                    excess_data: m.excess_data.into_static(),
+                };
+                PoolMessages::JobNegotiation(parsers::JobNegotiation::CommitMiningJob(m))
+            },
+            parsers::JobNegotiation::CommitMiningJobSuccess(m) => {
+                let m = CommitMiningJobSuccess {
+                    request_id: m.request_id,
+                    new_mining_job_token: m.new_mining_job_token.into_static(),
+                };
+                PoolMessages::JobNegotiation(parsers::JobNegotiation::CommitMiningJobSuccess(m))
+            },
+        },
+        PoolMessages::TemplateDistribution(m) => match m {
+            parsers::TemplateDistribution::CoinbaseOutputDataSize(m) => {
+                let m = CoinbaseOutputDataSize {
+                    coinbase_output_max_additional_size: m.coinbase_output_max_additional_size,
+                };
+                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::CoinbaseOutputDataSize(m))
+            },
+            parsers::TemplateDistribution::NewTemplate(m) => {
+                let m = NewTemplate {
+                    template_id: m.template_id,
+                    future_template: m.future_template,
+                    version: m.version,
+                    coinbase_tx_version: m.coinbase_tx_version,
+                    coinbase_prefix: m.coinbase_prefix.into_static(),
+                    coinbase_tx_input_sequence: m.coinbase_tx_input_sequence,
+                    coinbase_tx_value_remaining: m.coinbase_tx_value_remaining,
+                    coinbase_tx_outputs_count: m.coinbase_tx_outputs_count,
+                    coinbase_tx_outputs: m.coinbase_tx_outputs.into_static(),
+                    coinbase_tx_locktime: m.coinbase_tx_locktime,
+                    merkle_path: m.merkle_path.into_static(),
+                };
+                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::NewTemplate(m))
+            },
+            parsers::TemplateDistribution::RequestTransactionData(m) => {
+                let m = RequestTransactionData {
+                    template_id: m.template_id,
+                };
+                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::RequestTransactionData(m))
+            },
+            parsers::TemplateDistribution::RequestTransactionDataError(m) => {
+                let m = RequestTransactionDataError {
+                    template_id: m.template_id,
+                    error_code: m.error_code.into_static(),
+                };
+                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::RequestTransactionDataError(m))
+            },
+            parsers::TemplateDistribution::RequestTransactionDataSuccess(m) => {
+                let m = RequestTransactionDataSuccess {
+                    template_id: m.template_id,
+                    excess_data: m.excess_data.into_static(),
+                    transaction_list: m.transaction_list.into_static(), // TODO! DA RIVEDERE!
+                };
+                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::RequestTransactionDataSuccess(m))
+            },
+            parsers::TemplateDistribution::SetNewPrevHash(m) => {
+                let m = roles_logic_sv2::template_distribution_sv2::SetNewPrevHash {
+                    template_id: m.template_id,
+                    prev_hash: m.prev_hash.into_static(),
+                    header_timestamp: m.header_timestamp,
+                    n_bits: m.n_bits,
+                    target: m.target.into_static(),
+                };
+                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::SetNewPrevHash(m))
+            },
+            parsers::TemplateDistribution::SubmitSolution(m) => {
+                let m = SubmitSolution {
+                    template_id: m.template_id,
+                    version: m.version,
+                    header_timestamp: m.header_timestamp,
+                    header_nonce: m.header_nonce,
+                    coinbase_tx: m.coinbase_tx.into_static(),
+                };
+                PoolMessages::TemplateDistribution(parsers::TemplateDistribution::SubmitSolution(m))
+            },
+        },
+    }
+}

--- a/utils/message-generator/src/parser/frames.rs
+++ b/utils/message-generator/src/parser/frames.rs
@@ -9,9 +9,16 @@ pub struct Frames<'a> {
 }
 
 impl<'a> Frames<'a> {
-    pub fn from_step_1<'b: 'a>(test: &'b str, messages: HashMap<String, AnyMessage<'a>>) -> Self {
+    pub fn from_step_1<'b: 'a>(
+        test: &'b str,
+        messages: HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>,
+    ) -> (
+        Self,
+        HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>,
+    ) {
         let test: Map<String, Value> = serde_json::from_str(test).unwrap();
         let frames = test.get("frame_builders").unwrap().as_array().unwrap();
+        let mut messages = messages.clone();
 
         let mut result = HashMap::new();
         for frame in frames {
@@ -33,17 +40,20 @@ impl<'a> Frames<'a> {
                     messages
                         .get(&id[0])
                         .unwrap_or_else(|| panic!("Missing messages message_id {}", id[0]))
+                        .0
                         .clone(),
                     id[0].clone(),
                 ),
                 2 => {
-                    /// the function "message_from_id" returns a an AnyMessage from the path in
-                    /// input
+                    // the function "message_from_id" returns a an AnyMessage from the path in
+                    // input
                     let mut path = id[0].clone();
                     std::string::String::insert_str(&mut path, 0, "../../../../");
                     let message = message_from_path(&vec![path, id[1].clone()]);
-                    let id = id[1].clone();
-                    (message, id)
+                    // TODO: if a message is taken from a module, should it be allowed to have a
+                    // replace_fields? perhaps not. In this case, check that no replace_field appears in message
+                    messages.insert(id[1].clone(), (message.clone(), vec![]));
+                    (message, id[1].clone())
                 }
                 _ => panic!("The length if id vector should have length equal or less than 2"),
             };
@@ -72,6 +82,6 @@ impl<'a> Frames<'a> {
                 _ => panic!("Unrecognized frames parsing type {}", type_),
             }
         }
-        Frames { frames: result }
+        (Frames { frames: result }, messages)
     }
 }


### PR DESCRIPTION


###    Fix feature on the pool

    In test pool-sri-test-reject-auth.json the pool is launched with the
    ferature MG-reject-auth. A little modification to the pool toml is added
    to make this feature work and the test pass.


###   Stateful test works

    The test translation-proxy.json has a OpenExtendedMiningChannelSuccess
    message with request_id = 666.i If you run it, you see that the message
    is sent with the request_id field that is equal to the same field in the
    message OpenExtendedMiningChannel previously received, namely 0.
    This is done by a
    a field "replace_fields" in the json test message. Replace fields is a
    vector of objects of type ("field", "variable_name"). In this case, it is
    just ("request_id", "variable_name"). In the actions, there is a new action
    result called GetMessageField. This result is defined by a SV2 protocol, a
    message_type and a vector of element of the form ("field", "variable_name").
    Then it stores value = "field" and key = "variable_name" in an HashMap(key,
    value). When a message non-empty replace field is sent, then the message
    retrives from the HasMap the field values through the keys, that are the
    second components of the elements of the vectors replace_fields.
    So
    GetMessageField --> HashMap(key, field_value) taken from a received message
    Before sending a message, checks that for every ("field", "variable_name") there
    there is some "field_value" for the key "variable_name" in the HasMap, so that in
    the message that is going to be sent, the "field" is updated with "field_value".
    
    
###   into_static function

    a new file into_static.rs there is defined a new function called
    into_static that transforms an Anymessage<'a> into a owned
    Anymessage<'static>


###   into_static function for primitives

    Implementation of into static for Seq064<'s, T>, with T is B016M, u32, ShortTxId.
    For B032 it is necessary to distinguish between human readable or not
    1) Rust internal representation --> binary: not human readable
    2) Rust internal representation --> json: human readable
    In order to change a sv2-message in the MG, it has to be converted in
    serde_json::Value, modified, then in string and then deserialized again in a
    sv2-message. Without this modification, the B032 is transformed in an
    array in which the first element in the lenght of the vector that is in
    the second element. This made impossible to deserialise the modified
    message as string.

