### PR TITLE
Fix small bugs after pr 587

### DIFF
--- a/protocols/v2/subprotocols/job-declaration/src/commit_mining_job.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/commit_mining_job.rs
@@ -49,7 +49,9 @@ pub struct CommitMiningJobSuccess<'decoder> {
 #[repr(C)]
 pub struct CommitMiningJobError<'decoder> {
     pub request_id: u32,
+    #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub error_code: Str0255<'decoder>,
+    #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub error_details: B064K<'decoder>,
 }
 
@@ -61,10 +63,10 @@ impl<'d> GetSize for CommitMiningJob<'d> {
         self.request_id.get_size()
             + self.mining_job_token.get_size()
             + self.version.get_size()
-            + self.coninbase_tx_version.get_size()
-            + self.coninbase_prefix.get_size()
-            + self.coninbase_tx_input_nsequence.get_size()
-            + self.coninbase_tx_value_remaining.get_size()
+            + self.coinbase_tx_version.get_size()
+            + self.coinbase_prefix.get_size()
+            + self.coinbase_tx_input_n_sequence.get_size()
+            + self.coinbase_tx_value_remaining.get_size()
             + self.coinbase_tx_outputs.get_size()
             + self.coinbase_tx_locktime.get_size()
             + self.min_extranonce_size.get_size()

--- a/utils/message-generator/Cargo.lock
+++ b/utils/message-generator/Cargo.lock
@@ -595,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "noise_sv2"
 version = "0.1.2"
 dependencies = [
@@ -807,6 +813,7 @@ dependencies = [
  "framing_sv2",
  "job_declaration_sv2",
  "mining_sv2",
+ "nohash-hasher",
  "serde",
  "template_distribution_sv2",
  "tracing",

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -444,6 +444,36 @@ impl Executor {
                                         check_each_field(msg, field_data);
                                     }
                                 }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::CommitMiningJobError(m)) => {
+                                    if message_type.as_str() == "CommitMiningJobSuccess" {
+                                        let msg = serde_json::to_value(&m).unwrap();
+                                        check_each_field(msg, field_data);
+                                    }
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::IdentifyTransactions(m)) => {
+                                    if message_type.as_str() == "AllocateMiningJobTokenSuccess" {
+                                        let msg = serde_json::to_value(&m).unwrap();
+                                        check_each_field(msg, field_data);
+                                    }
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::IdentifyTransactionsSuccess(m)) => {
+                                    if message_type.as_str() == "AllocateMiningJobTokenSuccess" {
+                                        let msg = serde_json::to_value(&m).unwrap();
+                                        check_each_field(msg, field_data);
+                                    }
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::ProvideMissingTransactions(m)) => {
+                                    if message_type.as_str() == "AllocateMiningJobTokenSuccess" {
+                                        let msg = serde_json::to_value(&m).unwrap();
+                                        check_each_field(msg, field_data);
+                                    }
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::ProvideMissingTransactionsSuccess(m)) => {
+                                    if message_type.as_str() == "AllocateMiningJobTokenSuccess" {
+                                        let msg = serde_json::to_value(&m).unwrap();
+                                        check_each_field(msg, field_data);
+                                    }
+                                }
                                 Err(e) => panic!("err {:?}", e),
                             }
                         } else if subprotocol.as_str() == "TemplateDistributionProtocol" {
@@ -636,6 +666,26 @@ impl Executor {
                                     self.save = save_message_field(mess, self.save.clone(), fields);
                                 }
                                 Ok(parsers::JobDeclaration::CommitMiningJobSuccess(m)) => {
+                                    let mess = serde_json::to_value(&m).unwrap();
+                                    self.save = save_message_field(mess, self.save.clone(), fields);
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::CommitMiningJobError(m)) => {
+                                    let mess = serde_json::to_value(&m).unwrap();
+                                    self.save = save_message_field(mess, self.save.clone(), fields);
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::IdentifyTransactions(m)) => {
+                                    let mess = serde_json::to_value(&m).unwrap();
+                                    self.save = save_message_field(mess, self.save.clone(), fields);
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::IdentifyTransactionsSuccess(m)) => {
+                                    let mess = serde_json::to_value(&m).unwrap();
+                                    self.save = save_message_field(mess, self.save.clone(), fields);
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::ProvideMissingTransactions(m)) => {
+                                    let mess = serde_json::to_value(&m).unwrap();
+                                    self.save = save_message_field(mess, self.save.clone(), fields);
+                                }
+                                Ok(roles_logic_sv2::parsers::JobDeclaration::ProvideMissingTransactionsSuccess(m)) => {
                                     let mess = serde_json::to_value(&m).unwrap();
                                     self.save = save_message_field(mess, self.save.clone(), fields);
                                 }
@@ -844,6 +894,21 @@ fn change_fields<'a>(
                 roles_logic_sv2::parsers::JobDeclaration::CommitMiningJob(_) => "CommitMiningJob",
                 roles_logic_sv2::parsers::JobDeclaration::CommitMiningJobSuccess(_) => {
                     "CommitMiningJobSuccess"
+                }
+                roles_logic_sv2::parsers::JobDeclaration::CommitMiningJobError(_) => {
+                    "CommitMiningJobError"
+                }
+                roles_logic_sv2::parsers::JobDeclaration::IdentifyTransactions(_) => {
+                    "IdentifyTransactions"
+                }
+                roles_logic_sv2::parsers::JobDeclaration::IdentifyTransactionsSuccess(_) => {
+                    "IdentifyTransactionsSuccess"
+                }
+                roles_logic_sv2::parsers::JobDeclaration::ProvideMissingTransactions(_) => {
+                    "ProvideMissingTransactions"
+                }
+                roles_logic_sv2::parsers::JobDeclaration::ProvideMissingTransactionsSuccess(_) => {
+                    "ProvideMissingTransactionsSuccess"
                 }
             };
             let mut message_as_serde_value = serde_json::to_value(&m).unwrap();

