### PR TITLE
tarpaulin config file

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,16 +1,16 @@
 # Performs test coverage of project's libraries using cargo-tarpaulin and the message-generator, 
 # and generates results using codecov.io.
-# The follow flags are used when executing cargo-tarpaulin:
-# -- features: Includes the code with the listed features. The following features result in a
-#    tarpaulin error and are NOT included: derive, alloc, arbitrary-derive, attributes, and
-#    with_serde
-# --lib: Only tests the package's library unit tests. Includes protocols, and utils (without the
-#   exclude-files flag, it includes this example because it contains a lib.rs file)
-# --exclude-files examples/*: Excludes all projects in examples directory (specifically added to
-#   ignore examples that that contain a lib.rs file like interop-cpp)
-# --timeout 120: If unresponsive for 120 seconds, action will fail
-# --fail-under 30: If code coverage is less than 30%, action will fail
-# --out Xml: Required for codecov.io to generate coverage result
+# The following flags are set inside `tarpaulin.toml`:
+# `features = "..."`: Includes the code with the listed features. The following features result in a
+#     tarpaulin error and are NOT included: derive, alloc, arbitrary-derive, attributes, and
+#     with_serde
+# `run-types = [ "Lib" ]`: Only tests the package's library unit tests. Includes protocols, and utils (without the
+#     exclude-files flag, it includes this example because it contains a lib.rs file)
+# `exclude-files = [ "examples/*" ]`: Excludes all projects in examples directory (specifically added to
+#     ignore examples that that contain a lib.rs file like interop-cpp)
+# `timeout = "120s"`: If unresponsive for 120 seconds, action will fail
+# `fail-under = 20`: If code coverage is less than 20%, action will fail
+# `out = ["Xml"]`: Required for codecov.io to generate coverage result
 # All message-generator test flags are in tests in test/message-generator/test
 # This test loops through every test in test/message-generator/test, and runs each one, collecting
 # code coverage data for anything in the roles/ directory that is relevant to SV2(pool, mining-proxy)
@@ -40,7 +40,7 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo +nightly version; cargo +nightly tarpaulin --verbose --features disable_nopanic prop_test noise_sv2 fuzz with_buffer_pool async_std debug tokio with_tokio derive_codec_sv2 binary_codec_sv2 default core --lib --exclude-files examples/*,utils/message-generator/* --timeout 120 --fail-under 20 --out Xml
+          cargo +nightly version; cargo +nightly tarpaulin --verbose
 
       - name: Archive Tarpaulin code coverage results
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lcov.info
 .vscode
 *.py
 **/conf/**
+cobertura.xml

--- a/README.md
+++ b/README.md
@@ -476,31 +476,25 @@ This script will install cbindgen and then generate the `sv2.h` header file. Thi
 
 ### 4.02 Test
 
+As a prerequisite, you must have [`cargo-tarpaulin`](https://github.com/xd009642/tarpaulin) installed globally:
+
+```
+$ cargo install cargo-tarpaulin
+```
+
 Generate test coverage percentage with cargo-tarpaulin:
-
-Generate test coverage percentage with cargo-tarpaulin:
 ```
-cargo +nightly tarpaulin --verbose --features disable_nopanic prop_test noise_sv2 fuzz with_buffer_pool async_std debug tokio with_tokio derive_codec_sv2 binary_codec_sv2 default core --lib --exclude-files examples/* --timeout 120 --fail-under 30 --out Xml
+$ cargo +nightly tarpaulin --verbose
 ```
 
-Must have [cargo-tarpaulin](https://github.com/xd009642/tarpaulin) installed globally:
-
-```
-cargo install cargo-tarpaulin
-```
-
-Performs test coverage of entire project's libraries using cargo-tarpaulin and generates results using codecov.io.
-The following flags are used when executing cargo-tarpaulin:
-`--features`
-Includes the code with the listed features.
-The following features result in a tarpaulin error and are NOT included:
-derive, alloc, arbitrary-derive, attributes, with_serde
-`--lib`
-Only tests the package's library unit tests. Includes protocols, and utils (without the exclude-files flag, it includes this example because it contains a lib.rs file)
-`--exclude-files examples/*`: Excludes all projects in examples directory (specifically added to ignore examples that that contain a lib.rs file like interop-cpp)
-`--timeout 120`: If unresponsive for 120 seconds, action will fail
-`--fail-under 40`: If code coverage is less than 40%, action will fail
-`--out Xml`: Required for codecov.io to generate coverage result
+Performs test coverage of project's libraries using `cargo-tarpaulin` and generates results using `codecov.io`.
+The following flags are set inside `tarpaulin.toml`:
+- `features = "..."`: Includes the code with the listed features. The following features result in a `tarpaulin` error and are NOT included: `derive`, `alloc`, `arbitrary-derive`, `attributes`, and `with_serde`
+- `run-types = [ "Lib" ]`: Only tests the package's library unit tests. Includes protocols, and utils (without the exclude-files flag, it includes this example because it contains a `lib.rs` file)
+- `exclude-files = [ "examples/*" ]`: Excludes all projects in examples directory (specifically added to ignore examples that that contain a `lib.rs` file like `interop-cpp`)
+- `timeout = "120s"`: If unresponsive for 120 seconds, action will fail
+- `fail-under = 20`: If code coverage is less than 20%, action will fail
+- `out = ["Xml"]`: Required for `codecov.io` to generate coverage result
 
 ### 4.03 Run
 

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,9 @@
+[default]
+features = "disable_nopanic prop_test noise_sv2 fuzz with_buffer_pool async_std debug tokio with_tokio derive_codec_sv2 binary_codec_sv2 default core"
+run-types = [ "Lib" ]
+exclude-files = [ "examples/*" ]
+timeout = "120s"
+fail-under = 20
+
+[report]
+out = ["Xml"]


### PR DESCRIPTION
after #197 and #203 , `cargo-tarpaulin` performs test coverage via:
```
$ cargo +nightly tarpaulin --verbose --features disable_nopanic prop_test noise_sv2 fuzz with_buffer_pool async_std debug tokio with_tokio derive_codec_sv2 binary_codec_sv2 default core --lib --exclude-files examples/* --timeout 120 --fail-under 30 --out Xml
```

as requiested by @rrybarczyk in https://github.com/stratum-mining/stratum/issues/115, this PR adds a `tarpaulin.toml` file to the root of the project

with this PR, now the following is sufficient:
```
$ cargo +nightly tarpaulin --verbose
```

---

close #115 