### PR TITLE
fix JDC stack overflow

### DIFF
--- a/test/config/jds-stack-overflow/jdc-config.toml
+++ b/test/config/jds-stack-overflow/jdc-config.toml
@@ -1,0 +1,32 @@
+downstream_address = "0.0.0.0"
+downstream_port = 34265
+
+max_supported_version = 2
+min_supported_version = 2
+
+min_extranonce2_size = 8
+
+withhold = false
+
+authority_public_key = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+authority_secret_key = "7qbpUjScc865jyX2kiB4NVJANoC7GA7TAJupdzXWkc62"
+cert_validity_sec = 3600
+
+retry = 10
+
+tp_address = "75.119.150.111:8442"
+tp_authority_pub_key = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+
+coinbase_outputs = [
+    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+]
+
+[timeout]
+unit = "secs"
+value = 1
+
+[[upstreams]]
+authority_pubkey = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+pool_address = "127.0.0.1:34254"
+jd_address = "127.0.0.1:34264"
+pool_signature = "Stratum v2 SRI Pool"

--- a/test/config/jds-stack-overflow/mining-proxy-config.toml
+++ b/test/config/jds-stack-overflow/mining-proxy-config.toml
@@ -1,0 +1,11 @@
+upstreams = [
+    { channel_kind = "Extended",  address = "127.0.0.1", port = 34265, pub_key = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"},
+]
+listen_address = "127.0.0.1"
+listen_mining_port = 34255
+max_supported_version = 2
+min_supported_version = 2
+downstream_share_per_minute = 100
+coinbase_reward_sat = 5_000_000_000
+expected_total_downstream_hr = 10_000
+reconnect = false

--- a/test/config/jds-stack-overflow/pool-config.toml
+++ b/test/config/jds-stack-overflow/pool-config.toml
@@ -1,0 +1,13 @@
+listen_address = "127.0.0.1:34254"
+tp_address = "75.119.150.111:8442"
+authority_public_key = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+authority_secret_key = "7qbpUjScc865jyX2kiB4NVJANoC7GA7TAJupdzXWkc62"
+cert_validity_sec = 3600
+test_only_listen_adress_plain =  "0.0.0.0:34250"
+# list of coinbase outputs used to build the coinbase tx
+# ! right now only one output is supported, so comment all the ones you don't need !
+coinbase_outputs = [
+    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+]
+# Pool signature (string to be included in coinbase tx)
+pool_signature = "Stratum v2 SRI Pool"

--- a/test/message-generator/mock/jds-mock-no-token.json
+++ b/test/message-generator/mock/jds-mock-no-token.json
@@ -1,0 +1,49 @@
+{
+    "version": "2",
+    "doc": [
+        "This test does",
+        "Mock a JDS",
+        "Start listen to the port 34264",
+        "Receive setup_connection",
+        "Sends setup_connection_success",
+        "Receive new token",
+        "Hand leaving the connection opened"
+    ],
+    "frame_builders": [
+        {
+            "type": "automatic",
+            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_tproxy"
+        }
+    ],
+    "actions": [
+       {
+            "message_ids": ["setup_connection_success_tproxy"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x00"
+                }
+            ],
+            "actiondoc": "This action checks that a Setupconnection message is received"
+        }
+    ],
+    "setup_commands": [
+    ],
+    "execution_commands": [
+    ],
+    "cleanup_commands": [
+        {
+            "command": "sleep",
+            "args": ["10000000"],
+            "conditions": "None"
+        }
+    ],
+    "role": "server",
+    "upstream": {
+        "ip": "127.0.0.1",
+        "port": 34264,
+        "pub_key": "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign",
+        "secret_key": "7qbpUjScc865jyX2kiB4NVJANoC7GA7TAJupdzXWkc62"
+    }
+}

