### PR TITLE
Baseline benchmarks on bencher for main branch

### DIFF
--- a/.github/workflows/run-and-track-benchmarks-on-main.yaml
+++ b/.github/workflows/run-and-track-benchmarks-on-main.yaml
@@ -1,0 +1,124 @@
+name: Run and Track Benchmarks On Main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  benchmark_sv1_criterion_with_bencher:
+    name: Track sv1 criterion benchmarks with Bencher
+    runs-on: ubuntu-latest
+    env:
+        BENCHER_PROJECT: stratum
+        BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+        BENCHER_ADAPTER: rust_criterion
+        BENCHER_TESTBED: sv1
+    steps:
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.70.0
+          override: true
+      - name: Checkout repository
+        uses: actions/checkout@v2
+            
+      - uses: actions/checkout@v3
+      - uses: bencherdev/bencher@v0.3.10
+      - name: Benchmark with Bencher
+        run: |
+            cd benches 
+            bencher run \
+            --github-actions ${{ secrets.GITHUB_TOKEN }} \
+            "cargo bench --bench criterion_sv1_benchmark"
+
+  benchmark_sv2_criterion_with_bencher:
+    name: Track sv2 criterion benchmarks with Bencher
+    runs-on: ubuntu-latest
+    env:
+        BENCHER_PROJECT: stratum
+        BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+        BENCHER_ADAPTER: rust_criterion
+        BENCHER_TESTBED: sv2
+    steps:
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.70.0
+          override: true
+      - name: Checkout repository
+        uses: actions/checkout@v2
+            
+      - uses: actions/checkout@v3
+      - uses: bencherdev/bencher@v0.3.10
+      - name: Benchmark with Bencher
+        run: |
+            cd benches 
+            bencher run \
+            --github-actions ${{ secrets.GITHUB_TOKEN }} \
+            "cargo bench --bench criterion_sv2_benchmark"
+    
+  benchmark_sv1_iai_with_bencher:
+    name: Track sv1 iai benchmarks with Bencher
+    runs-on: ubuntu-latest
+    env:
+        BENCHER_PROJECT: stratum
+        BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+        BENCHER_ADAPTER: rust_iai
+        BENCHER_TESTBED: sv1
+    steps:
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.70.0
+          override: true
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Valgrind
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y valgrind=1:3.18.1-1ubuntu2 
+            
+      - uses: actions/checkout@v3
+      - uses: bencherdev/bencher@v0.3.10
+      - name: Benchmark with Bencher
+        run: |
+            cd benches 
+            bencher run \
+            --github-actions ${{ secrets.GITHUB_TOKEN }} \
+            "cargo bench --bench iai_sv1_benchmark"
+    
+  benchmark_sv2_iai_with_bencher:
+    name: Track sv2 iai benchmarks with Bencher
+    runs-on: ubuntu-latest
+    env:
+        BENCHER_PROJECT: stratum
+        BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+        BENCHER_ADAPTER: rust_iai
+        BENCHER_TESTBED: sv2
+    steps:
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.70.0
+          override: true
+      - name: Checkout repository
+        uses: actions/checkout@v2
+           
+      - name: Install Valgrind
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y valgrind=1:3.18.1-1ubuntu2 
+            
+      - uses: actions/checkout@v3
+      - uses: bencherdev/bencher@v0.3.10
+      - name: Benchmark with Bencher
+        run: |
+            cd benches 
+            bencher run \
+            --github-actions ${{ secrets.GITHUB_TOKEN }} \
+            "cargo bench --bench iai_sv2_benchmark"

--- a/.github/workflows/run-and-track-benchmarks-on-main.yaml
+++ b/.github/workflows/run-and-track-benchmarks-on-main.yaml
@@ -1,7 +1,7 @@
 name: Run and Track Benchmarks On Main
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/run-benchmarks.yaml
+++ b/.github/workflows/run-benchmarks.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   benchmark_sv1_criterion:

--- a/.github/workflows/track-benchmarks.yaml
+++ b/.github/workflows/track-benchmarks.yaml
@@ -54,7 +54,7 @@ jobs:
           script: |
             let fs = require('fs');
             let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
+            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
             core.exportVariable("PR_DEFAULT", prEvent.pull_request.base.repo.default_branch);
             core.exportVariable("PR_NUMBER", prEvent.number);


### PR DESCRIPTION
I added a new workflow to be executed every time we merge new PRs on main branch.
In this way we can maintain a better tracking of benchmarks executed on the main branch, visualizing them on [bencher.dev](https://bencher.dev/console/projects/stratum-v2-sri/perf?key=true&reports_per_page=4&branches_per_page=8&testbeds_per_page=8&benchmarks_per_page=8&reports_page=1&branches_page=2&testbeds_page=1&benchmarks_page=4&testbeds=057e03a0-be5a-4804-9dc0-9f914c196040%2C6e5299a9-5f8e-48db-b3e9-d0be3f592002&benchmarks=e99d34e3-9906-4ff4-9bda-b28360edf0fe%2C986d5bb7-2a50-443a-8c63-0c9d0a4eaf7c%2C0718860c-1091-41cf-be7e-1d4876b5fe79%2C41389b77-4f6b-4abc-a69b-44f73dddbc21%2C0372bad6-fe36-4b12-86b2-49f321a6bf50%2C8c7d8e76-33b4-4eef-87ef-1bf184855e6b%2Ca5429b2b-f710-4e7d-b6cc-3b5114804250%2C3290a515-f290-45eb-b85f-a40978196c36%2C9ad3419a-89d9-45a8-b834-d46f7ee873e3%2C4e68f814-5ccf-422b-b2c9-ddfb2ceb7699%2C26f91c9e-29b3-4d3e-9590-8b85448090d9%2C5ced806c-787b-4fd2-b0b0-1026233cc047&measures=4ee07488-ffef-41ac-ad4a-e286d204f134&start_time=1705506473000&end_time=1708098473000&clear=true&tab=benchmarks&branches=9c79faed-80db-4d0e-8100-b7dba4091898)