### PR TITLE
Fix dividing by zero

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -258,7 +258,10 @@ impl ChannelFactory {
                 .safe_lock(|ids| ids.new_channel_id(extended_channels_group))
                 .unwrap();
             self.channel_to_group_id.insert(channel_id, 0);
-            let target = crate::utils::hash_rate_to_target(hash_rate, self.share_per_min);
+            let target = match crate::utils::hash_rate_to_target(hash_rate, self.share_per_min) {
+                Ok(target) => target,
+                Err(_) => todo!(),
+            };
             let extranonce = self
                 .extranonces
                 .next_extended(max_extranonce_size as usize)?;
@@ -331,7 +334,10 @@ impl ChannelFactory {
         let hom_group_id = 0;
         let mut result = vec![];
         let channel_id = id;
-        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
+        let target = match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
+            Ok(target) => target,
+            Err(_) => todo!(),
+        };
         let extranonce = self
             .extranonces
             .next_standard()
@@ -374,7 +380,10 @@ impl ChannelFactory {
             .safe_lock(|ids| ids.new_channel_id(group_id))
             .unwrap();
         let complete_id = GroupId::into_complete_id(group_id, channel_id);
-        let target = crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min);
+        let target = match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
+            Ok(target_) => target_,
+            Err(_) => return Err(Error::ImpossibleToGetTarget),
+        };
         let extranonce = self
             .extranonces
             .next_standard()

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -932,7 +932,12 @@ impl ChannelFactory {
     }
     fn update_channel(&mut self, m: &UpdateChannel) -> Option<()> {
         if let Some(channel) = self.extended_channels.get_mut(&m.channel_id) {
-            let target = crate::utils::hash_rate_to_target(m.nominal_hash_rate, self.share_per_min);
+            let target = if let Ok(target_) = crate::utils::hash_rate_to_target(m.nominal_hash_rate, self.share_occurrance_frequency){
+                target_
+            } else {
+                return None;
+            };
+            
             channel.target = target;
             return Some(());
         };

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -334,10 +334,11 @@ impl ChannelFactory {
         let hom_group_id = 0;
         let mut result = vec![];
         let channel_id = id;
-        let target = match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
-            Ok(target) => target,
-            Err(_) => todo!(),
-        };
+        let target =
+            match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
+                Ok(target) => target,
+                Err(_) => todo!(),
+            };
         let extranonce = self
             .extranonces
             .next_standard()