--- a/test/message-generator/test/jds-do-not-stackoverflow-when-no-token.json
+++ b/test/message-generator/test/jds-do-not-stackoverflow-when-no-token.json
@@ -1,0 +1,158 @@
+{
+    "version": "2",
+    "doc": [
+        "This test does",
+        "Launch a jds mock on 34264",
+        "Launch a pool on 34254",
+        "Launch jdc on 34265",
+        "Launch a mining proxy",
+        "Run a mining device",
+        "Wait 10 seconds and verify that jdc do not panic"
+    ],
+    "frame_builders": [
+    ],
+    "actions": [
+    ],
+    "setup_commands": [
+        {
+            "command": "cargo",
+            "args": [
+                        "run",
+                        "../../test/message-generator/mock/jds-mock-no-token.json"
+            ],
+
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "Running `target/debug/message_generator_sv2 ../../test/message-generator/mock/jds-mock-no-token.json`",
+                            "output_location": "StdErr",
+                            "condition": true,
+                            "late_condition": false
+                        }
+                    ],
+                    "timer_secs": 600,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "cargo",
+            "args": [
+                        "llvm-cov",
+                        "--no-report",
+                        "run",
+                        "-p",
+                        "pool_sv2",
+                        "--",
+                        "-c",
+                        "../test/config/jds-stack-overflow/pool-config.toml"
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "Listening for encrypted connection on:",
+                            "output_location": "StdOut",
+                            "condition": true,
+                            "late_condition": false
+                        }
+                    ],
+                    "timer_secs": 600,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "cargo",
+            "args": [
+                        "llvm-cov",
+                        "--no-report",
+                        "run",
+                        "-p",
+                        "jd_client",
+                        "--",
+                        "-c",
+                        "../test/config/jds-stack-overflow/jdc-config.toml"
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "Listening for downstream mining connections on",
+                            "output_location": "StdOut",
+                            "condition": true,
+                            "late_condition": false
+                        },
+                        {
+                            "output_string": "thread 'tokio-runtime-worker' has overflowed its stack",
+                            "output_location": "StdErr",
+                            "condition": false,
+                            "late_condition": true
+                        }
+                    ],
+                    "timer_secs": 600,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "cargo",
+            "args": [
+                        "llvm-cov",
+                        "--no-report",
+                        "run",
+                        "-p",
+                        "mining_proxy_sv2",
+                        "--",
+                        "-c",
+                        "../test/config/jds-stack-overflow/mining-proxy-config.toml"
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "Listening for downstream mining connections on 127.0.0.1:34255",
+                            "output_location": "StdOut",
+                            "condition": true,
+                            "late_condition": false
+                        }
+                    ],
+                    "timer_secs": 30,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "sleep",
+            "args": ["10000"],
+            "conditions": "None"
+        }
+
+    ],
+    "execution_commands": [
+    ],
+    "cleanup_commands": [
+        {
+            "command": "pkill",
+            "args":  ["-f", "pool_sv2", "-SIGINT"],
+            "conditions": "None"
+        },
+        {
+            "command": "pkill",
+            "args":  ["-f", "jd_server", "-SIGINT"],
+            "conditions": "None"
+        },
+        {
+            "command": "pkill",
+            "args":  ["-f", "jd_client", "-SIGINT"],
+            "conditions": "None"
+        },
+        {
+            "command": "pkill",
+            "args":  ["-f", "mining_proxy_sv2", "-SIGINT"],
+            "conditions": "None"
+        }
+    ],
+    "role": "none"
+}


### PR DESCRIPTION
https://github.com/stratum-mining/stratum/issues/688 has an extensive discussion around a Stack Overflow happening on JDC.

As @GitGab19 pointed out:
* JDC sends a `DeclareMiningJob` message to JDS
* JDS for some unknown reason takes some seconds to answer with a `DeclareMiningJobSuccess` message to JDC
* in the meantime, the JDC creates a new MiningJob (because a NewTemplate arrived from TP)
* JDC's call to `Self::start_templates` initiates a call to `Self::get_last_token`.
* `Self::get_last_token` checks `self.allocated_tokens.len()`, and in case it is `0`, it recursively calls itself, in order to eventually fill `self.allocated_tokens` and have something to work with. That will eventually happen, because `Self::get_last_token` always calls `Self::allocate_tokens`, which sends a `AllocateMiningJobToken ` to JDS.

The problem on the last point is that sometimes, JDS takes a bit longer than expected to reply back with a `AllocateMiningJobTokenSuccess`. So JDC's `self.allocated_tokens` remains empty for a relatively long time, and the multiple recursions on `Self::get_last_token` eventually cause the Stack to overflow.

This PR fixes this issue, because now whenever JDC is executing `Self::get_last_token`, if `self.allocated_tokens` is still empty, then it will we block/yield, and only initiate `Self::get_last_token` recursion after a message has already been received from JDS.

This way, recursion on `Self::get_last_token` is finite. There is no case where it keeps happening indefinitely and causing the Stack Overflow.

I successfully tested this solution by also applying the following modification to JDS:
```diff
diff --git a/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs b/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs
index 40781e6c..58216e71 100644
--- a/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs
@@ -131,6 +131,7 @@ where
             Ok(JobDeclaration::DeclareMiningJob(message)) => {
                 info!("Received DeclareMiningJob with id: {}", message.request_id);
                 debug!("DeclareMiningJob: {:?}", message);
+                std::thread::sleep(std::time::Duration::from_secs(30));
                 self_
                     .safe_lock(|x| x.handle_declare_mining_job(message))
                     .map_err(|e| crate::Error::PoisonLock(e.to_string()))?
```

The JDS modification above is not committed and is not part of this PR.
@GitGab19 figured out that this is a way to force the Stack Overflow to happen deterministically.

With the changes to JDC introduced by this PR, the Stack Overflow never happens, even when we try to force it with the JDS modification technique above.