### PR TITLE
`release-libs.yaml` automatically triggered on PRs to `main`

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -11,7 +11,7 @@
 name: Release Libs
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: 'main'
 
       - name: Run check-versioning-lib-release.sh
         run: |

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -10,9 +10,10 @@
 
 name: Release Libs
 
-on: 
-  # Manually run by going to "Actions/Release" in Github and running the workflow
-  workflow_dispatch:
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   libs_publish:

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -11,7 +11,7 @@
 name: Release Libs
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: 'main'
 
       - name: Run check-versioning-lib-release.sh
         run: |

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -136,23 +136,3 @@ jobs:
         run: |
           cd roles/roles-utils/rpc
           cargo publish
-      - name: Publish crate jd_client
-        continue-on-error: true
-        run: |
-          cargo publish --manifest-path=roles/jd-client/Cargo.toml
-      - name: Publish crate jd_server
-        continue-on-error: true
-        run: |
-          cargo publish --manifest-path=roles/jd-server/Cargo.toml
-      - name: Publish crate mining_proxy_sv2
-        continue-on-error: true
-        run: |
-          cargo publish --manifest-path=roles/mining-proxy/Cargo.toml
-      - name: Publish crate pool_sv2
-        continue-on-error: true
-        run: |
-          cargo publish --manifest-path=roles/pool/Cargo.toml
-      - name: Publish crate translator_sv2
-        continue-on-error: true
-        run: |
-          cargo publish --manifest-path=roles/translator/Cargo.toml

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -16,6 +16,18 @@ on:
       - main
 
 jobs:
+  check_versioning_lib_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: run check-versioning-lib-release.sh
+      - uses: actions/checkout@v3
+        run: |
+          ./check-versioning-lib-release.sh
+          if [ $? -eq 1 ]; then
+            echo "Script returned exit code 1, halting the workflow"
+            exit 1
+          fi
+
   libs_publish:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -16,7 +16,7 @@ on:
       - main
 
 jobs:
-  check_versioning_lib_release:
+  libs_publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -30,14 +30,11 @@ jobs:
             exit 1
           fi
 
-  libs_publish:
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            override: true
+          toolchain: stable
+          override: true
       - name: Login
         run: cargo login ${{ secrets.CRATES_IO_DEPLOY_KEY }}
       - name: Publish crate common

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -19,8 +19,10 @@ jobs:
   check_versioning_lib_release:
     runs-on: ubuntu-latest
     steps:
-      - name: run check-versioning-lib-release.sh
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run check-versioning-lib-release.sh
         run: |
           ./check-versioning-lib-release.sh
           if [ $? -eq 1 ]; then

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -147,3 +147,28 @@ jobs:
         run: |
           cd roles/roles-utils/rpc
           cargo publish
+      - name: Publish crate jd_client
+        continue-on-error: true
+        run: |
+          cd roles/jd-client
+          cargo publish
+      - name: Publish crate jd_server
+        continue-on-error: true
+        run: |
+          cd roles/jd-server
+          cargo publish
+      - name: Publish crate mining_proxy_sv2
+        continue-on-error: true
+        run: |
+          cd roles/mining-proxy
+          cargo publish
+      - name: Publish crate pool_sv2
+        continue-on-error: true
+        run: |
+          cd roles/pool
+          cargo publish
+      - name: Publish crate translator_sv2
+        continue-on-error: true
+        run: |
+          cd roles/translator
+          cargo publish

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -33,8 +33,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          override: true
+            toolchain: stable
+            override: true
       - name: Login
         run: cargo login ${{ secrets.CRATES_IO_DEPLOY_KEY }}
       - name: Publish crate common

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -3,47 +3,49 @@
 git fetch origin main
 git fetch origin dev
 
