### PR TITLE
Refractor update_mempool module in JDS mempool module for simplified async flow

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -497,7 +497,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "codec_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-std",

--- a/roles/jd-server/src/lib/mempool/mod.rs
+++ b/roles/jd-server/src/lib/mempool/mod.rs
@@ -69,8 +69,7 @@ impl JDsMempool {
         let txids = add_txs_to_mempool_inner.known_transactions;
         let transactions = add_txs_to_mempool_inner.unknown_transactions;
         let client = self_
-            .safe_lock(|a| a.get_client())
-            .map_err(|e| JdsMempoolError::PoisonLock(e.to_string()))?
+            .safe_lock(|a| a.get_client())?
             .ok_or(JdsMempoolError::NoClient)?;
         // fill in the mempool the transactions id in the mempool with the full transactions
         // retrieved from the jd client
@@ -99,26 +98,18 @@ impl JDsMempool {
         let mut mempool_ordered: HashMap<Txid, Option<Transaction>> = HashMap::new();
 
         let client = self_
-            .safe_lock(|x| x.get_client())
-            .map_err(|e| JdsMempoolError::PoisonLock(e.to_string()))?
+            .safe_lock(|x| x.get_client())?
             .ok_or(JdsMempoolError::NoClient)?;
 
-        let mempool: Vec<String> = client.get_raw_mempool().await.map_err(|err| {
-            let err_msg = format!("Error occurred during deserialization: {:?}", err);
-            JdsMempoolError::Rpc(RpcError::Deserialization(err_msg))
-        })?;
+        let mempool: Vec<String> = client.get_raw_mempool().await?;
         for id in &mempool {
-            let key_id = Txid::from_str(id).map_err(|err| {
-                let err_msg = format!("Error occurred during deserialization: {:?}", err);
-                JdsMempoolError::Rpc(RpcError::Deserialization(err_msg))
-            })?;
+            let key_id = Txid::from_str(id)
+                .map_err(|err| JdsMempoolError::Rpc(RpcError::Deserialization(err.to_string())))?;
 
-            let tx = self_
-                .safe_lock(|x| match x.mempool.get(&key_id) {
-                    Some(entry) => entry.clone(),
-                    None => None,
-                })
-                .map_err(|e| JdsMempoolError::PoisonLock(e.to_string()))?;
+            let tx = self_.safe_lock(|x| match x.mempool.get(&key_id) {
+                Some(entry) => entry.clone(),
+                None => None,
+            })?;
 
             mempool_ordered.insert(key_id, tx);
         }
@@ -132,12 +123,10 @@ impl JDsMempool {
     }
 
     pub async fn on_submit(self_: Arc<Mutex<Self>>) -> Result<(), JdsMempoolError> {
-        let new_block_receiver: Receiver<String> = self_
-            .safe_lock(|x| x.new_block_receiver.clone())
-            .map_err(|e| JdsMempoolError::PoisonLock(e.to_string()))?;
+        let new_block_receiver: Receiver<String> =
+            self_.safe_lock(|x| x.new_block_receiver.clone())?;
         let client = self_
-            .safe_lock(|x| x.get_client())
-            .map_err(|e| JdsMempoolError::PoisonLock(e.to_string()))?
+            .safe_lock(|x| x.get_client())?
             .ok_or(JdsMempoolError::NoClient)?;
 
         while let Ok(block_hex) = new_block_receiver.recv().await {

--- a/roles/jd-server/src/main.rs
+++ b/roles/jd-server/src/main.rs
@@ -146,10 +146,6 @@ async fn main() {
                             mempool::error::handle_error(&err);
                             handle_result!(sender_update_mempool, Err(err));
                         }
-                        JdsMempoolError::TokioJoin(_) => {
-                            mempool::error::handle_error(&err);
-                            handle_result!(sender_update_mempool, Err(err));
-                        }
                         JdsMempoolError::PoisonLock(_) => {
                             mempool::error::handle_error(&err);
                             handle_result!(sender_update_mempool, Err(err));


### PR DESCRIPTION
### What does this PR do?

Closes #784 

- Removed the unnecessary use of tokio::task::spawn in update_mempool, leveraging the existing async function context for all operations.
- Removed the TokioJoin(JoinError) implementation since it is not been used 