### PR TITLE
Parse x-only pubkey for P2TR coinbase output

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -20,7 +20,7 @@ use stratum_common::{
             uint::{Uint128, Uint256},
             BitArray,
         },
-        PublicKey, Script, Transaction,
+        PublicKey, Script, Transaction, XOnlyPublicKey,
     },
 };
 use tracing::error;
@@ -237,12 +237,13 @@ impl TryFrom<CoinbaseOutput> for Script {
                 // Conceptually, every Taproot output corresponds to a combination of
                 // a single public key condition (the internal key),
                 // and zero or more general conditions encoded in scripts organized in a tree.
-                let pub_key = PublicKey::from_str(&value.output_script_value)
+                let pub_key = XOnlyPublicKey::from_str(&value.output_script_value)
                     .map_err(|_| Error::InvalidOutputScript)?;
-                Ok({
-                    let (pubkey_only, _) = pub_key.inner.x_only_public_key();
-                    Script::new_v1_p2tr::<All>(&Secp256k1::<All>::new(), pubkey_only, None)
-                })
+                Ok(Script::new_v1_p2tr::<All>(
+                    &Secp256k1::<All>::new(),
+                    pub_key,
+                    None,
+                ))
             }
             _ => Err(Error::UnknownOutputScriptType),
         }


### PR DESCRIPTION
Configuring a Taproot output for the coinbase currently expects a regular public key:

```toml
coinbase_outputs = [
    { output_script_type = "P2TR", output_script_value = "..." },
]
```

In order to extract the public key from a Bitcoin Core wallet, you'll need to do something like `getaddressinfo tr…` which will give you the _x-only_ public key. Same if you get the output descriptor.

This PR makes life easier by parsing an x-only pubkey.