-# Get the list of paths to `Cargo.toml` files
-crates=$(find . -name Cargo.toml -exec dirname {} \; | sort)
+# this list was taken from `.github/workflows/release-libs.yaml`.
+# if anything changes there (crates added/removed to publishing pipeline)
+# those changes should be reflected here
+crates=(
+"utils/buffer"
+"protocols/v2/binary-sv2/no-serde-sv2/derive_codec"
+"protocols/v2/binary-sv2/no-serde-sv2/codec"
+"protocols/v2/binary-sv2/serde-sv2"
+"protocols/v2/binary-sv2/binary-sv2"
+"protocols/v2/const-sv2"
+"protocols/v2/framing-sv2"
+"protocols/v2/noise-sv2"
+"protocols/v2/codec-sv2"
+"protocols/v2/subprotocols/common-messages"
+"protocols/v2/subprotocols/job-declaration"
+"protocols/v2/subprotocols/mining"
+"protocols/v2/subprotocols/template-distribution"
+"protocols/v2/sv2-ffi"
+"protocols/v2/roles-logic-sv2"
+"protocols/v1"
+"utils/bip32-key-derivation"
+"utils/error-handling"
+"utils/key-utils"
+"roles/roles-utils/network-helpers"
+"roles/roles-utils/rpc"
+)
 
-# Filter out crates that are not published to crates.io
-filter=("benches" "examples" "test" "roles")
-for crate in $crates; do
-    filtered=false
-    for f in "${filter[@]}"; do
-        if [ "$crate" = "./$f" ]; then
-            filtered=true
-            break
-        fi
-    done
-    if [ "$filtered" = false ]; then
-        filtered_crates+=("$crate")
-    fi
-done
+# Loop through each crate
+for crate in "${crates[@]}"; do
+  cd "$crate"
 
-crates="${filtered_crates[@]}"
+  # Check if there were any changes between dev and main
+  git diff --quiet "origin/dev" "origin/main" -- .
+  if [ $? -ne 0 ]; then
 
