### PR TITLE
Clippy on all worskpaces at once

### DIFF
--- a/clippy-on-all-workspaces.sh
+++ b/clippy-on-all-workspaces.sh
@@ -1,16 +1,30 @@
 #!/bin/sh
 
-WORKSPACES="benches/Cargo.toml common/Cargo.toml protocols/Cargo.toml roles/Cargo.toml
-utils/Cargo.toml"
+WORKSPACES="benches common protocols roles utils"
 
 for workspace in $WORKSPACES; do
     echo "Executing clippy on: $workspace"
-    cargo clippy --manifest-path="$workspace" -- -D warnings -A dead-code
+    cargo clippy --manifest-path="$workspace/Cargo.toml" -- -D warnings -A dead-code
     if [ $? -ne 0 ]; then
         echo "Clippy found some errors in: $workspace"
         exit 1
     fi
+
+    echo "Running tests on: $workspace"
+    cargo test --manifest-path="$workspace/Cargo.toml"
+    if [ $? -ne 0 ]; then
+        echo "Tests failed in: $workspace"
+        exit 1
+    fi
+
+    echo "Running fmt on: $workspace"
+    (cd $workspace && cargo +nightly fmt)
+    if [ $? -ne 0 ]; then
+        echo "Fmt failed in: $workspace"
+        exit 1
+    fi
 done
 
-echo "Clippy success!"
+echo "Clippy success, all tests passed!"
+
 

--- a/clippy-on-all-workspaces.sh
+++ b/clippy-on-all-workspaces.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+WORKSPACES="benches/Cargo.toml common/Cargo.toml protocols/Cargo.toml roles/Cargo.toml
+utils/Cargo.toml"
+
+for workspace in $WORKSPACES; do
+    echo "Executing clippy on: $workspace"
+    cargo clippy --manifest-path="$workspace" -- -D warnings -A dead-code
+    if [ $? -ne 0 ]; then
+        echo "Clippy found some errors in: $workspace"
+        exit 1
+    fi
+done
+
+echo "Clippy success!"
+


### PR DESCRIPTION
If we want to compile all the workspaces, we must do it for each separately. This is annoying and not practical.
This PR adds a small script that compiles all the workspaces sequentially and return an error if there are warnings or error