### PR TITLE
Jd short hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,7 @@ dependencies = [
  "quickcheck_macros 1.0.0",
  "rand 0.8.5",
  "serde",
+ "siphasher",
  "template_distribution_sv2",
  "toml",
  "tracing",
@@ -2055,6 +2056,12 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "siphasher"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
 
 [[package]]
 name = "slab"

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -22,6 +22,18 @@ impl<'a, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
 }
 
 // TODO add test for that and implement it also with serde!!!!
+impl<'a, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    Seq064K<'a, super::inner::Inner<'a, false, SIZE, HEADERSIZE, MAXSIZE>>
+{
+    pub fn to_vec(&self) -> Vec<Vec<u8>> {
+        self.0.iter().map(|x| x.to_vec()).collect()
+    }
+    pub fn inner_as_ref(&self) -> Vec<&[u8]> {
+        self.0.iter().map(|x| x.inner_as_ref()).collect()
+    }
+}
+
+// TODO add test for that and implement it also with serde!!!!
 impl<'a, const SIZE: usize> Seq0255<'a, super::inner::Inner<'a, true, SIZE, 0, 0>> {
     pub fn to_vec(&self) -> Vec<Vec<u8>> {
         self.0.iter().map(|x| x.to_vec()).collect()

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b016m.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b016m.rs
@@ -196,4 +196,10 @@ impl<'a> B016M<'a> {
             Inner::Owned(inner) => B016M(Inner::Owned(inner)),
         }
     }
+    pub fn to_vec(self) -> Vec<u8> {
+        match self.0 {
+            Inner::Ref(v) => v.to_vec(),
+            Inner::Owned(_) => todo!(),
+        }
+    }
 }

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
@@ -75,6 +75,18 @@ impl<'s, T: Clone + Serialize + TryFromBSlice<'s>> From<Seq<'s, T>> for Seq064K<
     }
 }
 
+impl<'s, T: Clone + Serialize + TryFromBSlice<'s>> From<Vec<T>> for Seq064K<'s, T> {
+    #[inline]
+    fn from(val: Vec<T>) -> Self {
+        Self {
+            seq: None,
+            data: Some(val),
+        }
+    }
+}
+
+
+
 impl<'s, T: Clone + FixedSize + Serialize + TryFromBSlice<'s>> Serialize for Seq064K<'s, T> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
@@ -446,6 +458,9 @@ impl<'s> Seq064K<'s, B016M<'s>> {
             panic!()
         }
     }
+    pub fn to_vec(&self) -> Vec<Vec<u8>> {
+        self.data.clone().unwrap().iter().map(|x| x.clone().to_vec()).collect()
+    }
 }
 impl<'s> Seq064K<'s, u32> {
     pub fn into_static(self) -> Seq064K<'static, u32> {
@@ -484,6 +499,9 @@ impl<'s> Seq064K<'s, ShortTxId<'s>> {
         } else {
             panic!()
         }
+    }
+    pub fn to_vec(&self) -> Vec<Vec<u8>> {
+        self.data.clone().unwrap().iter().map(|x| x.to_vec()).collect()
     }
 }
 impl<'s> Seq064K<'s, U256<'s>> {

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
@@ -85,8 +85,6 @@ impl<'s, T: Clone + Serialize + TryFromBSlice<'s>> From<Vec<T>> for Seq064K<'s, 
     }
 }
 
-
-
 impl<'s, T: Clone + FixedSize + Serialize + TryFromBSlice<'s>> Serialize for Seq064K<'s, T> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