@@ -380,10 +381,11 @@ impl ChannelFactory {
             .safe_lock(|ids| ids.new_channel_id(group_id))
             .unwrap();
         let complete_id = GroupId::into_complete_id(group_id, channel_id);
-        let target = match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
-            Ok(target_) => target_,
-            Err(_) => return Err(Error::ImpossibleToGetTarget),
-        };
+        let target =
+            match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
+                Ok(target_) => target_,
+                Err(_) => return Err(Error::ImpossibleToGetTarget),
+            };
         let extranonce = self
             .extranonces
             .next_standard()

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -202,7 +202,7 @@ struct ChannelFactory {
     extended_channels:
         HashMap<u32, OpenExtendedMiningChannelSuccess<'static>, BuildNoHashHasher<u32>>,
     extranonces: ExtendedExtranonce,
-    share_per_min: f32,
+    share_occurrance_frequency: u32,
     // (NewExtendedMiningJob,group ids that already received the future job)
     future_jobs: Vec<(NewExtendedMiningJob<'static>, Vec<u32>)>,
     // (SetNewPrevHash,group ids that already received the set prev_hash)
@@ -258,7 +258,7 @@ impl ChannelFactory {
                 .safe_lock(|ids| ids.new_channel_id(extended_channels_group))
                 .unwrap();
             self.channel_to_group_id.insert(channel_id, 0);
-            let target = match crate::utils::hash_rate_to_target(hash_rate, self.share_per_min) {
+            let target = match crate::utils::hash_rate_to_target(hash_rate, self.share_occurrance_frequency) {
                 Ok(target) => target,
                 Err(_) => todo!(),
             };
@@ -335,7 +335,7 @@ impl ChannelFactory {
         let mut result = vec![];
         let channel_id = id;
         let target =
-            match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
+            match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_occurrance_frequency) {
                 Ok(target) => target,
                 Err(_) => todo!(),
             };
@@ -382,7 +382,7 @@ impl ChannelFactory {
             .unwrap();
         let complete_id = GroupId::into_complete_id(group_id, channel_id);
         let target =
-            match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_per_min) {
+            match crate::utils::hash_rate_to_target(downstream_hash_rate, self.share_occurrance_frequency) {
                 Ok(target_) => target_,
                 Err(_) => return Err(Error::ImpossibleToGetTarget),
             };
@@ -958,7 +958,7 @@ impl PoolChannelFactory {
         ids: Arc<Mutex<GroupId>>,
         extranonces: ExtendedExtranonce,
         job_creator: JobsCreators,
-        share_per_min: f32,
+        share_occurrance_frequency: u32,
         kind: ExtendedChannelKind,
         pool_coinbase_outputs: Vec<TxOut>,
         pool_signature: String,
@@ -973,7 +973,7 @@ impl PoolChannelFactory {
             ),
             extended_channels: HashMap::with_hasher(BuildNoHashHasher::default()),
             extranonces,
-            share_per_min,
+            share_occurrance_frequency,
             future_jobs: Vec::new(),
             last_prev_hash: None,
             last_prev_hash_: None,
@@ -1267,7 +1267,7 @@ impl ProxyExtendedChannelFactory {
         ids: Arc<Mutex<GroupId>>,
         extranonces: ExtendedExtranonce,
         job_creator: Option<JobsCreators>,
-        share_per_min: f32,
+        share_occurrance_frequency: u32,
         kind: ExtendedChannelKind,
         pool_coinbase_outputs: Option<Vec<TxOut>>,
         pool_signature: String,
@@ -1296,7 +1296,7 @@ impl ProxyExtendedChannelFactory {
             ),
             extended_channels: HashMap::with_hasher(BuildNoHashHasher::default()),
             extranonces,
-            share_per_min,
+            share_occurrance_frequency,
             future_jobs: Vec::new(),
             last_prev_hash: None,
             last_prev_hash_: None,

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -52,6 +52,8 @@ pub enum Error {
     InvalidBip34Bytes(Vec<u8>),
     // (downstream_job_id, upstream_job_id)
     JobNotUpdated(u32, u32),
+    ImpossibleToGetHashrate,
+    ImpossibleToGetTarget,
 }
 
 impl From<BinarySv2Error> for Error {
@@ -138,6 +140,8 @@ impl Display for Error {
             PoisonLock(e) => write!(f, "Poison lock: {}", e),
             InvalidBip34Bytes(e) => write!(f, "Invalid Bip34 bytes {:?}", e),
             JobNotUpdated(ds_job_id, us_job_id) => write!(f, "Channel Factory did not update job: Downstream job id = {}, Upstream job id = {}", ds_job_id, us_job_id),
+            ImpossibleToGetTarget => write!(f, "Impossible to get Target"),
+            ImpossibleToGetHashrate => write!(f, "Impossible to get Hashrate"),
         }
     }
 }

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -312,12 +312,12 @@ pub fn hash_rate_to_target(h: f32, share_per_min: f32) -> Result<U256<'static>, 
 
 /// this function utilizes the equation used in [`hash_rate_to_target`], but
 /// translated to solve for hash_rate given a target: h = (2^256-t)/s(t+1)
-pub fn hash_rate_from_target(target: U256<'static>, share_per_min: f32) -> Result<f32, Error>  {
+pub fn hash_rate_from_target(target: U256<'static>, share_per_min: f32) -> Result<f32, Error> {
     // checks that we are not dividing by zero
     if share_per_min == 0.0 {
         return Err(Error::ImpossibleToGetHashrate);
     }
-    
+
     // *100 here to move the fractional bit up so we can make this an int later
     let s_times_100 = 60_f64 / (share_per_min as f64) * 100.0;
 
@@ -915,7 +915,9 @@ mod tests {
 
         let hr = 10.0; // 10 h/s
         let hrs = hr * 60.0; // number of hashes in 1 minute
-        let mut target = hash_rate_to_target(hr, 1.0).to_vec();
+        let mut target = hash_rate_to_target(hr, 1.0)
+            .expect("impossible to obtain target")
+            .to_vec();
         target.reverse();
         let target = bitcoin::util::uint::Uint256::from_be_slice(&target[..]).unwrap();
 
@@ -948,9 +950,11 @@ mod tests {
     fn test_hash_rate_from_target() {
         let hr = 202470.828;
         let expected_share_per_min = 1.0;
-        let target = hash_rate_to_target(hr, expected_share_per_min);
+        let target =
+            hash_rate_to_target(hr, expected_share_per_min).expect("impossible to obtain target");
         let realized_share_per_min = expected_share_per_min * 10.0; // increase SPM by 10x
-        let hash_rate = hash_rate_from_target(target, realized_share_per_min);
+        let hash_rate = hash_rate_from_target(target, realized_share_per_min)
+            .expect("impossible to obtain hashrate");
         // assert the hash_rate is the is the same as the initial set to ensure `hash_rate_from_target` is the
         // inverse of `hash_rate_to_target`
         let new_hr = (hr * 10.0).trunc();

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -297,7 +297,7 @@ pub fn hash_rate_to_target(hashrate: f32, shares_occurrency_frequence: u32) -> R
     let two_to_256_minus_one = bitcoin::util::uint::Uint256::from_be_bytes(two_to_256_minus_one);
 
     let mut  h_times_s_array = [0u8; 32];
-    h_times_s_array.copy_from_slice(&h_times_s.to_be_bytes());
+    h_times_s_array[16..32].copy_from_slice(&h_times_s.to_be_bytes());
     let numerator = two_to_256_minus_one - bitcoin::util::uint::Uint256::from_be_bytes(h_times_s_array);
 
     let mut target = numerator.div(denominator).to_be_bytes();

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -277,7 +277,7 @@ impl TryFrom<CoinbaseOutput> for Script {
 /// bdiff: 0x00000000ffff0000000000000000000000000000000000000000000000000000
 /// https://en.bitcoin.it/wiki/Difficulty#How_soon_might_I_expect_to_generate_a_block.3F
 
-pub fn hash_rate_to_target_(hashrate: f32, shares_occurrency_frequence: u32) -> Result<U256<'static>, crate::Error> {
+pub fn hash_rate_to_target(hashrate: f32, shares_occurrency_frequence: u32) -> Result<U256<'static>, crate::Error> {
     let hashrate: u128 = if let true = hashrate.is_sign_positive() {
        hashrate as u128 
     } else {
@@ -305,48 +305,10 @@ pub fn hash_rate_to_target_(hashrate: f32, shares_occurrency_frequence: u32) -> 
     Ok(U256::<'static>::from(target))
 }
 
-pub fn hash_rate_to_target(h: f32, share_per_min: f32) -> Result<U256<'static>, crate::Error> {
-    // checks that we are not dividing by zero
-    if share_per_min == 0.0 {
-        return Err(Error::ImpossibleToGetTarget);
-    }
-
-    // if we want 5 shares per minute, this means that s=60/5=12 seconds interval between shares
-    let s: f32 = 60_f32 / share_per_min;
-    let h_times_s = (h * s) as u128;
-
-    let h_times_s_plus_one = h_times_s + 1;
-    // checks that we are not dividing by zero
-    if h_times_s_plus_one == 0 {
-        return Err(Error::ImpossibleToGetTarget);
-    }
-    let h_times_s_plus_one: Uint256 = from_u128_to_uint256(h_times_s_plus_one);
-
-    let h_times_s: Uint256 = from_u128_to_uint256(h_times_s);
-
-    let two_to_256_minus_one = [255_u8; 32];
-    let two_to_256_minus_one = bitcoin::util::uint::Uint256::from_be_bytes(two_to_256_minus_one);
-
-    let numerator = two_to_256_minus_one - h_times_s;
-    let denominator = h_times_s_plus_one;
-    if denominator == Uint256::from_u64(0_u64).unwrap() {
-        return Err(Error::ImpossibleToGetTarget);
-    }
-    let target = numerator.div(denominator);
-    let mut target_be = target.to_be_bytes();
-    target_be.reverse();
-    Ok(U256::<'static>::from(target_be))
-}
-
-
-
-
-
-
 /// this function utilizes the equation used in [`hash_rate_to_target`], but
 /// translated to solve for hash_rate given a target: h = (2^256-t)/s(t+1)
 /// where s is seconds_between_two_consecutive_shares and t is target
-pub fn hash_rate_from_target_(target: U256<'static>, shares_occurrency_frequence: u32) -> Result<f32, Error> {
+pub fn hash_rate_from_target(target: U256<'static>, shares_occurrency_frequence: u32) -> Result<f32, Error> {
     let mut target_arr: [u8; 32] = [0; 32];
     target_arr.as_mut().copy_from_slice(target.inner_as_ref());
     target_arr.reverse();
@@ -373,45 +335,10 @@ pub fn hash_rate_from_target_(target: U256<'static>, shares_occurrency_frequence
     let result = from_uint128_to_u128(numerator.div(denominator).low_128());
     Ok(result as f32)
 }
-/// this function utilizes the equation used in [`hash_rate_to_target`], but
-/// translated to solve for hash_rate given a target: h = (2^256-t)/s(t+1)
-pub fn hash_rate_from_target(target: U256<'static>, share_per_min: f32) -> Result<f32, Error> {
-    // checks that we are not dividing by zero
-    if share_per_min == 0.0 {
-        return Err(Error::ImpossibleToGetHashrate);
-    }
-
-    // *100 here to move the fractional bit up so we can make this an int later
-    let s_times_100 = 60_f64 / (share_per_min as f64) * 100.0;
-
-    let mut target_arr: [u8; 32] = [0; 32];
-    target_arr.as_mut().copy_from_slice(target.inner_as_ref());
-    target_arr.reverse();
-
-    let target = Uint256::from_be_bytes(target_arr);
-    let mut target_plus_one = Uint256::from_be_bytes(target_arr);
-    target_plus_one.increment();
-
-    let max_target = [255_u8; 32];
-    let max_target = Uint256::from_be_bytes(max_target);
-    let share_times_target = u128_as_u256(s_times_100 as u128)
-        .mul(target_plus_one)
-        .div(Uint256::from_u64(100.0 as u64).unwrap()); //now divide the 100 back out
-    if share_times_target == Uint256::from_u64(0_u64).unwrap() {
-        return Err(Error::ImpossibleToGetHashrate);
-    }
-
-    Ok(((max_target - target).div(share_times_target).low_u32()) as f32)
-}
-
 fn from_uint128_to_u128(input: Uint128) -> u128 {
     let input = input.to_be_bytes();
     u128::from_be_bytes(input)
 }
-
-
-
-
 
 pub fn from_uint128_to_uint256(input: Uint128) -> Uint256 {
     let input: [u8; 16] = input.to_be_bytes();

--- a/roles/jd-client/src/downstream.rs
+++ b/roles/jd-client/src/downstream.rs
@@ -476,13 +476,13 @@ impl
             let coinbase_outputs = self.miner_coinbase_output.clone();
             let extranonces = ExtendedExtranonce::new(range_0, range_1, range_2);
             let creator = JobsCreators::new(extranonce_len as u8);
-            let share_per_min = 1.0;
+            let share_occurrance_frequency = 1_u32;
             let kind = roles_logic_sv2::channel_logic::channel_factory::ExtendedChannelKind::Pool;
             let channel_factory = PoolChannelFactory::new(
                 ids,
                 extranonces,
                 creator,
-                share_per_min,
+                share_occurrance_frequency,
                 kind,
                 coinbase_outputs,
                 "SOLO".to_string(),

--- a/roles/jd-client/src/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/upstream_sv2/upstream.rs
@@ -556,7 +556,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
 
         let extranonces = ExtendedExtranonce::new(range_0, range_1, range_2);
         let creator = roles_logic_sv2::job_creator::JobsCreators::new(total_len as u8);
-        let share_per_min = 1.0;
+        let share_occurrance_frequency = 1_u32;
         let channel_kind =
             roles_logic_sv2::channel_logic::channel_factory::ExtendedChannelKind::ProxyJd {
                 upstream_target: m.target.clone().into(),
@@ -565,7 +565,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
             ids,
             extranonces,
             creator,
-            share_per_min,
+            share_occurrance_frequency,
             channel_kind,
             vec![],
             pool_signature,

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -66,7 +66,7 @@ impl ChannelKind {
         &mut self,
         group_id: Arc<Mutex<GroupId>>,
         extranonces: ExtendedExtranonce,
-        downstream_share_per_minute: f32,
+        downstream_share_occurrence_frequency: u32,
         upstream_target: Target,
         up_id: u32,
     ) {
@@ -79,7 +79,7 @@ impl ChannelKind {
                     group_id,
                     extranonces,
                     None,
-                    downstream_share_per_minute,
+                    downstream_share_occurrence_frequency,
                     kind,
                     Some(vec![]),
                     String::from(""),
@@ -169,7 +169,7 @@ pub struct UpstreamMiningNode {
     pub channel_kind: ChannelKind,
     group_id: Arc<Mutex<GroupId>>,
     pub channel_ids: Arc<Mutex<Id>>,
-    downstream_share_per_minute: f32,
+    downstream_share_occurrence_frequency: u32,
     pub solution_sender: Option<Sender<SubmitSolution<'static>>>,
     pub recv_coinbase_out: Option<Receiver<(Vec<TxOut>, Vec<u8>)>>,
     #[allow(dead_code)]
@@ -201,7 +201,7 @@ impl UpstreamMiningNode {
         channel_kind: crate::ChannelKind,
         group_id: Arc<Mutex<GroupId>>,
         channel_ids: Arc<Mutex<Id>>,
-        downstream_share_per_minute: f32,
+        downstream_share_occurrence_frequency: u32,
         solution_sender: Option<Sender<SubmitSolution<'static>>>,
         recv_coinbase_out: Option<Receiver<(Vec<TxOut>, Vec<u8>)>>,
         downstream_hash_rate: f32,
@@ -222,7 +222,7 @@ impl UpstreamMiningNode {
             channel_kind: channel_kind.into(),
             group_id,
             channel_ids,
-            downstream_share_per_minute,
+            downstream_share_occurrence_frequency,
             solution_sender,
             recv_coinbase_out,
             tx_outs: HashMap::new(),
@@ -949,7 +949,7 @@ impl
         self.channel_kind.initialize_factory(
             self.group_id.clone(),
             extranonces,
-            self.downstream_share_per_minute,
+            self.downstream_share_occurrence_frequency,
             m.target.clone().try_into().unwrap(),
             m.channel_id,
         );

--- a/roles/mining-proxy/src/main.rs
+++ b/roles/mining-proxy/src/main.rs
@@ -121,7 +121,7 @@ pub struct Config {
     listen_mining_port: u16,
     max_supported_version: u16,
     min_supported_version: u16,
-    downstream_share_per_minute: f32,
+    downstream_share_occurrence_frequency: u32,
     expected_total_downstream_hr: f32,
     reconnect: bool,
 }
@@ -142,7 +142,7 @@ pub async fn initialize_r_logic(
             upstream_.channel_kind,
             group_id.clone(),
             channel_ids.clone(),
-            config.downstream_share_per_minute,
+            config.downstream_share_occurrence_frequency,
             None,
             None,
             config.expected_total_downstream_hr,

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -467,13 +467,13 @@ impl Pool {
         info!("PUB KEY: {:?}", pool_coinbase_outputs);
         let extranonces = ExtendedExtranonce::new(range_0, range_1, range_2);
         let creator = JobsCreators::new(extranonce_len as u8);
-        let share_per_min = 1.0;
+        let share_occurrence_frequency = 1_u32;
         let kind = roles_logic_sv2::channel_logic::channel_factory::ExtendedChannelKind::Pool;
         let channel_factory = Arc::new(Mutex::new(PoolChannelFactory::new(
             ids,
             extranonces,
             creator,
-            share_per_min,
+            share_occurrence_frequency,
             kind,
             pool_coinbase_outputs.expect("Invalid coinbase output in config"),
             config.pool_signature.clone(),

--- a/roles/translator/config-examples/proxy-config-local-jdc-example.toml
+++ b/roles/translator/config-examples/proxy-config-local-jdc-example.toml
@@ -28,9 +28,9 @@ coinbase_reward_sat = 5_000_000_000
 # hashes/s of the weakest miner that will be connecting
 min_individual_miner_hashrate=5_000_000.0
 # minimum number of shares needed before a mining.set_difficulty is sent for updating targets
-miner_num_submits_before_update=5
+miner_num_submits_before_update=10
 # target number of shares per minute the miner should be sending
-shares_per_minute = 6.0
+shares_occurrence_frequency = 10
 
 [upstream_difficulty_config]
 # interval in seconds to elapse before updating channel hashrate with the pool

--- a/roles/translator/config-examples/proxy-config-local-pool-example.toml
+++ b/roles/translator/config-examples/proxy-config-local-pool-example.toml
@@ -26,11 +26,11 @@ coinbase_reward_sat = 5_000_000_000
 # Difficulty params
 [downstream_difficulty_config]
 # hashes/s of the weakest miner that will be connecting
-min_individual_miner_hashrate=5_000_000.0
+min_individual_miner_hashrate=10_000_000.0
 # minimum number of shares needed before a mining.set_difficulty is sent for updating targets
 miner_num_submits_before_update=5
-# target number of shares per minute the miner should be sending
-shares_per_minute = 6.0
+# seconds between two consecutive shares the miner should be sending
+shares_occurrece_frequency = 10
 
 [upstream_difficulty_config]
 # interval in seconds to elapse before updating channel hashrate with the pool

--- a/roles/translator/src/error.rs
+++ b/roles/translator/src/error.rs
@@ -83,7 +83,6 @@ pub enum Error<'a> {
     Sv2ProtocolError(Mining<'a>),
     ImpossibleToGetTarget(roles_logic_sv2::errors::Error),
     ImpossibleToGetHashrate(roles_logic_sv2::errors::Error),
-
 }
 
 impl<'a> fmt::Display for Error<'a> {
@@ -115,9 +114,13 @@ impl<'a> fmt::Display for Error<'a> {
             Infallible(ref e) => write!(f, "Infallible Error:`{:?}`", e),
             Sv2ProtocolError(ref e) => {
                 write!(f, "Received Sv2 Protocol Error from upstream: `{:?}`", e)
-            },
-            ImpossibleToGetHashrate(ref e) => write!(f, "Impossible to get hashrate from target: `{:?}`", e),
-            ImpossibleToGetTarget(ref e) => write!(f, "Impossible to get target from hashrate: `{:?}`", e),
+            }
+            ImpossibleToGetHashrate(ref e) => {
+                write!(f, "Impossible to get hashrate from target: `{:?}`", e)
+            }
+            ImpossibleToGetTarget(ref e) => {
+                write!(f, "Impossible to get target from hashrate: `{:?}`", e)
+            }
         }
     }
 }

--- a/roles/translator/src/error.rs
+++ b/roles/translator/src/error.rs
@@ -81,6 +81,9 @@ pub enum Error<'a> {
     Infallible(std::convert::Infallible),
     // used to handle SV2 protocol error messages from pool
     Sv2ProtocolError(Mining<'a>),
+    ImpossibleToGetTarget(roles_logic_sv2::errors::Error),
+    ImpossibleToGetHashrate(roles_logic_sv2::errors::Error),
+
 }
 
 impl<'a> fmt::Display for Error<'a> {
@@ -112,7 +115,9 @@ impl<'a> fmt::Display for Error<'a> {
             Infallible(ref e) => write!(f, "Infallible Error:`{:?}`", e),
             Sv2ProtocolError(ref e) => {
                 write!(f, "Received Sv2 Protocol Error from upstream: `{:?}`", e)
-            }
+            },
+            ImpossibleToGetHashrate(ref e) => write!(f, "Impossible to get hashrate from target: `{:?}`", e),
+            ImpossibleToGetTarget(ref e) => write!(f, "Impossible to get target from hashrate: `{:?}`", e),
         }
     }
 }

--- a/roles/translator/src/proxy/bridge.rs
+++ b/roles/translator/src/proxy/bridge.rs
@@ -78,7 +78,7 @@ impl Bridge {
         up_id: u32,
     ) -> Arc<Mutex<Self>> {
         let ids = Arc::new(Mutex::new(GroupId::new()));
-        let share_per_min = 1.0;
+        let share_occurrence_frequency = 1_u32;
         let upstream_target: [u8; 32] =
             target.safe_lock(|t| t.clone()).unwrap().try_into().unwrap();
         let upstream_target: Target = upstream_target.into();
@@ -94,7 +94,7 @@ impl Bridge {
                 ids,
                 extranonces,
                 None,
-                share_per_min,
+                share_occurrence_frequency,
                 ExtendedChannelKind::Proxy { upstream_target },
                 None,
                 String::from(""),

--- a/roles/translator/src/proxy_config.rs
+++ b/roles/translator/src/proxy_config.rs
@@ -19,7 +19,7 @@ pub struct ProxyConfig {
 pub struct DownstreamDifficultyConfig {
     pub min_individual_miner_hashrate: f32,
     pub miner_num_submits_before_update: u32,
-    pub shares_per_minute: f32,
+    pub shares_occurrence_frequency: u32,
     #[serde(default = "u32::default")]
     pub submits_since_last_update: u32,
     #[serde(default = "u64::default")]

--- a/roles/translator/src/status.rs
+++ b/roles/translator/src/status.rs
@@ -170,7 +170,11 @@ pub async fn handle_error(
                 _ => send_status(sender, e, error_handling::ErrorBranch::Break).await,
             }
         }
-        Error::ImpossibleToGetTarget(_) => send_status(sender, e, error_handling::ErrorBranch::Continue).await,
-        Error::ImpossibleToGetHashrate(_) => send_status(sender, e, error_handling::ErrorBranch::Continue).await, 
+        Error::ImpossibleToGetTarget(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Continue).await
+        }
+        Error::ImpossibleToGetHashrate(_) => {
+            send_status(sender, e, error_handling::ErrorBranch::Continue).await
+        }
     }
 }

--- a/roles/translator/src/status.rs
+++ b/roles/translator/src/status.rs
@@ -170,5 +170,7 @@ pub async fn handle_error(
                 _ => send_status(sender, e, error_handling::ErrorBranch::Break).await,
             }
         }
+        Error::ImpossibleToGetTarget(_) => send_status(sender, e, error_handling::ErrorBranch::Continue).await,
+        Error::ImpossibleToGetHashrate(_) => send_status(sender, e, error_handling::ErrorBranch::Continue).await, 
     }
 }

--- a/utils/bip32-key-derivation/Cargo.toml
+++ b/utils/bip32-key-derivation/Cargo.toml
@@ -10,7 +10,7 @@ name = "bip32_derivation"
 path = "src/lib.rs"
 
 [[bin]]
-name = "bin"
+name = "bip32_derivation-bin"
 path = "src/main.rs"
 
 [dependencies]

--- a/utils/buffer/src/buffer.rs
+++ b/utils/buffer/src/buffer.rs
@@ -98,7 +98,7 @@ impl Buffer for TestBufferFromMemory {
     fn len(&self) -> usize {
         0
     }
-    fn danger_set_start(&mut self, index: usize) {
+    fn danger_set_start(&mut self, _index: usize) {
         todo!()
     }
 }

--- a/utils/error-handling/src/lib.rs
+++ b/utils/error-handling/src/lib.rs
@@ -7,7 +7,7 @@
 /// NOTE: There are 3 caveats to using this macro:
 /// 1. can only be used within async functions since status needs to be send over async channel
 /// 2. The macro must be used within a loop since it calls `continue` on error. If `unwraps/expects` are used within a function
-///     without a lopo, you should make the function return a result and handle the result within a main loop
+///     without a loop, you should make the function return a result and handle the result within a main loop
 /// 3. The macro must be able to reference the user defined function `crate::status::handle_error(T, U) -> ErrorBranch;` where U is the output
 ///     of `e.into()`
 ///

--- a/utils/key-utils/Cargo.toml
+++ b/utils/key-utils/Cargo.toml
@@ -10,7 +10,7 @@ name = "key_utils"
 path = "src/lib.rs"
 
 [[bin]]
-name = "bin"
+name = "key-utils-bin"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
the functions hash_rate_from_target and hash_rate_to_target performed some divisions between integers. If the denominator is zero, the process panics. So the signatures are changed with a Result<T,E> and consequentially the proper error management is introduced. When one of these two functions go with the unhappy path, the ambient process that called them just ignore the iteration of the loop. See [here](https://github.com/lorbax/stratum/blob/fix-dividing-by-zero/roles/translator/src/status.rs#L173) for details.

A test for the function update_miner_hashrate  in diff_management.rs is added.
