### PR TITLE
Improve sv2 cpuminer

### DIFF
--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -79,6 +79,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +586,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "codec_sv2"
 version = "1.0.0"
 dependencies = [
@@ -563,6 +651,12 @@ dependencies = [
  "serde",
  "tracing",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "common_messages_sv2"
@@ -1002,6 +1096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,15 +1413,19 @@ dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
  "async-std",
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "codec_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "buffer_sv2",
+ "clap",
+ "codec_sv2",
+ "const_sv2",
  "futures",
+ "key-utils",
  "network_helpers_sv2",
  "rand",
  "roles_logic_sv2",
  "stratum-common",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2016,6 +2120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,6 +2407,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -368,41 +368,19 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "binary_codec_sv2"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d2635651b7acd536bdf016919e5ce3d973cd53d7ac81c6f1d2523faf688a78"
-dependencies = [
- "buffer_sv2 0.1.3",
-]
-
-[[package]]
-name = "binary_codec_sv2"
 version = "1.0.0"
 dependencies = [
- "buffer_sv2 1.0.0",
-]
-
-[[package]]
-name = "binary_sv2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d073857c17f94784a1bf3477b7d000b4242766788bb67d83081828d966027cb"
-dependencies = [
- "binary_codec_sv2 0.1.5",
- "derive_codec_sv2 0.1.5",
- "serde",
- "serde_sv2 0.1.3",
- "tracing",
+ "buffer_sv2",
 ]
 
 [[package]]
 name = "binary_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_codec_sv2 1.0.0",
- "derive_codec_sv2 1.0.0",
+ "binary_codec_sv2",
+ "derive_codec_sv2",
  "serde",
- "serde_sv2 1.0.0",
+ "serde_sv2",
  "tracing",
 ]
 
@@ -505,19 +483,10 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ad62c33affff6687aa53d2e8124ebf96fa8b92a38fdd0c46fa93f0175a5e94"
-dependencies = [
- "aes-gcm",
- "serde",
-]
-
-[[package]]
-name = "buffer_sv2"
 version = "1.0.0"
 dependencies = [
  "aes-gcm",
+ "serde",
 ]
 
 [[package]]
@@ -616,7 +585,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -627,27 +596,13 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "codec_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "const_sv2 1.0.0",
- "framing_sv2 1.0.0",
- "noise_sv2 1.1.0",
- "tracing",
-]
-
-[[package]]
-name = "codec_sv2"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c306ce9b6e1a23cc2a8decadc6547b5b5240200a285ed826b15f1129c0bb9b5c"
-dependencies = [
- "binary_sv2 0.1.7",
- "buffer_sv2 0.1.3",
- "const_sv2 0.1.3",
- "framing_sv2 0.1.6",
- "noise_sv2 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "binary_sv2",
+ "buffer_sv2",
+ "const_sv2",
+ "framing_sv2",
+ "noise_sv2",
  "serde",
  "tracing",
 ]
@@ -662,8 +617,8 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "common_messages_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "const_sv2",
 ]
 
 [[package]]
@@ -673,15 +628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "const_sv2"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e86c77da33604c86f89f4ce7c7ae585f7cea0ee6e11388439ced40cd599c32"
-dependencies = [
- "secp256k1 0.28.2",
 ]
 
 [[package]]
@@ -728,18 +674,9 @@ dependencies = [
 
 [[package]]
 name = "derive_codec_sv2"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac6d35ced783f37b45a6315379aa81e01b444f64d90d49c7bb7f43f06dff356"
-dependencies = [
- "binary_codec_sv2 0.1.5",
-]
-
-[[package]]
-name = "derive_codec_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_codec_sv2 1.0.0",
+ "binary_codec_sv2",
 ]
 
 [[package]]
@@ -865,23 +802,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "framing_sv2"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a545e927300897731132ade9109a4150f1b30680ed7b942bb22c36894103334"
-dependencies = [
- "binary_sv2 0.1.7",
- "buffer_sv2 0.1.3",
- "const_sv2 0.1.3",
- "serde",
-]
-
-[[package]]
-name = "framing_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "buffer_sv2",
+ "const_sv2",
+ "serde",
 ]
 
 [[package]]
@@ -1275,11 +1201,11 @@ version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "codec_sv2 1.0.0",
+ "binary_sv2",
+ "buffer_sv2",
+ "codec_sv2",
  "error_handling",