@@ -459,7 +457,12 @@ impl<'s> Seq064K<'s, B016M<'s>> {
         }
     }
     pub fn to_vec(&self) -> Vec<Vec<u8>> {
-        self.data.clone().unwrap().iter().map(|x| x.clone().to_vec()).collect()
+        self.data
+            .clone()
+            .unwrap()
+            .iter()
+            .map(|x| x.clone().to_vec())
+            .collect()
     }
 }
 impl<'s> Seq064K<'s, u32> {
@@ -501,7 +504,12 @@ impl<'s> Seq064K<'s, ShortTxId<'s>> {
         }
     }
     pub fn to_vec(&self) -> Vec<Vec<u8>> {
-        self.data.clone().unwrap().iter().map(|x| x.to_vec()).collect()
+        self.data
+            .clone()
+            .unwrap()
+            .iter()
+            .map(|x| x.to_vec())
+            .collect()
     }
 }
 impl<'s> Seq064K<'s, U256<'s>> {

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -21,6 +21,7 @@ bitcoin = "0.27.1"
 tracing = { version = "0.1"}
 chacha20poly1305 = { version = "0.10.1"}
 nohash-hasher = "0.2.0"
+siphasher = "1"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use bitcoin::{
     blockdata::block::BlockHeader,
     hash_types::{BlockHash, TxMerkleNode},
-    hashes::{sha256d::Hash as DHash, Hash, sha256},
+    hashes::{sha256, sha256d::Hash as DHash, Hash},
     util::{psbt::serialize::Deserialize, uint::Uint256},
     Transaction,
 };
@@ -573,17 +573,17 @@ pub fn short_hash_list(
     (tx_short_hash_list, tx_hash_list_hash)
 }
 
