### PR TITLE
make `dev` up-to-date with `main`

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -10,14 +10,26 @@
 
 name: Release Libs
 
-on: 
-  # Manually run by going to "Actions/Release" in Github and running the workflow
-  workflow_dispatch:
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   libs_publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run check-versioning-lib-release.sh
+        run: |
+          ./check-versioning-lib-release.sh
+          if [ $? -eq 1 ]; then
+            echo "Script returned exit code 1, halting the workflow"
+            exit 1
+          fi
+
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
@@ -138,20 +150,25 @@ jobs:
       - name: Publish crate jd_client
         continue-on-error: true
         run: |
-          cargo publish --manifest-path=roles/jd-client/Cargo.toml
+          cd roles/jd-client
+          cargo publish
       - name: Publish crate jd_server
         continue-on-error: true
         run: |
-          cargo publish --manifest-path=roles/jd-server/Cargo.toml
+          cd roles/jd-server
+          cargo publish
       - name: Publish crate mining_proxy_sv2
         continue-on-error: true
         run: |
-          cargo publish --manifest-path=roles/mining-proxy/Cargo.toml
+          cd roles/mining-proxy
+          cargo publish
       - name: Publish crate pool_sv2
         continue-on-error: true
         run: |
-          cargo publish --manifest-path=roles/pool/Cargo.toml
+          cd roles/pool
+          cargo publish
       - name: Publish crate translator_sv2
         continue-on-error: true
         run: |
-          cargo publish --manifest-path=roles/translator/Cargo.toml
+          cd roles/translator
+          cargo publish

--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+git fetch origin main
+git fetch origin dev
+
+crates=(
+"utils/buffer"
+"protocols/v2/binary-sv2/no-serde-sv2/derive_codec"
+"protocols/v2/binary-sv2/no-serde-sv2/codec"
+"protocols/v2/binary-sv2/serde-sv2"
+"protocols/v2/binary-sv2/binary-sv2"
+"protocols/v2/const-sv2"
+"protocols/v2/framing-sv2"
+"protocols/v2/noise-sv2"
+"protocols/v2/codec-sv2"
+"protocols/v2/subprotocols/common-messages"
+"protocols/v2/subprotocols/job-declaration"
+"protocols/v2/subprotocols/mining"
+"protocols/v2/subprotocols/template-distribution"
+"protocols/v2/sv2-ffi"
+"protocols/v2/roles-logic-sv2"
+"protocols/v1"
+"utils/bip32-key-derivation"
+"utils/error-handling"
+"utils/key-utils"
+"roles/roles-utils/network-helpers"
+"roles/roles-utils/rpc"
+"roles/jd-client"
+"roles/jd-server"
+"roles/mining-proxy"
+"roles/pool"
+"roles/translator"
+)
+
+# Loop through each crate
+for crate in "${crates[@]}"; do
+  cd "$crate"
+
+  # Check if there were any changes between dev and main
+  git diff --quiet "origin/dev" "origin/main" -- .
+  if [ $? -ne 0 ]; then
+
+      # Check if crate versions on dev and main are identical
+      version_dev=$(git show origin/dev:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+      version_main=$(git show origin/main:./Cargo.toml | awk -F' = ' '$1 == "version" {gsub(/[ "]+/, "", $2); print $2}')
+      if [ "$version_dev" = "$version_main" ]; then
+         echo "Changes detected in crate $crate between dev and main branches! Versions on dev and main branches are identical ($version_dev), so you should bump the crate version on dev before merging into main."
+         exit 1
+      fi
+  fi
+
+  cd - >/dev/null
+done


### PR DESCRIPTION
this PR is just to make `dev` branch up-to-date with `main` branch, so that we can start development against `dev`

after https://github.com/stratum-mining/stratum/pull/790 it was outdated

I tried to rebase it locally but couldn't push it