### PR TITLE
docs `framing_sv2`

### DIFF
--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -21,9 +21,9 @@ pub use encoder::Encoder;
 #[cfg(feature = "noise_sv2")]
 pub use encoder::NoiseEncoder;
 
-pub use framing_sv2::framing2::{Frame, Sv2Frame};
 #[cfg(feature = "noise_sv2")]
 pub use framing_sv2::framing2::HandShakeFrame;
+pub use framing_sv2::framing2::{Frame, Sv2Frame};
 
 #[cfg(feature = "noise_sv2")]
 pub use noise_sv2::{self, Initiator, NoiseCodec, Responder};

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -23,7 +23,7 @@ pub use encoder::NoiseEncoder;
 
 pub use framing_sv2::framing2::{Frame, Sv2Frame};
 #[cfg(feature = "noise_sv2")]
-pub use framing_sv2::framing2::{HandShakeFrame, NoiseFrame};
+pub use framing_sv2::framing2::HandShakeFrame;
 
 #[cfg(feature = "noise_sv2")]
 pub use noise_sv2::{self, Initiator, NoiseCodec, Responder};

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -113,6 +113,8 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     type Deserialized = B;
 
     /// Write the serialized `Sv2Frame` into `dst`.
+    /// This operation when called on an already serialized frame is very cheap.
+    /// When called on a non serialized frame, it is not so cheap (because it serializes it).
     #[inline]
     fn serialize(self, dst: &mut [u8]) -> Result<(), Error> {
         if let Some(mut serialized) = self.serialized {

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -205,7 +205,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     }
 
     /// If `Sv2Frame` is serialized, returns the length of `self.serialized`,
-    /// otherwise, returns the length of `self.pauload`.
+    /// otherwise, returns the length of `self.payload`.
     #[inline]
     fn encoded_length(&self) -> usize {
         if let Some(serialized) = self.serialized.as_ref() {

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -98,14 +98,6 @@ pub struct NoiseFrame {
 /// todo
 pub type HandShakeFrame = NoiseFrame;
 
-/// todo (why unreachable?)
-#[cfg(feature = "with_buffer_pool")]
-impl<A> From<EitherFrame<A, Vec<u8>>> for Sv2Frame<A, buffer_sv2::Slice> {
-    fn from(_: EitherFrame<A, Vec<u8>>) -> Self {
-        unreachable!()
-    }
-}
-
 impl NoiseFrame {
     /// Returns payload of `NoiseFrame` as a `Vec<u8>`
     pub fn get_payload_when_handshaking(&self) -> Vec<u8> {
@@ -240,12 +232,6 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
             serialized: None,
         })
     }
-}
-
-#[inline]
-pub fn build_noise_frame_header(frame: &mut [u8], len: u16) {
-    frame[0] = len.to_le_bytes()[0];
-    frame[1] = len.to_le_bytes()[1];
 }
 
 impl<'a> Frame<'a, Slice> for NoiseFrame {

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -43,10 +43,14 @@ pub trait Frame<'a, T: Serialize + GetSize>: Sized {
     fn get_header(&self) -> Option<crate::header::Header>;
 
     /// Try to build a `Frame` from raw bytes.
+    /// Checks if the payload has the correct size (as stated in the `Header`).
     /// Returns `Self` on success, or the number of the bytes needed to complete the frame
     /// as an error. Nothing is assumed or checked about the correctness of the payload.
     fn from_bytes(bytes: Self::Buffer) -> Result<Self, isize>;
 
+    /// Builds a `Frame` from raw bytes.
+    /// Does not check if the payload has the correct size (as stated in the `Header`).
+    /// Nothing is assumed or checked about the correctness of the payload.
     fn from_bytes_unchecked(bytes: Self::Buffer) -> Self;
 
     /// Helps to determine if the frame size encoded in a byte array correctly representing the size of the frame.

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -90,12 +90,14 @@ impl<T, B> Default for Sv2Frame<T, B> {
 }
 
 /// Abstraction for a Noise Frame
+/// In practice, it is only used as the alias `HandShakeFrame`
+/// Contains only a `Slice` payload
 #[derive(Debug)]
 pub struct NoiseFrame {
     payload: Slice,
 }
 
-/// todo
+/// The only practical usage of `NoiseFrame`
 pub type HandShakeFrame = NoiseFrame;
 
 impl NoiseFrame {
@@ -340,7 +342,8 @@ fn update_extension_type(extension_type: u16, channel_msg: bool) -> u16 {
     }
 }
 
-/// todo
+/// A wrapper to be used in a context we need a generic reference to a frame
+/// but it doesn't matter which kind of frame it is (`Sv2Frame` or `HandShakeFrame`)
 #[derive(Debug)]
 pub enum EitherFrame<T, B> {
     HandShake(HandShakeFrame),

--- a/protocols/v2/framing-sv2/src/header.rs
+++ b/protocols/v2/framing-sv2/src/header.rs
@@ -7,6 +7,7 @@ use binary_sv2::{Deserialize, Serialize, U24};
 use const_sv2::{AEAD_MAC_LEN, SV2_FRAME_CHUNK_SIZE};
 use core::convert::TryInto;
 
+/// Abstraction for a SV2 Frame Header.
 #[derive(Debug, Serialize, Deserialize, Copy, Clone)]
 pub struct Header {
     extension_type: u16, // TODO use specific type?
@@ -32,6 +33,7 @@ impl Header {
 
     pub const SIZE: usize = const_sv2::SV2_FRAME_HEADER_SIZE;
 
+    /// Construct a `Header` from ray bytes
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < Self::SIZE {
@@ -52,6 +54,7 @@ impl Header {
         })
     }
 
+    /// Get the message length
     #[allow(clippy::len_without_is_empty)]
     #[inline]
     pub fn len(&self) -> usize {
@@ -59,6 +62,7 @@ impl Header {
         inner as usize
     }
 
+    /// Construct a `Header` from message length, type and extension type.
     #[inline]
     pub fn from_len(len: u32, message_type: u8, extension_type: u16) -> Option<Header> {
         Some(Self {
@@ -68,19 +72,23 @@ impl Header {
         })
     }
 
+    /// Get the `Header` message type.
     pub fn msg_type(&self) -> u8 {
         self.msg_type
     }
 
+    /// Get the `Header` extension type.
     pub fn ext_type(&self) -> u16 {
         self.extension_type
     }
 
+    /// Check if `Header` represents a channel message
     pub fn channel_msg(&self) -> bool {
         let mask = 0b0000_0000_0000_0001;
         self.extension_type & mask == self.extension_type
     }
 
+    /// Calculate the length of the encrypted `Header`
     pub fn encrypted_len(&self) -> usize {
         let len = self.len();
         let mut chunks = len / (SV2_FRAME_CHUNK_SIZE - AEAD_MAC_LEN);

--- a/protocols/v2/framing-sv2/src/header.rs
+++ b/protocols/v2/framing-sv2/src/header.rs
@@ -54,7 +54,7 @@ impl Header {
         })
     }
 
-    /// Get the message length
+    /// Get the payload length
     #[allow(clippy::len_without_is_empty)]
     #[inline]
     pub fn len(&self) -> usize {
@@ -62,7 +62,7 @@ impl Header {
         inner as usize
     }
 
-    /// Construct a `Header` from message length, type and extension type.
+    /// Construct a `Header` from payload length, type and extension type.
     #[inline]
     pub fn from_len(len: u32, message_type: u8, extension_type: u16) -> Option<Header> {
         Some(Self {

--- a/protocols/v2/framing-sv2/src/lib.rs
+++ b/protocols/v2/framing-sv2/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! This crate provides primitives for framing of SV2 binary messages.
 //!
-//! The message framing is outlined below:
+//! The message framing is outlined below ([according to SV2 specs](https://stratumprotocol.org/specification/03-Protocol-Overview/#32-framing)):
 //!
 //! | Protocol Type  | Byte Length | Description |
 //! |----------------|-------------|-------------|

--- a/protocols/v2/framing-sv2/src/lib.rs
+++ b/protocols/v2/framing-sv2/src/lib.rs
@@ -1,25 +1,31 @@
+//! The SV2 protocol is binary, with fixed message framing.
+//! Each message begins with the extension type, message type, and message length (six bytes in total), followed by a variable length message.
+//!
+//! This crate provides primitives for framing of SV2 binary messages.
+//!
+//! The message framing is outlined below:
+//!
+//! | Protocol Type  | Byte Length | Description |
+//! |----------------|-------------|-------------|
+//! | `extension_type` | `U16` | Unique identifier of the extension describing this protocol message. <br><br> Most significant bit (i.e.bit `15`, `0`-indexed, aka `channel_msg`) indicates a message which is specific to a channel, whereas if the most significant bit is unset, the message is to be interpreted by the immediate receiving device. <br><br> Note that the `channel_msg` bit is ignored in the extension lookup, i.e.an `extension_type` of `0x8ABC` is for the same "extension" as `0x0ABC`. <br><br> If the `channel_msg` bit is set, the first four bytes of the payload field is a `U32` representing the `channel_id` this message is destined for (these bytes are repeated in the message framing descriptions below). <br><br> Note that for the Job Declaration and Template Distribution Protocols the `channel_msg` bit is always unset. |
+//! | `msg_type` | `U8` | Unique identifier of the extension describing this protocol message. |
+//! | `msg_length` | `U24` | Length of the protocol message, not including this header. |
+//! | `payload` | `BYTES` | Message-specific payload of length `msg_length`. If the MSB in `extension_type` (the `channel_msg` bit) is set the first four bytes are defined as a `U32` `"channel_id"`, though this definition is repeated in the message definitions below and these 4 bytes are included in `msg_length`. |
+//!
+//! # Features
+//! This crate can be built with the following features:
+//! - `with_serde`: builds `binary_sv2` and `buffer_sv2` crates with `serde`-based encoding and decoding.
+//! - `with_buffer_pool`: uses `buffer_sv2` to provide a more efficient allocation method for `non_std` environments. Please refer to `buffer_sv2` crate docs for more context.
+
 #![no_std]
 extern crate alloc;
 
-///
-/// Sv2 messages are framed as
-/// ```txt
-/// extension type: u16
-/// msg type: u8
-/// msg length: u24
-/// payload: [u8; msg length]
-/// ```
-///
-/// Sv2 messages can be encapsulated in noise messages, noise messages are framed as:
-///
-/// ```txt
-/// msg length: u16
-/// payload: [u8; msg length]
-/// ```
-///
-///
+/// SV2 framing types
 pub mod framing2;
 
+/// SV2 framing errors
 pub mod error;
+
+/// SV2 framing header
 pub mod header;
 pub use error::Error;

--- a/protocols/v2/framing-sv2/src/lib.rs
+++ b/protocols/v2/framing-sv2/src/lib.rs
@@ -16,6 +16,8 @@
 //! This crate can be built with the following features:
 //! - `with_serde`: builds `binary_sv2` and `buffer_sv2` crates with `serde`-based encoding and decoding.
 //! - `with_buffer_pool`: uses `buffer_sv2` to provide a more efficient allocation method for `non_std` environments. Please refer to `buffer_sv2` crate docs for more context.
+//!
+//! The `with_serde` feature flag is only used for the Message Generator, and deprecated for any other kind of usage. It will likely be fully deprecated in the future.
 
 #![no_std]
 extern crate alloc;


### PR DESCRIPTION
adds Rust Docs for `framing_sv2`, as described in https://github.com/stratum-mining/stratum/issues/845

also renames `NoiseFrame` into `HandShakeFrame`

the documentation effort was guided by discussion with @Fi3 on https://github.com/stratum-mining/stratum/discussions/858