--- a/utils/message-generator/src/into_static.rs
+++ b/utils/message-generator/src/into_static.rs
@@ -5,7 +5,8 @@ use roles_logic_sv2::{
     },
     job_declaration_sv2::{
         AllocateMiningJobToken, AllocateMiningJobTokenSuccess, CommitMiningJob,
-        CommitMiningJobSuccess,
+        CommitMiningJobError, CommitMiningJobSuccess, IdentifyTransactions,
+        IdentifyTransactionsSuccess, ProvideMissingTransactions, ProvideMissingTransactionsSuccess,
     },
     mining_sv2::{
         CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannel,
@@ -293,10 +294,10 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     request_id: m.request_id,
                     mining_job_token: m.mining_job_token.into_static(),
                     version: m.version,
-                    coninbase_tx_version: m.coninbase_tx_version,
-                    coninbase_prefix: m.coninbase_prefix.into_static(),
-                    coninbase_tx_input_nsequence: m.coninbase_tx_input_nsequence,
-                    coninbase_tx_value_remaining: m.coninbase_tx_value_remaining,
+                    coinbase_tx_version: m.coinbase_tx_version,
+                    coinbase_prefix: m.coinbase_prefix.into_static(),
+                    coinbase_tx_input_n_sequence: m.coinbase_tx_input_n_sequence,
+                    coinbase_tx_value_remaining: m.coinbase_tx_value_remaining,
                     coinbase_tx_outputs: m.coinbase_tx_outputs.into_static(),
                     coinbase_tx_locktime: m.coinbase_tx_locktime,
                     min_extranonce_size: m.min_extranonce_size,
@@ -314,6 +315,52 @@ pub fn into_static<'a>(m: AnyMessage<'a>) -> AnyMessage<'static> {
                     new_mining_job_token: m.new_mining_job_token.into_static(),
                 };
                 PoolMessages::JobDeclaration(parsers::JobDeclaration::CommitMiningJobSuccess(m))
+            }
+            parsers::JobDeclaration::CommitMiningJobError(m) => {
+                let m = CommitMiningJobError {
+                    request_id: m.request_id,
+                    error_code: m.error_code.into_static(),
+                    error_details: m.error_details.into_static(),
+                };
+                PoolMessages::JobDeclaration(parsers::JobDeclaration::CommitMiningJobError(m))
+            }
+            parsers::JobDeclaration::IdentifyTransactions(m) => {
+                let m = IdentifyTransactions {
+                    user_identifier: m.user_identifier.into_static(),
+                    request_id: m.request_id,
+                };
+                PoolMessages::JobDeclaration(parsers::JobDeclaration::IdentifyTransactions(m))
+            }
+            parsers::JobDeclaration::IdentifyTransactionsSuccess(m) => {
+                let m = IdentifyTransactionsSuccess {
+                    request_id: m.request_id,
+                    mining_job_token: m.mining_job_token.into_static(),
+                    coinbase_output_max_additional_size: m.coinbase_output_max_additional_size,
+                    coinbase_output: m.coinbase_output.into_static(),
+                    async_mining_allowed: m.async_mining_allowed,
+                };
+                PoolMessages::JobDeclaration(parsers::JobDeclaration::IdentifyTransactionsSuccess(
+                    m,
+                ))
+            }
+            parsers::JobDeclaration::ProvideMissingTransactions(m) => {
+                let m = ProvideMissingTransactions {
+                    user_identifier: m.user_identifier.into_static(),
+                    request_id: m.request_id,
+                };
+                PoolMessages::JobDeclaration(parsers::JobDeclaration::ProvideMissingTransactions(m))
+            }
+            parsers::JobDeclaration::ProvideMissingTransactionsSuccess(m) => {
+                let m = ProvideMissingTransactionsSuccess {
+                    request_id: m.request_id,
+                    mining_job_token: m.mining_job_token.into_static(),
+                    coinbase_output_max_additional_size: m.coinbase_output_max_additional_size,
+                    coinbase_output: m.coinbase_output.into_static(),
+                    async_mining_allowed: m.async_mining_allowed,
+                };
+                PoolMessages::JobDeclaration(
+                    parsers::JobDeclaration::ProvideMissingTransactionsSuccess(m),
+                )
             }
         },
         PoolMessages::TemplateDistribution(m) => match m {


### PR DESCRIPTION
    FIRST: in the implementation of GetSize of CommitMiningJob in JD protocol, there were
    some bugs, like "coninbase" in place of "coinbase". The compiling of this
    part of software is disabled by default, unless compiling with the
    feature "with_serde". This is why these issues do not appear in normal compiling.

    SECOND: iin PR 587, some JD messages are added to the SRI, so their correspectives
    in the MG are added
