### PR TITLE
Fix outdated timestamp

### DIFF
--- a/roles/jd-client/src/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/upstream_sv2/upstream.rs
@@ -268,13 +268,19 @@ impl Upstream {
             };
             tokio::task::yield_now().await;
         };
+
+        let updated_timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+
         let to_send = SetCustomMiningJob {
             channel_id,
             request_id,
             token: signed_token,
             version: declare_mining_job.version,
             prev_hash: set_new_prev_hash.prev_hash,
-            min_ntime: set_new_prev_hash.header_timestamp,
+            min_ntime: updated_timestamp,
             nbits: set_new_prev_hash.n_bits,
             coinbase_tx_version,
             coinbase_prefix,

--- a/roles/jd-client/src/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/upstream_sv2/upstream.rs
@@ -270,9 +270,9 @@ impl Upstream {
         };
 
         let updated_timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as u32;
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
 
         let to_send = SetCustomMiningJob {
             channel_id,

--- a/roles/translator/src/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/downstream_sv1/diff_management.rs
@@ -438,10 +438,10 @@ mod test {
             Arc::new(Mutex::new(upstream_config)),
         );
 
-        let total_run_time = std::time::Duration::from_secs(30);
+        let total_run_time = std::time::Duration::from_secs(120);
         let config_shares_per_minute = downstream_conf.shares_per_minute;
         // get initial hashrate
-        let initial_nominal_hashrate = measure_hashrate(5);
+        let initial_nominal_hashrate = measure_hashrate(10);
         // get target from hashrate and shares_per_sec
         let initial_target = match roles_logic_sv2::utils::hash_rate_to_target(
             initial_nominal_hashrate,

--- a/roles/translator/src/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/downstream_sv1/diff_management.rs
@@ -73,6 +73,7 @@ impl Downstream {
     pub async fn try_update_difficulty_settings(
         self_: Arc<Mutex<Self>>,
     ) -> ProxyResult<'static, ()> {
+        println!("ENTERED!!!!");
         let (diff_mgmt, channel_id) = self_
             .clone()
             .safe_lock(|d| (d.difficulty_mgmt.clone(), d.connection_id))
@@ -110,6 +111,7 @@ impl Downstream {
                 channel_id,
                 new_target: new_target.into(),
             };
+            println!("Message sent!");
             // notify bridge of target update
             Downstream::send_message_upstream(
                 self_.clone(),
@@ -273,6 +275,7 @@ impl Downstream {
                 let realized_share_per_min =
                     d.difficulty_mgmt.submits_since_last_update as f64 / (delta_time as f64 / 60.0);
                 tracing::debug!("\nREALIZED SHARES PER MINUTE {:?}", realized_share_per_min);
+                println!("\nREALIZED SHARES PER MINUTE {:?}", realized_share_per_min);
                 let mut new_miner_hashrate = match roles_logic_sv2::utils::hash_rate_from_target(
                     miner_target.clone().try_into()?,
                     realized_share_per_min,
@@ -290,6 +293,9 @@ impl Downstream {
                     / d.difficulty_mgmt.min_individual_miner_hashrate)
                     * 100.0;
                 tracing::debug!("\nMINER HASHRATE: {:?}", new_miner_hashrate);
+                println!("\nMINER HASHRATE: {:?}", new_miner_hashrate);
+                println!("\nHASHRATE DELTA %: {:?}", hashrate_delta_percentage);
+                println!("\nDELTA TIME: {:?}", delta_time);
 
                 if (hashrate_delta_percentage >= 100.0)
                     || (hashrate_delta_percentage >= 60.0) && (delta_time >= 60)
@@ -432,10 +438,10 @@ mod test {
             Arc::new(Mutex::new(upstream_config)),
         );
 
-        let total_run_time = std::time::Duration::from_secs(60);
+        let total_run_time = std::time::Duration::from_secs(30);
         let config_shares_per_minute = downstream_conf.shares_per_minute;
         // get initial hashrate
-        let initial_nominal_hashrate = measure_hashrate(10);
+        let initial_nominal_hashrate = measure_hashrate(5);
         // get target from hashrate and shares_per_sec
         let initial_target = match roles_logic_sv2::utils::hash_rate_to_target(
             initial_nominal_hashrate,

--- a/roles/translator/src/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/downstream_sv1/diff_management.rs
@@ -73,7 +73,6 @@ impl Downstream {
     pub async fn try_update_difficulty_settings(
         self_: Arc<Mutex<Self>>,
     ) -> ProxyResult<'static, ()> {
-        println!("ENTERED!!!!");
         let (diff_mgmt, channel_id) = self_
             .clone()
             .safe_lock(|d| (d.difficulty_mgmt.clone(), d.connection_id))
@@ -111,7 +110,6 @@ impl Downstream {
                 channel_id,
                 new_target: new_target.into(),
             };
-            println!("Message sent!");
             // notify bridge of target update
             Downstream::send_message_upstream(
                 self_.clone(),
@@ -275,7 +273,6 @@ impl Downstream {
                 let realized_share_per_min =
                     d.difficulty_mgmt.submits_since_last_update as f64 / (delta_time as f64 / 60.0);
                 tracing::debug!("\nREALIZED SHARES PER MINUTE {:?}", realized_share_per_min);
-                println!("\nREALIZED SHARES PER MINUTE {:?}", realized_share_per_min);
                 let mut new_miner_hashrate = match roles_logic_sv2::utils::hash_rate_from_target(
                     miner_target.clone().try_into()?,
                     realized_share_per_min,
@@ -293,9 +290,6 @@ impl Downstream {
                     / d.difficulty_mgmt.min_individual_miner_hashrate)
                     * 100.0;
                 tracing::debug!("\nMINER HASHRATE: {:?}", new_miner_hashrate);
-                println!("\nMINER HASHRATE: {:?}", new_miner_hashrate);
-                println!("\nHASHRATE DELTA %: {:?}", hashrate_delta_percentage);
-                println!("\nDELTA TIME: {:?}", delta_time);
 
                 if (hashrate_delta_percentage >= 100.0)
                     || (hashrate_delta_percentage >= 60.0) && (delta_time >= 60)

--- a/roles/translator/src/proxy/next_mining_notify.rs
+++ b/roles/translator/src/proxy/next_mining_notify.rs
@@ -37,7 +37,10 @@ pub fn create_notify(
     // u32 -> HexBytes
     let version = HexU32Be(new_job.version);
     let bits = HexU32Be(new_prev_hash.nbits);
-    let time = HexU32Be(new_prev_hash.min_ntime);
+    let time = HexU32Be(match new_job.is_future() {
+        true => new_prev_hash.min_ntime,
+        false => new_job.min_ntime.clone().into_inner().unwrap(),
+    });
 
     let notify_response = server_to_client::Notify {
         job_id,


### PR DESCRIPTION
From dev notes:
```
Timestamp issue - we should look into it
  - Every block we mine have the same timestamp as the previous block
  - New block is mined TP sees it and sends a current template, downstream doesn’t change the timestamp (JDC, translator      nor the mining machine)
  - When downstream receives a new template it can create a job with updated timestamp
  - Translator proxy should add this;
```

This PR fixes this issue, giving to the mining-device the most updated timestamp