### PR TITLE
Add handlers for deserilized messages

### DIFF
--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noise_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -602,7 +602,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "roles_logic_sv2"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "binary_sv2",
  "chacha20poly1305",

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roles_logic_sv2"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 description = "Common handlers for use within SV2 roles"
 license = "MIT OR Apache-2.0"

--- a/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs
@@ -18,7 +18,14 @@ where
         message_type: u8,
         payload: &mut [u8],
     ) -> Result<SendTo, Error> {
-        match (message_type, payload).try_into() {
+        Self::handle_message_job_declaration_deserialized(self_, (message_type, payload).try_into())
+    }
+
+    fn handle_message_job_declaration_deserialized(
+        self_: Arc<Mutex<Self>>,
+        message: Result<JobDeclaration<'_>, Error>,
+    ) -> Result<SendTo, Error> {
+        match message {
             Ok(JobDeclaration::AllocateMiningJobTokenSuccess(message)) => {
                 debug!(
                     "Received AllocateMiningJobTokenSuccess with id: {}",
@@ -117,7 +124,14 @@ where
         message_type: u8,
         payload: &mut [u8],
     ) -> Result<SendTo, Error> {
-        match (message_type, payload).try_into() {
+        Self::handle_message_job_declaration_deserialized(self_, (message_type, payload).try_into())
+    }
+
+    fn handle_message_job_declaration_deserialized(
+        self_: Arc<Mutex<Self>>,
+        message: Result<JobDeclaration<'_>, Error>,
+    ) -> Result<SendTo, Error> {
+        match message {
             Ok(JobDeclaration::AllocateMiningJobToken(message)) => {
                 debug!(
                     "Received AllocateMiningJobToken with id: {}",

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -1199,7 +1199,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noise_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1527,7 +1527,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "roles_logic_sv2"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "binary_sv2",
  "chacha20poly1305",

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "noise_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",

--- a/utils/message-generator/Cargo.lock
+++ b/utils/message-generator/Cargo.lock
@@ -121,14 +121,14 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "binary_codec_sv2"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "buffer_sv2",
 ]
 
 [[package]]
 name = "binary_sv2"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "binary_codec_sv2",
  "derive_codec_sv2",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "serde",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "common_messages_sv2"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -306,7 +306,10 @@ dependencies = [
 
 [[package]]
 name = "const_sv2"
-version = "0.1.2"
+version = "0.1.3"
+dependencies = [
+ "secp256k1 0.28.2",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -359,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "derive_codec_sv2"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "binary_codec_sv2",
 ]
@@ -394,7 +397,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "framing_sv2"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -587,7 +590,7 @@ name = "key-utils"
 version = "1.0.0"
 dependencies = [
  "bs58",
- "secp256k1 0.27.0",
+ "secp256k1 0.28.2",
  "serde",
 ]
 
@@ -654,7 +657,7 @@ dependencies = [
  "network_helpers",
  "rand",
  "roles_logic_sv2",
- "secp256k1 0.27.0",
+ "secp256k1 0.28.2",
  "serde",
  "serde_json",
  "sv1_api",
@@ -666,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "mining_sv2"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -695,11 +698,12 @@ dependencies = [
 
 [[package]]
 name = "network_helpers"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel",
  "binary_sv2",
  "codec_sv2",
+ "const_sv2",
  "futures",
  "serde",
  "tokio",
@@ -714,14 +718,14 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noise_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "const_sv2",
  "rand",
  "rand_chacha",
- "secp256k1 0.28.1",
+ "secp256k1 0.28.2",
 ]
 
 [[package]]
@@ -954,7 +958,7 @@ checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "roles_logic_sv2"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "binary_sv2",
  "chacha20poly1305",
@@ -1001,20 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
-dependencies = [
- "bitcoin_hashes 0.12.0",
- "rand",
- "secp256k1-sys 0.8.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f622567e3b4b38154fb8190bcf6b160d7a4301d70595a49195b48c116007a27"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "bitcoin_hashes 0.12.0",
  "rand",
@@ -1026,15 +1019,6 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -1092,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "serde_sv2"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "buffer_sv2",
  "serde",
@@ -1175,7 +1159,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "sv1_api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -1201,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "template_distribution_sv2"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "binary_sv2",
  "const_sv2",


### PR DESCRIPTION
Each Sv2 protocol have a server and client trait. This trait have a method that handle serilaized messages. This PR add a method that handle deserilized messages, and modify the method for serilaized so that it just deserilize the message and call the new method. This can be usefull if we have more roles managed by the same rust process, to avoid some serailization and deserialization. It also bump the minor version of the roles-logic-sv2 lib cause it add a feature and do not breack and API.