### PR TITLE
publish `roles` lib crates to `crates.io`

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -135,3 +135,23 @@ jobs:
         run: |
           cd utils/network-helpers
           cargo publish
+      - name: Publish crates jd_client
+        continue-on-error: true
+        run: |
+          cargo publish --manifest-path=roles/jd-client/Cargo.toml
+      - name: Publish crates jd_server
+        continue-on-error: true
+        run: |
+          cargo publish --manifest-path=roles/jd-server/Cargo.toml
+      - name: Publish crates mining_proxy_sv2
+        continue-on-error: true
+        run: |
+          cargo publish --manifest-path=roles/mining-proxy/Cargo.toml
+      - name: Publish crates pool_sv2
+        continue-on-error: true
+        run: |
+          cargo publish --manifest-path=roles/pool/Cargo.toml
+      - name: Publish crates translator_sv2
+        continue-on-error: true
+        run: |
+          cargo publish --manifest-path=roles/translator/Cargo.toml

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -25,133 +25,133 @@ jobs:
             override: true
       - name: Login
         run: cargo login ${{ secrets.CRATES_IO_DEPLOY_KEY }}
-      - name: Publish crates common
+      - name: Publish crate common
         continue-on-error: true
         run: |
           cd common
           cargo publish
-      - name: Publish crates buffer_sv2
+      - name: Publish crate buffer_sv2
         continue-on-error: true
         run: |
           cd utils/buffer
           cargo publish
-      - name: Publish crates no_serde_sv2_derive_codec
+      - name: Publish crate no_serde_sv2_derive_codec
         continue-on-error: true
         run: |
           cd protocols/v2/binary-sv2/no-serde-sv2/derive_codec
           cargo publish
-      - name: Publish crates no_serde_sv2_codec
+      - name: Publish crate no_serde_sv2_codec
         continue-on-error: true
         run: |
           cd protocols/v2/binary-sv2/no-serde-sv2/codec
           cargo publish
-      - name: Publish crates serde_sv2
+      - name: Publish crate serde_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/binary-sv2/serde-sv2
           cargo publish
-      - name: Publish crates binary_sv2
+      - name: Publish crate binary_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/binary-sv2/binary-sv2
           cargo publish
-      - name: Publish crates binary_sv2
+      - name: Publish crate binary_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/binary-sv2/binary-sv2
           cargo publish
-      - name: Publish crates const_sv2
+      - name: Publish crate const_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/const-sv2
           cargo publish
-      - name: Publish crates framing_sv2
+      - name: Publish crate framing_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/framing-sv2
           cargo publish
-      - name: Publish crates noise_sv2
+      - name: Publish crate noise_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/noise-sv2
           cargo publish
-      - name: Publish crates codec_sv2
+      - name: Publish crate codec_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/codec-sv2
           cargo publish
-      - name: Publish crates common_messages
+      - name: Publish crate common_messages
         continue-on-error: true
         run: |
           cd protocols/v2/subprotocols/common-messages
           cargo publish
-      - name: Publish crates job_declaration
+      - name: Publish crate job_declaration
         continue-on-error: true
         run: |
           cd protocols/v2/subprotocols/job-declaration
           cargo publish
-      - name: Publish crates mining
+      - name: Publish crate mining
         continue-on-error: true
         run: |
           cd protocols/v2/subprotocols/mining
           cargo publish
-      - name: Publish crates template_distribution
+      - name: Publish crate template_distribution
         continue-on-error: true
         run: |
           cd protocols/v2/subprotocols/template-distribution
           cargo publish
-      - name: Publish crates sv2_ffi
+      - name: Publish crate sv2_ffi
         continue-on-error: true
         run: |
           cd protocols/v2/sv2-ffi
           cargo publish
-      - name: Publish crates roles_logic_sv2
+      - name: Publish crate roles_logic_sv2
         continue-on-error: true
         run: |
           cd protocols/v2/roles-logic-sv2
           cargo publish
-      - name: Publish crates v1
+      - name: Publish crate v1
         continue-on-error: true
         run: |
           cd protocols/v1
           cargo publish
-      - name: Publish crates bip32-key-derivation
+      - name: Publish crate bip32-key-derivation
         continue-on-error: true
         run: |
           cd utils/bip32-key-derivation
           cargo publish
-      - name: Publish crates error-handling
+      - name: Publish crate error-handling
         continue-on-error: true
         run: |
           cd utils/error-handling
           cargo publish
-      - name: Publish crates key-utils
+      - name: Publish crate key-utils
         continue-on-error: true
         run: |
           cd utils/key-utils
           cargo publish
-      - name: Publish crates network-helpers
+      - name: Publish crate network-helpers
         continue-on-error: true
         run: |
           cd utils/network-helpers
           cargo publish
-      - name: Publish crates jd_client
+      - name: Publish crate jd_client
         continue-on-error: true
         run: |
           cargo publish --manifest-path=roles/jd-client/Cargo.toml
-      - name: Publish crates jd_server
+      - name: Publish crate jd_server
         continue-on-error: true
         run: |
           cargo publish --manifest-path=roles/jd-server/Cargo.toml
-      - name: Publish crates mining_proxy_sv2
+      - name: Publish crate mining_proxy_sv2
         continue-on-error: true
         run: |
           cargo publish --manifest-path=roles/mining-proxy/Cargo.toml
-      - name: Publish crates pool_sv2
+      - name: Publish crate pool_sv2
         continue-on-error: true
         run: |
           cargo publish --manifest-path=roles/pool/Cargo.toml
-      - name: Publish crates translator_sv2
+      - name: Publish crate translator_sv2
         continue-on-error: true
         run: |
           cargo publish --manifest-path=roles/translator/Cargo.toml


### PR DESCRIPTION
since `roles` crates are `lib`, it makes sense to have them on crates.io as well