### PR TITLE
critical fix for jdc config

### DIFF
--- a/roles/jd-client/README.md
+++ b/roles/jd-client/README.md
@@ -21,8 +21,8 @@ The configuration file contains the following information:
 1. The Job Declarator information which includes the Pool JD connection address (`jd_address`) and the Template Provider connection address to which to connect (`tp_address`).
 
 ### Run
-1. Copy the `proxy-config-example.toml` into `conf/` directory.
-2. Edit it with custom desired configuration and rename it `proxy-config.toml`
+1. Copy the `jdc-config-example.toml` into `conf/` directory.
+2. Edit it with custom desired configuration and rename it `jdc-config.toml`
 3. Point the SV1 Downstream Mining Device(s) to the Translator Proxy IP address and port.
 4. Run the Translator Proxy:
 
@@ -30,5 +30,5 @@ The configuration file contains the following information:
    cd roles/translator
    ```
    ```
-   cargo run -p translator_sv2 -- -c conf/proxy-config.toml
+   cargo run -p translator_sv2 -- -c conf/jdc-config.toml
    ```

--- a/roles/jd-client/src/args.rs
+++ b/roles/jd-client/src/args.rs
@@ -18,7 +18,7 @@ enum ArgsResult {
 }
 
 impl Args {
-    const DEFAULT_CONFIG_PATH: &'static str = "proxy-config.toml";
+    const DEFAULT_CONFIG_PATH: &'static str = "jdc-config.toml";
 
     pub fn from_args() -> Result<Self, String> {
         let cli_args = std::env::args();

--- a/roles/jd-client/src/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/upstream_sv2/upstream.rs
@@ -69,7 +69,7 @@ pub struct Upstream {
     /// This allows the upstream threads to be able to communicate back to the main thread its
     /// current status.
     tx_status: status::Sender,
-    /// Minimum `extranonce2` size. Initially requested in the `proxy-config.toml`, and ultimately
+    /// Minimum `extranonce2` size. Initially requested in the `jdc-config.toml`, and ultimately
     /// set by the SV2 Upstream via the SV2 `OpenExtendedMiningChannelSuccess` message.
     pub min_extranonce_size: u16,
     pub upstream_extranonce1_size: usize,


### PR DESCRIPTION
In the last PR (#637) I renamed the config file for jd-client from proxy-config.toml to jdc-config.toml.
However, the default config name was not updated, so right now if you do `cargo run` in jdc path, it doesn't work.
Here the fixes to this problem.