### PR TITLE
FFI: pass in `message` to `Sv2Error::PayloadTooBig` variant

### DIFF
--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -144,7 +144,7 @@ pub extern "C" fn drop_sv2_error(s: Sv2Error) {
         Sv2Error::EncoderBusy => (),
         Sv2Error::InvalidSv2Frame => (),
         Sv2Error::MissingBytes => (),
-        Sv2Error::PayloadTooBig(a) => drop(a),
+        Sv2Error::PayloadTooBig(_) => (),
         Sv2Error::Unknown => (),
     }
 }

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(not(feature = "with_serde"))]
 use std::{
+    ffi::{CString, c_char},
     fmt,
     fmt::{Display, Formatter},
 };
@@ -313,7 +314,7 @@ pub enum Sv2Error {
     EncoderBusy,
     InvalidSv2Frame,
     MissingBytes,
-    PayloadTooBig(String),
+    PayloadTooBig(*const c_char),
     Unknown,
 }
 
@@ -404,7 +405,11 @@ fn encode_(
         EXTENSION_TYPE_NO_EXTENSION,
         c_bit,
     )
-    .ok_or(Sv2Error::PayloadTooBig(format!("{}", message)))?;
+    .ok_or(Sv2Error::PayloadTooBig(
+        CString::new(format!("{}", message))
+            .expect("CString::new failed")
+            .into_raw(),
+    ))?;
     encoder
         .encoder
         .encode(frame)

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg(not(feature = "with_serde"))]
 use std::{
-    ffi::{CString, c_char},
     fmt,
     fmt::{Display, Formatter},
 };
@@ -314,7 +313,7 @@ pub enum Sv2Error {
     EncoderBusy,
     InvalidSv2Frame,
     MissingBytes,
-    PayloadTooBig(*const c_char),
+    PayloadTooBig(CVec),
     Unknown,
 }
 
@@ -406,9 +405,7 @@ fn encode_(
         c_bit,
     )
     .ok_or(Sv2Error::PayloadTooBig(
-        CString::new(format!("{}", message))
-            .expect("CString::new failed")
-            .into_raw(),
+        format!("{}", message).as_bytes().into(),
     ))?;
     encoder
         .encoder

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg(not(feature = "with_serde"))]
-use std::fmt;
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 
 use codec_sv2::{Encoder, Frame, StandardDecoder, StandardSv2Frame};
 use common_messages_sv2::{
@@ -92,6 +95,12 @@ impl<'a> Sv2Message<'a> {
     }
 }
 
+impl<'a> Display for Sv2Message<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", *self)
+    }
+}
+
 #[repr(C)]
 pub enum CSv2Message {
     CoinbaseOutputDataSize(CoinbaseOutputDataSize),
@@ -135,7 +144,7 @@ pub extern "C" fn drop_sv2_error(s: Sv2Error) {
         Sv2Error::EncoderBusy => (),
         Sv2Error::InvalidSv2Frame => (),
         Sv2Error::MissingBytes => (),
-        Sv2Error::PayloadTooBig => (),
+        Sv2Error::PayloadTooBig(a) => drop(a),
         Sv2Error::Unknown => (),
     }
 }
@@ -304,7 +313,7 @@ pub enum Sv2Error {
     EncoderBusy,
     InvalidSv2Frame,
     MissingBytes,
-    PayloadTooBig,
+    PayloadTooBig(String),
     Unknown,
 }
 
@@ -314,7 +323,7 @@ impl fmt::Display for Sv2Error {
         match self {
             BinaryError(ref e) => write!(f, "{:?}", e),
             CodecError(ref e) => write!(f, "{:?}", e),
-            PayloadTooBig => write!(f, "Payload is too big"),
+            PayloadTooBig(ref e) => write!(f, "Payload is too big: {:?}", e),
             InvalidSv2Frame => write!(f, "Invalid Sv2 frame"),
             MissingBytes => write!(f, "Missing expected bytes"),
             EncoderBusy => write!(f, "Encoder is busy"),
@@ -390,12 +399,12 @@ fn encode_(
     let m_type = message.message_type();
     let c_bit = message.channel_bit();
     let frame = StandardSv2Frame::<Sv2Message<'static>>::from_message(
-        message,
+        message.clone(),
         m_type,
         EXTENSION_TYPE_NO_EXTENSION,
         c_bit,
     )
-    .ok_or(Sv2Error::PayloadTooBig)?;
+    .ok_or(Sv2Error::PayloadTooBig(format!("{}", message)))?;
     encoder
         .encoder
         .encode(frame)

--- a/protocols/v2/sv2-ffi/sv2.h
+++ b/protocols/v2/sv2-ffi/sv2.h
@@ -561,7 +561,7 @@ struct Sv2Error {
   };
 
   struct PayloadTooBig_Body {
-    const char *_0;
+    CVec _0;
   };
 
   Tag tag;

--- a/protocols/v2/sv2-ffi/sv2.h
+++ b/protocols/v2/sv2-ffi/sv2.h
@@ -560,10 +560,15 @@ struct Sv2Error {
     CError _0;
   };
 
+  struct PayloadTooBig_Body {
+    const char *_0;
+  };
+
   Tag tag;
   union {
     BinaryError_Body binary_error;
     CodecError_Body codec_error;
+    PayloadTooBig_Body payload_too_big;
   };
 };
 


### PR DESCRIPTION
close https://github.com/stratum-mining/stratum/issues/166

in this PR we are making `Sv2Error::PayloadTooBig` into `Sv2Error::PayloadTooBig(*const std::ffi::c_char)` so that it can carry `message`.

as @rrybarczyk put it on the original issue description:
> This will help tremendously with better understanding error messages for the sv2 bindings.

---

Note 1: this PR is not doing `Sv2Error::PayloadTooBig(String)` like it was suggested on the original issue description.

`*const std::ffi::c_char` was chosen instead of `String` for easier `cbindgen` compatibility. If `String` is used, `sv2.h` has incomplete type ‘String’ and compilation of `examples/interop-cpp/template-provider/template-provider.cpp` breaks as a consequence.

---

Note 2: this PR is not modifying `trait Frame` like it was suggested on the original issue description.

Instead, we simply implement the `Display` trait for `Sv2Message` and the error can be created via:
```rust
let message: Sv2Message;
...
Sv2Error::PayloadTooBig(
  CString::new(format!("{}", message))
    .expect("CString::new failed")
    .into_raw(),
))
```