### PR TITLE
Hosted TP authority_public_key fix

### DIFF
--- a/roles/jd-client/config-examples/jdc-config-hosted-example.toml
+++ b/roles/jd-client/config-examples/jdc-config-hosted-example.toml
@@ -28,7 +28,7 @@ retry = 10
 # tp_address = "127.0.0.1:8442"
 # Hosted testnet TP 
 tp_address = "75.119.150.111:8442"
-tp_authority_public_key = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+tp_authority_public_key = "9azQdassggC7L3YMVcZyRJmK7qrFDj5MZNHb4LkaUrJRUhct92W"
 
 # Solo Mining config
 # List of coinbase outputs used to build the coinbase tx in case of Solo Mining (as last-resort solution of the pools fallback system)

--- a/roles/pool/config-examples/pool-config-hosted-tp-example.toml
+++ b/roles/pool/config-examples/pool-config-hosted-tp-example.toml
@@ -25,4 +25,4 @@ pool_signature = "Stratum v2 SRI Pool"
 #tp_address = "127.0.0.1:8442"
 # Hosted testnet TP 
 tp_address = "75.119.150.111:8442"
-tp_authority_public_key = "EguTM8URcZDQVeEBsM4B5vg9weqEUnufA8pm85fG4bZd"
+tp_authority_public_key = "9azQdassggC7L3YMVcZyRJmK7qrFDj5MZNHb4LkaUrJRUhct92W"


### PR DESCRIPTION
This PR fixes the `authority_public_key` for our hosted TP, so that testers can correctly use again the `jdc-config-hosted-example.toml` as described in our [getting-started](authority_public_key) guide.