### PR TITLE
Mg replacefield struct and code tests

### DIFF
--- a/test/message-generator/test/translation-proxy.json
+++ b/test/message-generator/test/translation-proxy.json
@@ -12,18 +12,27 @@
         "You can use any miner you want, by changing the execution command or by launching it separately"
     ],
     "common_messages": [
+        {
+            "message": {
+                "type": "SetupConnectionSuccess",
+                "flags": 300,
+                "used_version": 180
+            },
+            "replace_fields": [["flags", "setup_connection_success_flag"],["used_version", "setup_connection_success_used_version"]],
+            "id": "setup_connection_success_tproxy"
+        }
     ],
     "mining_messages": [
         {
             "message": {
                 "type": "OpenExtendedMiningChannelSuccess",
-                "request_id": 666666,
+                "request_id": 666,
                 "channel_id": 1,
-                "target": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255],
+                "target": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 55, 55, 55, 55, 25, 25, 0, 0],
                 "extranonce_size": 16,
                 "extranonce_prefix": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
             },
-            "replace_fields": [["request_id","variable_name"]],
+            "replace_fields": [["request_id","open_extended_mining_channel_success_request_id"], ["target", "open_extended_mining_channel_success_target"]],
             "id": "open_extended_mining_channel_success"
         },
         {
@@ -76,8 +85,21 @@
             "role": "server",
             "results": [
                 {
-                    "type": "match_message_type",
-                    "value": "0x00"
+                    "type": "get_message_field",
+                    "value": [
+                        "CommonMessages",
+                        "SetupConnection",
+                        [
+                            [
+                                "flags",
+                                "setup_connection_success_flag"
+                            ],
+                            [
+                                "min_version",
+                                "setup_connection_success_used_version"
+                            ]
+                        ]
+                    ]
                 }
             ],
             "actiondoc": "This action checks that a Setupconnection message is received"
@@ -100,7 +122,11 @@
                         [
                             [
                                 "request_id",
-                                "variable_name"
+                                "open_extended_mining_channel_success_request_id"
+                            ],
+                            [
+                                "max_target",
+                                "open_extended_mining_channel_success_target"
                             ]
                         ]
                     ]

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -3,7 +3,7 @@ use crate::{
     into_static::into_static,
     net::{setup_as_downstream, setup_as_upstream},
     parser::sv2_messages::ReplaceField,
-    Action, ActionResult, Command, Role, Sv2Type, Test,
+    Action, ActionResult, Command, Role, SaveField, Sv2Type, Test,
 };
 use async_channel::{Receiver, Sender};
 use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
