### PR TITLE
JDS block construction and propagation fix

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -785,7 +785,7 @@ impl<'a> From<BlockCreator<'a>> for bitcoin::Block {
 
         let prev_blockhash = u256_to_block_hash(message.prev_hash.into_static());
         let header = stratum_common::bitcoin::blockdata::block::BlockHeader {
-            version: last_declare.version as i32,
+            version: message.version as i32,
             prev_blockhash,
             merkle_root,
             time: message.ntime,

--- a/protocols/v2/subprotocols/job-declaration/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/submit_solution.rs
@@ -17,6 +17,7 @@ pub struct SubmitSolutionJd<'decoder> {
     pub ntime: u32,
     pub nonce: u32,
     pub nbits: u32,
+    pub version: u32,
 }
 
 #[cfg(feature = "with_serde")]

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -422,6 +422,7 @@ impl JobDeclarator {
             ntime: solution.ntime,
             nonce: solution.nonce,
             nbits: prev_hash.n_bits,
+            version: solution.version,
         };
         let frame: StdFrame =
             PoolMessages::JobDeclaration(JobDeclaration::SubmitSolution(solution))


### PR DESCRIPTION
This PR fixes the way JDS manages and uses `version` field in the block header, taking it from the `successful share` instead of taking it from the `DeclareMiningJob` message.

Right now, since version-rolling is used, this field was changed many times by the miner and so JDS was not able to correctly build the right block header, as pointed out in the Template Provider logs as well:
`2024-02-29T17:45:55Z ERROR: ProcessNewBlock: AcceptBlock FAILED (high-hash, proof of work failed)`.
In the past we didn't figure out the exact reason of this message, because in the meantime block were propagated also from JDC. While testing PR #761 we forced JDC to not propagate it and the result was that we couldn't propagate valid blocks found because of the aforementioned reason.

Since I applied this patch to that PR, we finally mined and properly propagated many blocks on the testnet.