-fn short_hash_list_builder(tx_short_hash_nonce: u64, tx_data: Seq064K<'static, B016M<'static>>) -> Seq064K<'static, ShortTxId<'static>>{
+fn short_hash_list_builder(
+    tx_short_hash_nonce: u64,
+    tx_data: Seq064K<'static, B016M<'static>>,
+) -> Seq064K<'static, ShortTxId<'static>> {
     // hash the short hash nonce
-    let nonce_hash = sha256::Hash::hash(
-        &tx_short_hash_nonce
-            .to_le_bytes(),
-    );
+    let nonce_hash = sha256::Hash::hash(&tx_short_hash_nonce.to_le_bytes());
     // take first two integers from the hash
     let k0 = u64::from_le_bytes(nonce_hash[0..8].try_into().unwrap());
     let k1 = u64::from_le_bytes(nonce_hash[8..16].try_into().unwrap());
     let mut tx_short_hash_list = vec![];
-     // get every transaction, hash it, remove first two bytes and push the ShortTxId in a vector
+    // get every transaction, hash it, remove first two bytes and push the ShortTxId in a vector
     for tx in tx_data.to_vec() {
         let hasher = SipHasher24::new_with_keys(k0, k1);
         let tx_hashed = hasher.hash(&tx);
@@ -594,8 +594,7 @@ fn short_hash_list_builder(tx_short_hash_nonce: u64, tx_data: Seq064K<'static, B
     Seq064K::from(tx_short_hash_list)
 }
 
-fn tx_hash_list_hash_builder(_tx_data: Seq064K<'static, B016M<'static>>) -> U256{
-
+fn tx_hash_list_hash_builder(_tx_data: Seq064K<'static, B016M<'static>>) -> U256 {
     // TODO: understand if this field is redunant and to be deleted since
     // the full coinbase is known
     /*
@@ -603,8 +602,7 @@ fn tx_hash_list_hash_builder(_tx_data: Seq064K<'static, B016M<'static>>) -> U256
     let hash = sha256::Hash::hash(&vec_concatenated_txs.as_ref()).as_inner().to_owned();
     hash.to_vec().try_into().unwrap()
     */
-    vec![0;32].try_into().unwrap()
-    
+    vec![0; 32].try_into().unwrap()
 }
 
 #[cfg(test)]

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use bitcoin::{
     blockdata::block::BlockHeader,
     hash_types::{BlockHash, TxMerkleNode},
-    hashes::{sha256d::Hash as DHash, Hash},
+    hashes::{sha256d::Hash as DHash, Hash, sha256},
     util::{psbt::serialize::Deserialize, uint::Uint256},
     Transaction,
 };
@@ -568,19 +568,22 @@ pub fn short_hash_list(
     tx_data: Seq064K<'static, B016M<'static>>,
     tx_short_hash_nonce: u64,
 ) -> (Seq064K<'static, ShortTxId<'static>>, U256<'static>) {
+    let tx_short_hash_list = short_hash_list_builder(tx_short_hash_nonce, tx_data.clone());
+    let tx_hash_list_hash = tx_hash_list_hash_builder(tx_data);
+    (tx_short_hash_list, tx_hash_list_hash)
+}
+
+fn short_hash_list_builder(tx_short_hash_nonce: u64, tx_data: Seq064K<'static, B016M<'static>>) -> Seq064K<'static, ShortTxId<'static>>{
     // hash the short hash nonce
-    let nonce_hash = DHash::from_inner(
-        tx_short_hash_nonce
-            .to_le_bytes()
-            .to_vec()
-            .try_into()
-            .unwrap(),
+    let nonce_hash = sha256::Hash::hash(
+        &tx_short_hash_nonce
+            .to_le_bytes(),
     );
-    // take first two bytes of the hash
+    // take first two integers from the hash
     let k0 = u64::from_le_bytes(nonce_hash[0..8].try_into().unwrap());
     let k1 = u64::from_le_bytes(nonce_hash[8..16].try_into().unwrap());
     let mut tx_short_hash_list = vec![];
-    // make a vector of ShortTxID [u8; 6]
+     // get every transaction, hash it, remove first two bytes and push the ShortTxId in a vector
     for tx in tx_data.to_vec() {
         let hasher = SipHasher24::new_with_keys(k0, k1);
         let tx_hashed = hasher.hash(&tx);
@@ -588,11 +591,20 @@ pub fn short_hash_list(
         let tx_hashed_bytes: ShortTxId = tx_hashed_bytes.try_into().unwrap();
         tx_short_hash_list.push(tx_hashed_bytes);
     }
-    let tx_short_hash_list1 = Seq064K::from(tx_short_hash_list);
-    // TODO: let mut tx_hash_list_hash = DHash::from(tx_data.to_vec().try_into().unwrap());
-    let tx_hash_list_hash = vec![0; 32].try_into().unwrap();
+    Seq064K::from(tx_short_hash_list)
+}
 
-    (tx_short_hash_list1, tx_hash_list_hash)
+fn tx_hash_list_hash_builder(_tx_data: Seq064K<'static, B016M<'static>>) -> U256{
+
+    // TODO: understand if this field is redunant and to be deleted since
+    // the full coinbase is known
+    /*
+    let vec_concatenated_txs = tx_data.to_vec().concat();
+    let hash = sha256::Hash::hash(&vec_concatenated_txs.as_ref()).as_inner().to_owned();
+    hash.to_vec().try_into().unwrap()
+    */
+    vec![0;32].try_into().unwrap()
+    
 }
 
 #[cfg(test)]

--- a/roles/jd-client/src/downstream.rs
+++ b/roles/jd-client/src/downstream.rs
@@ -272,6 +272,8 @@ impl DownstreamMiningNode {
             let frame: StdFrame = message.try_into().unwrap();
             Self::send(self_mutex, frame).await.unwrap();
         }
+        // See coment on the definition of the global for memory
+        // ordering
         crate::IS_NEW_TEMPLATE_HANDLED.store(true, std::sync::atomic::Ordering::Release);
         Ok(())
     }

--- a/roles/jd-client/src/job_declarator/mod.rs
+++ b/roles/jd-client/src/job_declarator/mod.rs
@@ -8,7 +8,7 @@ use roles_logic_sv2::{
     job_declaration_sv2::AllocateMiningJobTokenSuccess,
     parsers::{JobDeclaration, PoolMessages},
     template_distribution_sv2::SetNewPrevHash,
-    utils::{short_hash_list, Mutex},
+    utils::{hash_lists_tuple, Mutex},
 };
 use std::{collections::HashMap, convert::TryInto, str::FromStr};
 use tokio::task::AbortHandle;
@@ -209,8 +209,8 @@ impl JobDeclarator {
             coinbase_tx_locktime: template.coinbase_tx_locktime,
             min_extranonce_size,
             tx_short_hash_nonce,
-            tx_short_hash_list: short_hash_list(tx_list.clone(), tx_short_hash_nonce).0,
-            tx_hash_list_hash: short_hash_list(tx_list.clone(), tx_short_hash_nonce).1,
+            tx_short_hash_list: hash_lists_tuple(tx_list.clone(), tx_short_hash_nonce).0,
+            tx_hash_list_hash: hash_lists_tuple(tx_list.clone(), tx_short_hash_nonce).1,
             excess_data, // request transaction data
         };
         self_mutex

--- a/roles/jd-client/src/main.rs
+++ b/roles/jd-client/src/main.rs
@@ -40,13 +40,13 @@ use tracing::{error, info};
 ///
 /// Memory Ordering Explanation:
 /// We use Acquire-Release ordering instead of SeqCst or Relaxed for the following reasons:
-/// 1. Acquire in template receiver context ensures we see all operations before the Release store 
+/// 1. Acquire in template receiver context ensures we see all operations before the Release store
 ///    the downstream.
-/// 2. Within the same execution context (template receiver), a Relaxed store followed by an Acquire 
-///    load is sufficient. This is because operations within the same context execute in the order 
+/// 2. Within the same execution context (template receiver), a Relaxed store followed by an Acquire
+///    load is sufficient. This is because operations within the same context execute in the order
 ///    they appear in the code.
-/// 3. The combination of Release in downstream and Acquire in template receiver contexts establishes 
-///    a happens-before relationship, guaranteeing that we handle the SetNewPrevHash message after 
+/// 3. The combination of Release in downstream and Acquire in template receiver contexts establishes
+///    a happens-before relationship, guaranteeing that we handle the SetNewPrevHash message after
 ///    that downstream have finished handling the NewTemplate.
 /// 3. SeqCst is overkill we only need to synchronize two contexts, a globally agreed-upon order
 ///    between all the contexts is not necessary.

--- a/roles/jd-client/src/main.rs
+++ b/roles/jd-client/src/main.rs
@@ -26,8 +26,30 @@ use crate::status::{State, Status};
 use std::sync::atomic::AtomicBool;
 use tracing::{error, info};
 
-/// USED to make sure that if a future new_template and a set_new_prev_hash are received together
-/// the future new_template is always handled before the set new prev hash.
+/// USED to make sure that if a future new_temnplate and a set_new_prev_hash are received together
+/// the future new_temnplate is always handled before the set new prev hash.
+///
+/// Is used by the template receiver and the downstream. When a NewTemplate is received the context
+/// that is running the template receiver set this value to false and then the message is sent to
+/// the context that is running the Downstream that do something and then set it back to true.
+///
+/// In the meantime if the context that is running the template receiver receives a SetNewPrevHash
+/// it wait until the value of this global is true before doing anything.
+///
+/// Acuire and Release memory ordering is used.
+///
+/// Memory Ordering Explanation:
+/// We use Acquire-Release ordering instead of SeqCst or Relaxed for the following reasons:
+/// 1. Acquire in template receiver context ensures we see all operations before the Release store 
+///    the downstream.
+/// 2. Within the same execution context (template receiver), a Relaxed store followed by an Acquire 
+///    load is sufficient. This is because operations within the same context execute in the order 
+///    they appear in the code.
+/// 3. The combination of Release in downstream and Acquire in template receiver contexts establishes 
+///    a happens-before relationship, guaranteeing that we handle the SetNewPrevHash message after 
+///    that downstream have finished handling the NewTemplate.
+/// 3. SeqCst is overkill we only need to synchronize two contexts, a globally agreed-upon order
+///    between all the contexts is not necessary.
 pub static IS_NEW_TEMPLATE_HANDLED: AtomicBool = AtomicBool::new(true);
 
 /// Process CLI args, if any.

--- a/roles/jd-client/src/template_receiver/mod.rs
+++ b/roles/jd-client/src/template_receiver/mod.rs
@@ -159,7 +159,7 @@ impl TemplateRx {
                                 // declare the mining job
                                 Some(TemplateDistribution::NewTemplate(m)) => {
                                     crate::IS_NEW_TEMPLATE_HANDLED
-                                        .store(false, std::sync::atomic::Ordering::SeqCst);
+                                        .store(false, std::sync::atomic::Ordering::Release);
                                     Self::send_tx_data_request(&self_mutex, m.clone()).await;
                                     self_mutex
                                         .safe_lock(|t| t.new_template_message = Some(m.clone()))

--- a/roles/jd-client/src/template_receiver/mod.rs
+++ b/roles/jd-client/src/template_receiver/mod.rs
@@ -158,8 +158,10 @@ impl TemplateRx {
                                 // Send the new template along with the token to the JD so that JD can
                                 // declare the mining job
                                 Some(TemplateDistribution::NewTemplate(m)) => {
+                                    // See coment on the definition of the global for memory
+                                    // ordering
                                     crate::IS_NEW_TEMPLATE_HANDLED
-                                        .store(false, std::sync::atomic::Ordering::Release);
+                                        .store(false, std::sync::atomic::Ordering::Relaxed);
                                     Self::send_tx_data_request(&self_mutex, m.clone()).await;
                                     self_mutex
                                         .safe_lock(|t| t.new_template_message = Some(m.clone()))
@@ -184,9 +186,8 @@ impl TemplateRx {
                                 }
                                 Some(TemplateDistribution::SetNewPrevHash(m)) => {
                                     info!("Received SetNewPrevHash, waiting for IS_NEW_TEMPLATE_HANDLED");
-                                    // use Acquire-Release for IS_NEW_TEMPLATE_HANDLED to wait until the
-                                    // NEW_TEMPLATE message is arrived. Acquire-Release ordering is used
-                                    // because only this two messages must be ordered in this context.
+                                    // See coment on the definition of the global for memory
+                                    // ordering
                                     while !crate::IS_NEW_TEMPLATE_HANDLED
                                         .load(std::sync::atomic::Ordering::Acquire)
                                     {

--- a/roles/jd-client/src/template_receiver/mod.rs
+++ b/roles/jd-client/src/template_receiver/mod.rs
@@ -184,8 +184,9 @@ impl TemplateRx {
                                 }
                                 Some(TemplateDistribution::SetNewPrevHash(m)) => {
                                     info!("Received SetNewPrevHash, waiting for IS_NEW_TEMPLATE_HANDLED");
-                                    // use Acquire-Release for IS_NEW_TEMPLATE_HANDLED because
-                                    // is not needed a total order with other atomics in the code
+                                    // use Acquire-Release for IS_NEW_TEMPLATE_HANDLED to wait until the
+                                    // NEW_TEMPLATE message is arrived. Acquire-Release ordering is used
+                                    // because only this two messages must be ordered in this context.
                                     while !crate::IS_NEW_TEMPLATE_HANDLED
                                         .load(std::sync::atomic::Ordering::Acquire)
                                     {

--- a/utils/message-generator/Cargo.lock
+++ b/utils/message-generator/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "mining_sv2",
  "nohash-hasher",
  "serde",
+ "siphasher",
  "template_distribution_sv2",
  "tracing",
 ]
@@ -1191,6 +1192,12 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "siphasher"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
---recreate PR because it was created on wrong branch---

Add functionality for the DeclareMiningJob message for the values: tx_short _hash _list and tx_hash_list_hash. These are required to let the JD server to propagate the block by checking the transactions hashes against its own TP or mempool. If they are not present IdentifyTransactions message will be sent by the JD server to retrive the missing transactions.