### PR TITLE
Update: translator do not accept bigger than 64K bytes lines from downstream

### DIFF
--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -113,6 +113,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1854,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.6"
 source = "git+https://github.com/diondokter/toml-rs?rev=c4161aa#c4161aa70202b3992dbec79b76e7a8659713b604"
@@ -1911,6 +1938,7 @@ name = "translator_sv2"
 version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
+ "async-compat",
  "async-recursion 0.3.2",
  "async-std",
  "binary_sv2",
@@ -1930,6 +1958,7 @@ dependencies = [
  "stratum-common",
  "sv1_api",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -32,6 +32,9 @@ tracing-subscriber = { version = "0.3" }
 v1 = { version = "^0.1.1", path = "../../protocols/v1", package="sv1_api" }
 error_handling = { version = "0.1", path = "../../utils/error-handling" }
 key-utils = { version = "^1.0.0", path = "../../utils/key-utils" }
+tokio-util = { version = "*", features = ["codec"] }
+async-compat = "0.2.1"
+
 
 
 [dev-dependencies]

--- a/roles/translator/src/lib/status.rs
+++ b/roles/translator/src/lib/status.rs
@@ -173,5 +173,8 @@ pub async fn handle_error(
         Error::TargetError(_) => {
             send_status(sender, e, error_handling::ErrorBranch::Continue).await
         }
+        Error::Sv1MessageTooLong => {
+            send_status(sender, e, error_handling::ErrorBranch::Break).await
+        }
     }
 }


### PR DESCRIPTION
Update the translator so that it do not accept any line from downstream but only the ones shorter then 2^16 bytes. Doing that it remove a possible vector for a dos attack. It must be said that translator is supposed to be used by miner in their local network with their mining device so I'm not sure how much useful this patch can be.

Unfortunately `async_std` do not have the equivalent of `tokio_util::codec::LineCodec` (not sure if out there there is something that can be used) so i had to implement the logic manually. Should be optimized enough. If we want better performance we can open a new PR.   


EDIT:

didn't notice PR #429 it seems that we can just use `LineCodec` from `tokio_util` I will remove the manual implementation and use that one, and force push it.