- "framing_sv2 1.0.0",
+ "framing_sv2",
  "futures",
  "key-utils",
  "network_helpers_sv2",
@@ -1298,17 +1224,17 @@ name = "jd_server"
 version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "codec_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "buffer_sv2",
+ "codec_sv2",
+ "const_sv2",
  "error_handling",
  "hashbrown 0.11.2",
  "hex",
  "key-utils",
  "network_helpers_sv2",
  "nohash-hasher",
- "noise_sv2 1.1.0",
+ "noise_sv2",
  "rand",
  "roles_logic_sv2",
  "rpc_sv2",
@@ -1326,8 +1252,8 @@ dependencies = [
 name = "job_declaration_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "const_sv2",
 ]
 
 [[package]]
@@ -1423,6 +1349,7 @@ dependencies = [
  "network_helpers_sv2",
  "rand",
  "roles_logic_sv2",
+ "sha2 0.10.8",
  "stratum-common",
  "tracing",
  "tracing-subscriber",
@@ -1434,10 +1361,10 @@ version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "codec_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "buffer_sv2",
+ "codec_sv2",
+ "const_sv2",
  "futures",
  "key-utils",
  "network_helpers_sv2",
@@ -1456,8 +1383,8 @@ dependencies = [
 name = "mining_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "const_sv2",
 ]
 
 [[package]]
@@ -1482,13 +1409,13 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-std",
- "binary_sv2 1.0.0",
- "codec_sv2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "codec_sv2",
+ "const_sv2",
  "futures",
  "serde",
  "tokio",
@@ -1507,21 +1434,7 @@ version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "const_sv2 1.0.0",
- "rand",
- "rand_chacha",
- "secp256k1 0.28.2",
-]
-
-[[package]]
-name = "noise_sv2"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be5decbcc8c7487c91277675df156c472a025c1a5d83d9a6a3da5ff458c4d3f"
-dependencies = [
- "aes-gcm",
- "chacha20poly1305",
- "const_sv2 0.1.3",
+ "const_sv2",
  "rand",
  "rand_chacha",
  "secp256k1 0.28.2",
@@ -1735,16 +1648,16 @@ version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 1.1.0",
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "codec_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "buffer_sv2",
+ "codec_sv2",
+ "const_sv2",
  "error_handling",
  "hex",
  "key-utils",
  "network_helpers_sv2",
  "nohash-hasher",
- "noise_sv2 1.1.0",
+ "noise_sv2",
  "rand",
  "roles_logic_sv2",
  "secp256k1 0.28.2",
@@ -1868,11 +1781,11 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 name = "roles_logic_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_sv2 1.0.0",
+ "binary_sv2",
  "chacha20poly1305",
  "common_messages_sv2",
- "const_sv2 1.0.0",
- "framing_sv2 1.0.0",
+ "const_sv2",
+ "framing_sv2",
  "job_declaration_sv2",
  "mining_sv2",
  "nohash-hasher",
@@ -2013,19 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "serde_sv2"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149f67cef8328b644f1e48d3d420f07dc57505424f6c399d66b3b10a658cc0d4"
-dependencies = [
- "buffer_sv2 0.1.3",
- "serde",
-]
-
-[[package]]
-name = "serde_sv2"
 version = "1.0.0"
 dependencies = [
- "buffer_sv2 1.0.0",
+ "buffer_sv2",
  "serde",
 ]
 
@@ -2150,7 +2053,7 @@ dependencies = [
 name = "sv1_api"
 version = "1.0.0"
 dependencies = [
- "binary_sv2 1.0.0",
+ "binary_sv2",
  "bitcoin_hashes 0.3.2",
  "byteorder",
  "hex",
@@ -2187,8 +2090,8 @@ dependencies = [
 name = "template_distribution_sv2"
 version = "1.0.0"
 dependencies = [
- "binary_sv2 1.0.0",
- "const_sv2 1.0.0",
+ "binary_sv2",
+ "const_sv2",
 ]
 
 [[package]]
@@ -2357,11 +2260,11 @@ dependencies = [
  "async-compat",
  "async-recursion 0.3.2",
  "async-std",
- "binary_sv2 1.0.0",
- "buffer_sv2 1.0.0",
- "codec_sv2 1.0.0",
+ "binary_sv2",
+ "buffer_sv2",
+ "codec_sv2",
  "error_handling",
- "framing_sv2 1.0.0",
+ "framing_sv2",
  "futures",
  "key-utils",
  "network_helpers_sv2",

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -19,3 +19,7 @@ buffer_sv2 = { version = "1.0.0", path = "../../../utils/buffer"}
 async-recursion = "0.3.2"
 rand = "0.8.4"
 futures = "0.3.5"
+key-utils = { version = "^1.0.0", path = "../../../utils/key-utils" }
+clap = { version = "^4.5.4", features = ["derive"] }
+tracing = { version = "0.1" }
+tracing-subscriber = "0.3"

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -23,3 +23,4 @@ key-utils = { version = "^1.0.0", path = "../../../utils/key-utils" }
 clap = { version = "^4.5.4", features = ["derive"] }
 tracing = { version = "0.1" }
 tracing-subscriber = "0.3"
+sha2 = "0.10.6"

--- a/roles/test-utils/mining-device/src/main.rs
+++ b/roles/test-utils/mining-device/src/main.rs
@@ -236,7 +236,7 @@ pub struct Device {
 fn open_channel(device_id: Option<String>) -> OpenStandardMiningChannel<'static> {
     let user_identity = device_id.unwrap_or_default().try_into().unwrap();
     let id: u32 = 10;
-    info!("Misuring pc hashrate");
+    info!("Measuring pc hashrate");
     let nominal_hash_rate = measure_hashrate(5) as f32;
     info!("Pc hashrate is {}", nominal_hash_rate);
     info!("MINING DEVICE: send open channel with request id {}", id);

--- a/roles/test-utils/mining-device/src/main.rs
+++ b/roles/test-utils/mining-device/src/main.rs
@@ -6,13 +6,13 @@ use std::{net::SocketAddr, sync::Arc, thread::sleep, time::Duration};
 
 use async_std::net::ToSocketAddrs;
 use clap::Parser;
+use rand::{thread_rng, Rng};
+use sha2::{Digest, Sha256};
+use std::time::Instant;
 use stratum_common::bitcoin::{
     blockdata::block::BlockHeader, hash_types::BlockHash, hashes::Hash, util::uint::Uint256,
 };
 use tracing::{error, info};
-use std::time::Instant;
-use rand::{Rng,thread_rng};
-use sha2::{Digest, Sha256};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -290,9 +290,7 @@ impl Device {
         let handicap = miner.safe_lock(|m| m.handicap).unwrap();
         std::thread::spawn(move || loop {
             std::thread::sleep(std::time::Duration::from_micros(handicap.into()));
-            if miner.safe_lock(|m|  {
-                               m.next_share()
-            }).unwrap().is_ok() {
+            if miner.safe_lock(|m| m.next_share()).unwrap().is_ok() {
                 let nonce = miner.safe_lock(|m| m.header.unwrap().nonce).unwrap();
                 let time = miner.safe_lock(|m| m.header.unwrap().time).unwrap();
                 let job_id = miner.safe_lock(|m| m.job_id).unwrap();
@@ -629,9 +627,7 @@ fn measure_hashrate(duration_secs: u64) -> f64 {
     }
 
     let elapsed_secs = start_time.elapsed().as_secs_f64();
-    let hashrate = hashes as f64 / elapsed_secs;
-    let nominal_hash_rate = hashrate;
-    nominal_hash_rate
+    hashes as f64 / elapsed_secs
 }
 fn generate_random_80_byte_array() -> [u8; 80] {
     let mut rng = thread_rng();

--- a/utils/key-utils/src/lib.rs
+++ b/utils/key-utils/src/lib.rs
@@ -27,6 +27,8 @@ impl Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl From<Bs58DecodeError> for Error {
     fn from(e: Bs58DecodeError) -> Self {
         Error::Bs58Decode(e)


### PR DESCRIPTION
Add a nicer user interface to the sv2 cpuminer with help messages. Add noise to the cpuminer.

This is the output of  `cargo run -- --help`

```console
Usage: mining-device [OPTIONS] --address-pool <ADDRESS_POOL>

Options:
  -p, --pubkey-pool <PUBKEY_POOL>    Pool pub key, when left empty the pool certificate is not checked
  -i, --id-device <ID_DEVICE>        Sometimes used by the pool to identify the device
  -a, --address-pool <ADDRESS_POOL>  Address of the pool in this format ip:port or domain:port
      --handicap <HANDICAP>          This value is used to slow down the cpu miner, it rapresents the number of micro-seconds that are awaited between one hashes, default is 0 [default: 0]
  -h, --help                         Print help
  -V, --version                      Print version
```