### PR TITLE
easy script for compiling during development

### DIFF
--- a/build-on-all-workspaces.sh
+++ b/build-on-all-workspaces.sh
@@ -1,0 +1,24 @@
+
+#!/bin/sh
+
+WORKSPACES="benches common protocols roles utils"
+
+for workspace in $WORKSPACES; do
+    echo "Executing build on: $workspace"
+    cargo build --manifest-path="$workspace/Cargo.toml" -- 
+    if [ $? -ne 0 ]; then
+        echo "Build found some errors in: $workspace"
+        exit 1
+    fi
+
+    echo "Running fmt on: $workspace"
+    (cd $workspace && cargo +nightly fmt)
+    if [ $? -ne 0 ]; then
+        echo "Fmt failed in: $workspace"
+        exit 1
+    fi
+done
+
+echo "build success!"
+
+


### PR DESCRIPTION
this PR follows a [suggestion](https://github.com/stratum-mining/stratum/pull/761/files#r1495079458) by @plebhash during the review of [PR761](https://github.com/stratum-mining/stratum/pull/761/). This should be merged *before* PR761 (because already includes this script)

WHAT THIS PR DOES:
after that the SRI has been divided in several workspaces for external consuption, it is annoying to compile every workspace manually. So, a script named clippy-on-all-workspaces.sh has been added. This script is mean to aid the the final phase of developing a feature, where build compiles and we pass to clippy.
In a preliminary phase of developing though, it is necessary something that compiles a bit less deep and we do want to make tests pass. Thats why I propose this script that does exactly this:
performes `cargo build` and `cargo +nightly fmt` in each workspace.