### PR TITLE
fix `sv2_ffi` lib publishing

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -99,7 +99,7 @@ jobs:
         continue-on-error: true
         run: |
           cd protocols/v2/sv2-ffi
-          cargo publish
+          cargo publish --all-features
       - name: Publish crate roles_logic_sv2
         continue-on-error: true
         run: |

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -18,7 +18,7 @@ buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "1.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
 const_sv2 = { version = "^1.0.0", path = "../../protocols/v2/const-sv2" }
 network_helpers_sv2 = { version = "1.0.0", path = "../roles-utils/network-helpers", features =["with_tokio","with_buffer_pool"] }
-noise_sv2 = { version = "1.0.0", path = "../../protocols/v2/noise-sv2" }
+noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common" }
+stratum-common = { version = "1.0.0", path = "../../../common" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc","raw_value"] }
 hex = "0.4.3"


### PR DESCRIPTION
close #810 

also fixes:
- `noise_sv` version dependency on `pool`
- missing version for `stratum-common` dependency on `rpc_sv2`