@@ -977,11 +977,11 @@ fn change_value_of_serde_field(
 fn save_message_field(
     mess: serde_json::Value,
     mut save: HashMap<String, String>,
-    fields: &Vec<(String, String)>,
+    fields: &Vec<SaveField>,
 ) -> HashMap<String, String> {
     for field in fields {
-        let key = field.1.clone();
-        let field_name = &field.0;
+        let key = field.keyword.clone();
+        let field_name = &field.field_name;
         let to_save = message_to_value(&mess, field_name);
         save.insert(key, to_save);
     }

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -2,7 +2,7 @@ use crate::{
     external_commands::os_command,
     into_static::into_static,
     net::{setup_as_downstream, setup_as_upstream},
-    Action, ActionResult, Command, Role, Sv2Type, Test,
+    Action, ActionResult, Command, Role, Sv2Type, Test, parser::sv2_messages::ReplaceField,
 };
 use async_channel::{Receiver, Sender};
 use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
@@ -808,15 +808,15 @@ impl Executor {
 
 fn change_fields<'a>(
     m: AnyMessage<'a>,
-    replace_fields: Vec<(String, String)>,
+    replace_fields: Vec<ReplaceField>,
     values: HashMap<String, String>,
 ) -> AnyMessage<'static> {
     let mut replace_fields = replace_fields.clone();
     let next = replace_fields
         .pop()
         .expect("replace_fields cannot be empty");
-    let keyword = next.1;
-    let field_name = next.0;
+    let keyword = next.keyword;
+    let field_name = next.field_name;
     let value = values
         .get(&keyword)
         .expect("value not found for the keyword");

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -8,36 +8,12 @@ use crate::{
 use async_channel::{Receiver, Sender};
 use binary_sv2::Serialize;
 use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
-use roles_logic_sv2::{
-    common_messages_sv2::{
-        ChannelEndpointChanged, SetupConnection, SetupConnectionError, SetupConnectionSuccess,
-    },
-    job_declaration_sv2::{
-        AllocateMiningJobToken, AllocateMiningJobTokenSuccess, CommitMiningJob,
-        CommitMiningJobSuccess,
-    },
-    mining_sv2::{
-        CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannel,
-        OpenExtendedMiningChannelSuccess, OpenMiningChannelError, OpenStandardMiningChannel,
-        OpenStandardMiningChannelSuccess, Reconnect, SetCustomMiningJob, SetCustomMiningJobError,
-        SetCustomMiningJobSuccess, SetExtranoncePrefix, SetGroupChannel,
-        SetNewPrevHash as MiningSetNewPrevHash, SetTarget, SubmitSharesError, SubmitSharesExtended,
-        SubmitSharesStandard, SubmitSharesSuccess, UpdateChannel, UpdateChannelError,
-    },
-    parsers::{self, AnyMessage, CommonMessages, IsSv2Message, PoolMessages},
-    template_distribution_sv2::{
-        CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, RequestTransactionDataError,
-        RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution,
-    },
-};
-use serde_json::json;
+use roles_logic_sv2::parsers::{self, AnyMessage};
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
 
-use std::time::Duration;
 use tokio::{
     fs::File,
     io::{copy, BufReader, BufWriter},
-    time::timeout,
 };
 
 pub struct Executor {
@@ -54,7 +30,7 @@ pub struct Executor {
 
 impl Executor {
     pub async fn new(test: Test<'static>, test_name: String) -> Executor {
-        let mut save: HashMap<String, serde_json::Value> = HashMap::new();
+        let save: HashMap<String, serde_json::Value> = HashMap::new();
         let mut process: Vec<Option<tokio::process::Child>> = vec![];
         for command in test.setup_commmands {
             if command.command == "kill" {
@@ -235,8 +211,6 @@ impl Executor {
                 println!("RECV {:#?}", message);
                 let header = message.get_header().unwrap();
                 let payload = message.payload();
-                let mut message_hashmap: HashMap<std::string::String, PoolMessages<'static>> =
-                    HashMap::new();
                 match result {
                     ActionResult::MatchMessageType(message_type) => {
                         if header.msg_type() != *message_type {
@@ -260,25 +234,25 @@ impl Executor {
                             match (header.msg_type(), payload).try_into() {
                                 Ok(roles_logic_sv2::parsers::CommonMessages::SetupConnection(m)) => {
                                     if message_type.as_str() == "SetupConnection" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::CommonMessages::SetupConnectionError(m)) => {
                                     if message_type.as_str() == "SetupConnectionError" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::CommonMessages::SetupConnectionSuccess(m)) => {
                                     if message_type.as_str() == "SetupConnectionSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::CommonMessages::ChannelEndpointChanged(m)) => {
                                     if message_type.as_str() == "ChannelEndpointChanged" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
@@ -288,133 +262,133 @@ impl Executor {
                             match (header.msg_type(), payload).try_into() {
                                 Ok(roles_logic_sv2::parsers::Mining::OpenExtendedMiningChannel(m)) => {
                                     if message_type.as_str() == "OpenExtendedMiningChannel" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::OpenStandardMiningChannel(m)) => {
                                     if message_type.as_str() == "OpenStandardMiningChannel" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::OpenStandardMiningChannelSuccess(m)) => {
                                     if message_type.as_str() == "OpenStandardMiningChannelSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::CloseChannel(m)) => {
                                     if message_type.as_str() == "CloseChannel" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::NewMiningJob(m)) => {
                                     if message_type.as_str() == "NewMiningJob" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::NewExtendedMiningJob(m)) => {
                                     if message_type.as_str() == "NewExtendedMiningJob" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SetTarget(m)) => {
                                     if message_type.as_str() == "SetTarget" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SubmitSharesError(m)) => {
                                     if message_type.as_str() == "SubmitSharesError" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SubmitSharesStandard(m)) => {
                                     if message_type.as_str() == "SubmitSharesStandard" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SubmitSharesSuccess(m)) => {
                                     if message_type.as_str() == "SubmitSharesSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SubmitSharesExtended(m)) => {
                                     if message_type.as_str() == "SubmitSharesExtended" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SetCustomMiningJob(m)) => {
                                     if message_type.as_str() == "SetCustomMiningJob" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SetCustomMiningJobError(m)) => {
                                     if message_type.as_str() == "SetCustomMiningJobError" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::OpenExtendedMiningChannelSuccess(m)) => {
                                     if message_type.as_str() == "OpenExtendedMiningChannelSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::OpenMiningChannelError(m)) => {
                                     if message_type.as_str() == "OpenMiningChannelError" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::Reconnect(m)) => {
                                     if message_type.as_str() == "Reconnect" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SetCustomMiningJobSuccess(m)) => {
                                     if message_type.as_str() == "SetCustomMiningJobSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SetExtranoncePrefix(m)) => {
                                     if message_type.as_str() == "SetExtranoncePrefix" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SetGroupChannel(m)) => {
                                     if message_type.as_str() == "SetGroupChannel" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::SetNewPrevHash(m)) => {
                                     if message_type.as_str() == "SetNewPrevHash" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::UpdateChannel(m)) => {
                                     if message_type.as_str() == "UpdateChannel" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::Mining::UpdateChannelError(m)) => {
                                     if message_type.as_str() == "UpdateChannelError" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
@@ -424,25 +398,25 @@ impl Executor {
                             match (header.msg_type(), payload).try_into() {
                                 Ok(roles_logic_sv2::parsers::JobDeclaration::AllocateMiningJobTokenSuccess(m)) => {
                                     if message_type.as_str() == "AllocateMiningJobTokenSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 }
                                 Ok(roles_logic_sv2::parsers::JobDeclaration::AllocateMiningJobToken(m)) => {
                                     if message_type.as_str() == "AllocateMiningJobToken" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 }
                                 Ok(roles_logic_sv2::parsers::JobDeclaration::CommitMiningJob(m)) => {
                                     if message_type.as_str() == "CommitMiningJob" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 }
                                 Ok(roles_logic_sv2::parsers::JobDeclaration::CommitMiningJobSuccess(m)) => {
                                     if message_type.as_str() == "CommitMiningJobSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 }
@@ -482,43 +456,43 @@ impl Executor {
                             match (header.msg_type(), payload).try_into() {
                                 Ok(roles_logic_sv2::parsers::TemplateDistribution::SubmitSolution(m)) => {
                                     if message_type.as_str() == "SubmitSolution" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::TemplateDistribution::NewTemplate(m)) => {
                                     if message_type.as_str() == "NewTemplate" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::TemplateDistribution::SetNewPrevHash(m)) => {
                                     if message_type.as_str() == "SetNewPrevHash" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::TemplateDistribution::CoinbaseOutputDataSize(m)) => {
                                     if message_type.as_str() == "CoinbaseOutputDataSize" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::TemplateDistribution::RequestTransactionData(m)) => {
                                     if message_type.as_str() == "RequestTransactionData" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::TemplateDistribution::RequestTransactionDataError(m)) => {
                                     if message_type.as_str() == "RequestTransactionDataError" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
                                 Ok(roles_logic_sv2::parsers::TemplateDistribution::RequestTransactionDataSuccess(m)) => {
                                     if message_type.as_str() == "RequestTransactionDataSuccess" {
-                                        let msg = serde_json::to_value(&m).unwrap();
+                                        let msg = serde_json::to_value(m).unwrap();
                                         check_each_field(msg, field_data);
                                     }
                                 },
@@ -813,7 +787,7 @@ fn change_fields<'a>(
     replace_fields: Vec<ReplaceField>,
     values: HashMap<String, serde_json::Value>,
 ) -> AnyMessage<'static> {
-    let mut replace_fields = replace_fields.clone();
+    let mut replace_fields = replace_fields;
     let next = replace_fields
         .pop()
         .expect("replace_fields cannot be empty");
@@ -840,18 +814,18 @@ fn change_fields<'a>(
 
             let m_ = into_static(AnyMessage::Common(serde_json::from_str(&m_).unwrap()));
             if replace_fields.is_empty() {
-                return m_;
+                m_
             } else {
-                return change_fields(m_, replace_fields, values);
+                change_fields(m_, replace_fields, values)
             }
         }
         AnyMessage::Mining(m) => {
             let m_ = change_value_of_serde_field(m, value, field_name);
             let m_ = into_static(AnyMessage::Mining(serde_json::from_str(&m_).unwrap()));
             if replace_fields.is_empty() {
-                return m_;
+                m_
             } else {
-                return change_fields(m_, replace_fields, values);
+                change_fields(m_, replace_fields, values)
             }
         }
         AnyMessage::JobDeclaration(m) => {
@@ -860,9 +834,9 @@ fn change_fields<'a>(
                 serde_json::from_str(&m_).unwrap(),
             ));
             if replace_fields.is_empty() {
-                return m_;
+                m_
             } else {
-                return change_fields(m_, replace_fields, values);
+                change_fields(m_, replace_fields, values)
             }
         }
         AnyMessage::TemplateDistribution(m) => {
@@ -871,9 +845,9 @@ fn change_fields<'a>(
                 serde_json::from_str(&m_).unwrap(),
             ));
             if replace_fields.is_empty() {
-                return m_;
+                m_
             } else {
-                return change_fields(m_, replace_fields, values);
+                change_fields(m_, replace_fields, values)
             }
         }
     }
@@ -895,8 +869,7 @@ fn change_value_of_serde_field<T: Serialize>(
     *message_as_serde_value
         .pointer_mut(&format!("/{}/{}", path, field_name.as_str()))
         .unwrap() = value.clone();
-    let message_as_string = serde_json::to_string(&message_as_serde_value).unwrap();
-    message_as_string
+    serde_json::to_string(&message_as_serde_value).unwrap()
 }
 
 fn save_message_field(

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -832,8 +832,9 @@ fn change_fields<'a>(
                 CommonMessages::SetupConnectionError(_) => "SetupConnectionError",
                 CommonMessages::SetupConnectionSuccess(_) => "SetupConnectionSuccess",
             };
-            let mut message_as_serde_value = serde_json::to_value(&m).unwrap();
+            let message_as_serde_value = serde_json::to_value(&m).unwrap();
             let m_ = change_value_of_serde_field(message_as_serde_value, path, value, field_name);
+            let m_ = into_static(AnyMessage::Common(serde_json::from_str(&m_).unwrap()));
             if replace_fields.len() == 0 {
                 return m_;
             } else {
@@ -867,19 +868,9 @@ fn change_fields<'a>(
                 parsers::Mining::UpdateChannel(_) => "UpdateChannel",
                 parsers::Mining::UpdateChannelError(_) => "UpdateChannelError",
             };
-            let mut message_as_serde_value = serde_json::to_value(&m).unwrap();
-            match message_as_serde_value.pointer_mut(&format!("/{}/{}", path, field_name.as_str()))
-            {
-                Some(field_value) => {
-                    let value = value.parse::<i32>().unwrap();
-                    *field_value = json!(value);
-                }
-                _ => panic!("value not found"),
-            }
-            let message_as_string = serde_json::to_string(&message_as_serde_value).unwrap();
-            let m_ = into_static(AnyMessage::Mining(
-                serde_json::from_str(&message_as_string).unwrap(),
-            ));
+            let message_as_serde_value = serde_json::to_value(&m).unwrap();
+            let m_ = change_value_of_serde_field(message_as_serde_value, path, value, field_name);
+            let m_ = into_static(AnyMessage::Mining(serde_json::from_str(&m_).unwrap()));
             if replace_fields.len() == 0 {
                 return m_;
             } else {
@@ -914,8 +905,11 @@ fn change_fields<'a>(
                     "ProvideMissingTransactionsSuccess"
                 }
             };
-            let mut message_as_serde_value = serde_json::to_value(&m).unwrap();
+            let message_as_serde_value = serde_json::to_value(&m).unwrap();
             let m_ = change_value_of_serde_field(message_as_serde_value, path, value, field_name);
+            let m_ = into_static(AnyMessage::JobDeclaration(
+                serde_json::from_str(&m_).unwrap(),
+            ));
             if replace_fields.len() == 0 {
                 return m_;
             } else {
@@ -944,8 +938,11 @@ fn change_fields<'a>(
                     "SubmitSolution"
                 }
             };
-            let mut message_as_serde_value = serde_json::to_value(&m).unwrap();
+            let message_as_serde_value = serde_json::to_value(&m).unwrap();
             let m_ = change_value_of_serde_field(message_as_serde_value, path, value, field_name);
+            let m_ = into_static(AnyMessage::TemplateDistribution(
+                serde_json::from_str(&m_).unwrap(),
+            ));
             if replace_fields.len() == 0 {
                 return m_;
             } else {
@@ -960,7 +957,7 @@ fn change_value_of_serde_field(
     path: &str,
     value: &str,
     field_name: String,
-) -> AnyMessage<'static> {
+) -> String {
     match message_as_serde_value.pointer_mut(&format!("/{}/{}", path, field_name.as_str())) {
         Some(field_value) => {
             let value = value.parse::<i32>().unwrap();
@@ -969,9 +966,7 @@ fn change_value_of_serde_field(
         _ => panic!("value not found"),
     }
     let message_as_string = serde_json::to_string(&message_as_serde_value).unwrap();
-    into_static(AnyMessage::Mining(
-        serde_json::from_str(&message_as_string).unwrap(),
-    ))
+    message_as_string
 }
 
 fn save_message_field(

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -2,7 +2,8 @@ use crate::{
     external_commands::os_command,
     into_static::into_static,
     net::{setup_as_downstream, setup_as_upstream},
-    Action, ActionResult, Command, Role, Sv2Type, Test, parser::sv2_messages::ReplaceField,
+    parser::sv2_messages::ReplaceField,
+    Action, ActionResult, Command, Role, Sv2Type, Test,
 };
 use async_channel::{Receiver, Sender};
 use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
@@ -820,6 +821,8 @@ fn change_fields<'a>(
     let value = values
         .get(&keyword)
         .expect("value not found for the keyword");
+
+    let message_as_string = serde_json::to_string(&m.clone()).unwrap();
 
     match m.clone() {
         AnyMessage::Common(m) => {

--- a/utils/message-generator/src/into_static.rs
+++ b/utils/message-generator/src/into_static.rs
@@ -1,4 +1,3 @@
-use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{
         ChannelEndpointChanged, SetupConnection, SetupConnectionError, SetupConnectionSuccess,
@@ -16,10 +15,10 @@ use roles_logic_sv2::{
         SetNewPrevHash as MiningSetNewPrevHash, SetTarget, SubmitSharesError, SubmitSharesExtended,
         SubmitSharesStandard, SubmitSharesSuccess, UpdateChannel, UpdateChannelError,
     },
-    parsers::{self, AnyMessage, CommonMessages, IsSv2Message, PoolMessages},
+    parsers::{self, AnyMessage, CommonMessages, PoolMessages},
     template_distribution_sv2::{
         CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, RequestTransactionDataError,
-        RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution,
+        RequestTransactionDataSuccess, SubmitSolution,
     },
 };
 

--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -38,13 +38,19 @@ enum Sv2Type {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct SaveField {
+    field_name: String,
+    keyword: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 enum ActionResult {
     MatchMessageType(u8),
     MatchMessageField((String, String, Vec<(String, Sv2Type)>)),
     GetMessageField {
         subprotocol: String,
         message_type: String,
-        fields: Vec<(String, String)>,
+        fields: Vec<SaveField>,
     },
     MatchMessageLen(usize),
     MatchExtensionType(u16),
@@ -179,7 +185,7 @@ mod test {
     use std::{convert::TryInto, io::Write};
     use tokio::join;
 
-    // The following test see that the composition serialise fist and deserialize 
+    // The following test see that the composition serialise fist and deserialize
     // second is the identity function (on an example message)
     #[test]
     fn test_serialise_and_deserialize() {

--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -8,15 +8,13 @@ mod parser;
 extern crate load_file;
 
 use crate::parser::sv2_messages::ReplaceField;
-use binary_sv2::{Deserialize, GetSize, Serialize};
+use binary_sv2::{Deserialize, Serialize};
 use codec_sv2::{
     noise_sv2::formats::{EncodedEd25519PublicKey, EncodedEd25519SecretKey},
-    Frame, StandardEitherFrame as EitherFrame, Sv2Frame,
+    StandardEitherFrame as EitherFrame,
 };
 use external_commands::*;
-use net::{setup_as_downstream, setup_as_upstream};
-use roles_logic_sv2::{common_messages_sv2::SetupConnectionSuccess, parsers::AnyMessage};
-use serde_json;
+use roles_logic_sv2::parsers::AnyMessage;
 use std::net::SocketAddr;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -17,6 +17,7 @@ use net::{setup_as_downstream, setup_as_upstream};
 use roles_logic_sv2::{common_messages_sv2::SetupConnectionSuccess, parsers::AnyMessage};
 use serde_json;
 use std::net::SocketAddr;
+use crate::parser::sv2_messages::ReplaceField;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 enum Sv2Type {
@@ -109,7 +110,7 @@ pub struct Action<'a> {
     messages: Vec<(
         EitherFrame<AnyMessage<'a>>,
         AnyMessage<'a>,
-        Vec<(String, String)>,
+        Vec<ReplaceField>,
     )>,
     result: Vec<ActionResult>,
     role: Role,

--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -7,6 +7,7 @@ mod parser;
 #[macro_use]
 extern crate load_file;
 
+use crate::parser::sv2_messages::ReplaceField;
 use binary_sv2::{Deserialize, GetSize, Serialize};
 use codec_sv2::{
     noise_sv2::formats::{EncodedEd25519PublicKey, EncodedEd25519SecretKey},
@@ -17,7 +18,6 @@ use net::{setup_as_downstream, setup_as_upstream};
 use roles_logic_sv2::{common_messages_sv2::SetupConnectionSuccess, parsers::AnyMessage};
 use serde_json;
 use std::net::SocketAddr;
-use crate::parser::sv2_messages::ReplaceField;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 enum Sv2Type {
@@ -170,6 +170,7 @@ async fn main() {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::into_static::into_static;
     use roles_logic_sv2::{
         common_messages_sv2::{Protocol, SetupConnection},
         mining_sv2::{CloseChannel, SetTarget},
@@ -177,6 +178,52 @@ mod test {
     };
     use std::{convert::TryInto, io::Write};
     use tokio::join;
+
+    // The following test see that the composition serialise fist and deserialize 
+    // second is the identity function (on an example message)
+    #[test]
+    fn test_serialise_and_deserialize() {
+        let message_string = r#"{"Mining":{"OpenExtendedMiningChannelSuccess":{"request_id":666666,"channel_id":1,"target":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,255,255,255,255,255,255,255,255],"extranonce_size":16,"extranonce_prefix":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]}}}"#;
+        let message_: AnyMessage<'_> = serde_json::from_str(&message_string).unwrap();
+        let message_as_serde_value = serde_json::to_value(&message_).unwrap();
+        let message_as_string = serde_json::to_string(&message_as_serde_value).unwrap();
+        let message: AnyMessage<'_> = serde_json::from_str(&message_as_string).unwrap();
+        let m_ = into_static(message);
+        let message_as_string_ = serde_json::to_string(&m_).unwrap();
+
+        let message_ = match message_ {
+            AnyMessage::Mining(m) => m,
+            _ => panic!(),
+        };
+        let message_ = match message_ {
+            Mining::OpenExtendedMiningChannelSuccess(m) => m,
+            _ => panic!(),
+        };
+
+        let m_ = match m_ {
+            AnyMessage::Mining(m) => m,
+            _ => panic!(),
+        };
+        let m_ = match m_ {
+            Mining::OpenExtendedMiningChannelSuccess(m) => m,
+            _ => panic!(),
+        };
+        if message_.request_id != m_.request_id {
+            panic!();
+        };
+        if message_.channel_id != m_.channel_id {
+            panic!();
+        };
+        if message_.target != m_.target {
+            panic!();
+        };
+        if message_.extranonce_size != m_.extranonce_size {
+            panic!();
+        };
+        if message_.extranonce_prefix != m_.extranonce_prefix {
+            panic!();
+        };
+    }
 
     #[tokio::test]
     async fn it_send_and_receive() {
@@ -289,15 +336,17 @@ mod test {
         let mut pool = os_command(
             "cargo",
             vec![
+                "llvm-cov",
+                "--no-report",
                 "run",
                 "-p",
-                "pool",
+                "pool_sv2",
                 "--",
                 "-c",
-                "./roles/v2/pool/pool-config.toml",
+                "./test/config/pool-config-sri-tp.toml",
             ],
             ExternalCommandConditions::new_with_timer_secs(60)
-                .continue_if_std_out_have("Listening for encrypted connection on: 0.0.0.0:34254"),
+                .continue_if_std_out_have("Listening for encrypted connection on: 127.0.0.1:34254"),
         )
         .await;
 

--- a/utils/message-generator/src/parser/actions.rs
+++ b/utils/message-generator/src/parser/actions.rs
@@ -43,10 +43,7 @@ impl ActionParser {
                 action_frames.push((frame, message.0, message.1));
             }
 
-            let actiondoc = match action.get("actiondoc") {
-                Some(T) => Some(T.to_string()),
-                None => None,
-            };
+            let actiondoc = action.get("actiondoc").map(|t| t.to_string());
             let mut action_results = vec![];
             let results = action.get("results").unwrap().as_array().unwrap();
             for result in results {

--- a/utils/message-generator/src/parser/actions.rs
+++ b/utils/message-generator/src/parser/actions.rs
@@ -4,6 +4,8 @@ use roles_logic_sv2::parsers::AnyMessage;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 
+use super::sv2_messages::ReplaceField;
+
 pub struct ActionParser {}
 
 impl ActionParser {
@@ -11,7 +13,7 @@ impl ActionParser {
         test: &'b str,
         frames: HashMap<String, Sv2Frame<AnyMessage<'a>, Slice>>,
         //Action.messages: Vec<(EitherFrame<AnyMessage<'a>>,AnyMessage<'a>,Vec<(String,String)>)>
-        messages: HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>,
+        messages: HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>,
     ) -> Vec<Action<'a>> {
         let test: Map<String, Value> = serde_json::from_str(test).unwrap();
         let actions = test.get("actions").unwrap().as_array().unwrap();

--- a/utils/message-generator/src/parser/actions.rs
+++ b/utils/message-generator/src/parser/actions.rs
@@ -1,4 +1,4 @@
-use crate::{Action, ActionResult, Role, Sv2Type};
+use crate::{Action, ActionResult, Role, SaveField, Sv2Type};
 use codec_sv2::{buffer_sv2::Slice, StandardEitherFrame, Sv2Frame};
 use roles_logic_sv2::parsers::AnyMessage;
 use serde_json::{Map, Value};
@@ -57,7 +57,7 @@ impl ActionParser {
                     }
                     "get_message_field" => {
                         let sv2_type = result.get("value").unwrap().clone();
-                        let sv2_type: (String, String, Vec<(String, String)>) =
+                        let sv2_type: (String, String, Vec<SaveField>) =
                             serde_json::from_value(sv2_type)
                                 .expect("match_message_field values not correct");
                         let get_message_field = ActionResult::GetMessageField {

--- a/utils/message-generator/src/parser/frames.rs
+++ b/utils/message-generator/src/parser/frames.rs
@@ -1,4 +1,4 @@
-use super::sv2_messages::message_from_path;
+use super::sv2_messages::{message_from_path, ReplaceField};
 use codec_sv2::{buffer_sv2::Slice, Frame as _Frame, Sv2Frame};
 use roles_logic_sv2::parsers::AnyMessage;
 use serde_json::{Map, Value};
@@ -11,10 +11,10 @@ pub struct Frames<'a> {
 impl<'a> Frames<'a> {
     pub fn from_step_1<'b: 'a>(
         test: &'b str,
-        messages: HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>,
+        messages: HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>,
     ) -> (
         Self,
-        HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>,
+        HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>,
     ) {
         let test: Map<String, Value> = serde_json::from_str(test).unwrap();
         let frames = test.get("frame_builders").unwrap().as_array().unwrap();

--- a/utils/message-generator/src/parser/frames.rs
+++ b/utils/message-generator/src/parser/frames.rs
@@ -12,10 +12,7 @@ impl<'a> Frames<'a> {
     pub fn from_step_1<'b: 'a>(
         test: &'b str,
         messages: HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>,
-    ) -> (
-        Self,
-        HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>,
-    ) {
+    ) -> (Self, HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>) {
         let test: Map<String, Value> = serde_json::from_str(test).unwrap();
         let frames = test.get("frame_builders").unwrap().as_array().unwrap();
         let mut messages = messages.clone();

--- a/utils/message-generator/src/parser/mod.rs
+++ b/utils/message-generator/src/parser/mod.rs
@@ -2,8 +2,7 @@ mod actions;
 mod frames;
 pub mod sv2_messages;
 
-use crate::{Action, Command, Test};
-use crate::parser::sv2_messages::ReplaceField;
+use crate::{parser::sv2_messages::ReplaceField, Action, Command, Test};
 use codec_sv2::{buffer_sv2::Slice, Frame, Sv2Frame};
 use frames::Frames;
 use roles_logic_sv2::parsers::AnyMessage;

--- a/utils/message-generator/src/parser/mod.rs
+++ b/utils/message-generator/src/parser/mod.rs
@@ -3,7 +3,7 @@ mod frames;
 pub mod sv2_messages;
 
 use crate::{parser::sv2_messages::ReplaceField, Action, Command, Test};
-use codec_sv2::{buffer_sv2::Slice, Frame, Sv2Frame};
+use codec_sv2::{buffer_sv2::Slice, Sv2Frame};
 use frames::Frames;
 use roles_logic_sv2::parsers::AnyMessage;
 use serde_json::{Map, Value};

--- a/utils/message-generator/src/parser/mod.rs
+++ b/utils/message-generator/src/parser/mod.rs
@@ -1,8 +1,9 @@
 mod actions;
 mod frames;
-mod sv2_messages;
+pub mod sv2_messages;
 
 use crate::{Action, Command, Test};
+use crate::parser::sv2_messages::ReplaceField;
 use codec_sv2::{buffer_sv2::Slice, Frame, Sv2Frame};
 use frames::Frames;
 use roles_logic_sv2::parsers::AnyMessage;
@@ -15,15 +16,15 @@ pub enum Parser<'a> {
     /// Parses any number or combination of messages to be later used by an action identified by
     /// message id.
     /// they are saved as (field_name, keyword)
-    Step1(HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>),
+    Step1(HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>),
     /// Serializes messages into `Sv2Frames` identified by message id.
     Step2 {
-        messages: HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>,
+        messages: HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>,
         frames: HashMap<String, Sv2Frame<AnyMessage<'a>, Slice>>,
     },
     /// Parses the setup, execution, and cleanup shell commands, roles, and actions.
     Step3 {
-        messages: HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)>,
+        messages: HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)>,
         frames: HashMap<String, Sv2Frame<AnyMessage<'a>, Slice>>,
         actions: Vec<Action<'a>>,
     },

--- a/utils/message-generator/src/parser/sv2_messages.rs
+++ b/utils/message-generator/src/parser/sv2_messages.rs
@@ -76,12 +76,24 @@ pub struct TestMessageParser<'a> {
 //                          },
 //This is contained         "id": "setup_connection_success_flag_0"
 //field "id"            }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplaceField {
+    pub field_name: String,
+    pub keyword: String,
+}
+impl ReplaceField {
+    fn from_vec_string_string(input: (String, String)) -> ReplaceField {
+        ReplaceField { field_name: input.0, keyword: input.1 }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CommonMessage<'a> {
     #[serde(borrow)]
     message: CommonMessages<'a>,
     id: String,
-    replace_fields: Option<Vec<(String, String)>>,
+    replace_fields: Option<Vec<ReplaceField>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -90,7 +102,7 @@ struct JobDeclarationMessage<'a> {
     message: JobDeclaration<'a>,
     id: String,
     // filed_name, keyword
-    replace_fields: Option<Vec<(String, String)>>,
+    replace_fields: Option<Vec<ReplaceField>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,7 +111,7 @@ struct MiningMessage<'a> {
     message: Mining<'a>,
     id: String,
     // filed_name, keyword
-    replace_fields: Option<Vec<(String, String)>>,
+    replace_fields: Option<Vec<ReplaceField>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -108,11 +120,11 @@ struct TemplateDistributionMessage<'a> {
     message: TemplateDistribution<'a>,
     id: String,
     // filed_name, keyword
-    replace_fields: Option<Vec<(String, String)>>,
+    replace_fields: Option<Vec<ReplaceField>>,
 }
 
 impl<'a> TestMessageParser<'a> {
-    pub fn into_map(self) -> HashMap<String, (AnyMessage<'a>, Vec<(String, String)>)> {
+    pub fn into_map(self) -> HashMap<String, (AnyMessage<'a>, Vec<ReplaceField>)> {
         let mut map = HashMap::new();
         if let Some(common_messages) = self.common_messages {
             for message in common_messages {

--- a/utils/message-generator/src/parser/sv2_messages.rs
+++ b/utils/message-generator/src/parser/sv2_messages.rs
@@ -84,7 +84,10 @@ pub struct ReplaceField {
 }
 impl ReplaceField {
     fn from_vec_string_string(input: (String, String)) -> ReplaceField {
-        ReplaceField { field_name: input.0, keyword: input.1 }
+        ReplaceField {
+            field_name: input.0,
+            keyword: input.1,
+        }
     }
 }
 
@@ -270,7 +273,7 @@ mod test {
             }
             _ => panic!(),
         }
-        match v.get("close_channel").unwrap() {
+        match &v.get("close_channel").unwrap().0 {
             AnyMessage::Mining(roles_logic_sv2::parsers::Mining::CloseChannel(m)) => {
                 assert!(m.channel_id == 78);
                 let reason_code = m.reason_code.to_vec().clone();


### PR DESCRIPTION
FIRST COMMIT:
    ReplaceField struct

    The messages came along with a vector of (String, String), where the
    first entry is the field_name to be replaced and the second is the
    keyword associated. This is replaced with a much more human readable
    struct Replacefield {
        field_name: String,
        keyword: String
    }

SECOND COMMIT:
    improve code tests

    - one test did't pass and now it is fixed
    - add a second test that checks on a sv2 message that the composition
    (serialization and then deserialization) is the identity

THIRD COMMIT:
    SaveField string

    In GetMessageField, the field "fields" that represents the fields that
    must be saved from the message is Vec<(String, Strin)>, where first
    entry is the the field_id and the second is the keyword to retrieve the
    first. Now a more suitable struct
    SaveField {
       field_id: String,
       keyword: String,
    }
    is introduced.

FOURTH COMMIT:
    fix bug in function change_value_of_serde_field

    This function (in executor.rs) worked only for MiningMessages. Now it returns the
    modified message as a String and can be used in everywhere in
    change_fields function (also in executor.rs)

FIFTH COMMIT
    fix replace field bug

    Before, if we tried to use ReplaceField in a message with a field that
    is not a u32, it would generate an error because the function
    change_value_of_serde_field was set to modify only fields that are u32.
    Now it is fixed. You can see it by running the translation-proxy.json,
    where several fields' types in messages are replaced.