-# Loop through each crate, while avoiding root workspace Cargo.toml and files under `target` directory
-for crate in $crates; do
-    if [ "$crate" != "./protocols" ] && \
-       [ "$crate" != "./common" ] && \
-       ! echo "$crate" | grep -q "target"; then
+      # Check if crate versions on dev and main are identical
+      version_dev=$(git show origin/dev:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+      version_main=$(git show origin/main:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+      if [ "$version_dev" = "$version_main" ]; then
+         echo "Changes detected in crate $crate between dev and main branches! Versions on dev and main branches are identical ($version_dev), so you should bump the crate version on dev before merging into main."
+         exit 1
+      fi
+  fi
 
-        cd "$crate"
-
-        # Check if there were any changes between dev and main
-        git diff --quiet "origin/dev" "origin/main" -- .
-        if [ $? -ne 0 ]; then
-
-            # Check if crate versions on dev and main are identical
-            version_dev=$(git show origin/dev:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
-            version_main=$(git show origin/main:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
-            if [ "$version_dev" = "$version_main" ]; then
-               echo "Changes detected in crate $crate between dev and main branches! Versions on dev and main branches are identical ($version_dev), so you should bump the crate version on dev before merging into main."
-               exit 1
-            fi
-        fi
-
-        cd - >/dev/null
-    fi
+  cd - >/dev/null
 done

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Get the list of paths to `Cargo.toml` files
 crates=$(find . -name Cargo.toml -exec dirname {} \; | sort)

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+git fetch origin main
+git fetch origin dev
+
 # Get the list of paths to `Cargo.toml` files
 crates=$(find . -name Cargo.toml -exec dirname {} \; | sort)
 

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -9,9 +9,14 @@ for f in "${filter[@]}"; do
     crates=$(echo "$crates" | grep -v "$f")
 done
 
-# Loop through each crate, while avoiding root workspace Cargo.toml
+# Loop through each crate, while avoiding root workspace Cargo.toml and files under `target` directory
 for crate in $crates; do
-    if [ "$crate" != "./protocols" ] && [ "$crate" != "./common" ] && [ "$crate" != "./roles" ] && [ "$crate" != "./utils" ]; then
+    if [ "$crate" != "./protocols" ] && \
+       [ "$crate" != "./common" ] && \
+       [ "$crate" != "./roles" ] && \
+       [ "$crate" != "./utils" ] && \
+       ! echo "$crate" | grep -q "target"; then
+
         cd "$crate"
 
         # Check if there were any changes between dev and main

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -4,7 +4,7 @@
 crates=$(find . -name Cargo.toml -exec dirname {} \; | sort)
 
 # Filter out crates that are not published to crates.io
-filter=("benches" "examples" "test")
+filter=("benches" "examples" "test" "roles")
 for f in "${filter[@]}"; do
     crates=$(echo "$crates" | grep -v "$f")
 done

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Get the list of paths to `Cargo.toml` files
+crates=$(find . -name Cargo.toml -exec dirname {} \; | sort)
+
+# Filter out crates that are not published to crates.io
+filter=("benches" "examples" "test")
+for f in "${filter[@]}"; do
+    crates=$(echo "$crates" | grep -v "$f")
+done
+
+# Loop through each crate, while avoiding root workspace Cargo.toml
+for crate in $crates; do
+    if [ "$crate" != "./protocols" ] && [ "$crate" != "./common" ] && [ "$crate" != "./roles" ] && [ "$crate" != "./utils" ]; then
+        cd "$crate"
+
+        # Check if there were any changes between dev and main
+        git diff --quiet "dev" "main" -- .
+        if [ $? -ne 0 ]; then
+
+            # Check if crate versions on dev and main are identical
+            version_dev=$(git show dev:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+            version_main=$(git show main:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+            if [ "$version_dev" = "$version_main" ]; then
+               echo "Changes detected in crate $crate between dev and main branches! Versions on dev and main branches are identical ($version_dev), so you should bump the crate version on dev before merging into main."
+               exit 1
+            fi
+        fi
+
+        cd - >/dev/null
+    fi
+done

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -5,27 +5,36 @@ crates=$(find . -name Cargo.toml -exec dirname {} \; | sort)
 
 # Filter out crates that are not published to crates.io
 filter=("benches" "examples" "test" "roles")
-for f in "${filter[@]}"; do
-    crates=$(echo "$crates" | grep -v "$f")
+for crate in $crates; do
+    filtered=false
+    for f in "${filter[@]}"; do
+        if [ "$crate" = "./$f" ]; then
+            filtered=true
+            break
+        fi
+    done
+    if [ "$filtered" = false ]; then
+        filtered_crates+=("$crate")
+    fi
 done
+
+crates="${filtered_crates[@]}"
 
 # Loop through each crate, while avoiding root workspace Cargo.toml and files under `target` directory
 for crate in $crates; do
     if [ "$crate" != "./protocols" ] && \
        [ "$crate" != "./common" ] && \
-       [ "$crate" != "./roles" ] && \
-       [ "$crate" != "./utils" ] && \
        ! echo "$crate" | grep -q "target"; then
 
         cd "$crate"
 
         # Check if there were any changes between dev and main
-        git diff --quiet "dev" "main" -- .
+        git diff --quiet "origin/dev" "origin/main" -- .
         if [ $? -ne 0 ]; then
 
             # Check if crate versions on dev and main are identical
-            version_dev=$(git show dev:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
-            version_main=$(git show main:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+            version_dev=$(git show origin/dev:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+            version_main=$(git show origin/main:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
             if [ "$version_dev" = "$version_main" ]; then
                echo "Changes detected in crate $crate between dev and main branches! Versions on dev and main branches are identical ($version_dev), so you should bump the crate version on dev before merging into main."
                exit 1

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -3,9 +3,6 @@
 git fetch origin main
 git fetch origin dev
 
-# this list was taken from `.github/workflows/release-libs.yaml`.
-# if anything changes there (crates added/removed to publishing pipeline)
-# those changes should be reflected here
 crates=(
 "utils/buffer"
 "protocols/v2/binary-sv2/no-serde-sv2/derive_codec"
@@ -28,6 +25,11 @@ crates=(
 "utils/key-utils"
 "roles/roles-utils/network-helpers"
 "roles/roles-utils/rpc"
+"roles/jd-client"
+"roles/jd-server"
+"roles/mining-proxy"
+"roles/pool"
+"roles/translator"
 )
 
 # Loop through each crate


### PR DESCRIPTION
Every time we merge some PR from `dev` to `main`, we need to make sure every modified crate version is properly increased. Otherwise, we will mess up the dependency chain of whoever is fetching from crates.io

This PR:
- changes `release-libs.yaml` so that the `Release Libs` workflow is triggered every time a PR is created against `main`.
- introduces a shell script (`check-versioning-lib-release.sh`) that checks the diff between `main` and `dev` branches... if some lib crate has been changed but its version wasn't bumped, the CI will trigger an error and stop (here's an [example](https://github.com/plebhash/stratum/actions/runs/8530384769/job/23368058479?pr=47#step:3:15) on my fork)
- removes `roles` from being published to crates.io (it doesn't make sense until https://github.com/stratum-mining/stratum/issues/702 is completed, which will take a long time)

