### PR TITLE
fix(translator): fix HexError(OddLength) in mining.subscribe handler

### DIFF
--- a/benches/benches/src/sv1/lib/client.rs
+++ b/benches/benches/src/sv1/lib/client.rs
@@ -199,8 +199,7 @@ impl IsClient<'static> for Client {
     }
 }
 pub fn extranonce_from_hex(hex: &str) -> Extranonce<'static> {
-    let data = utils::decode_hex(hex).unwrap();
-    Extranonce::try_from(data).expect("Failed to convert hex to U256")
+    Extranonce::try_from(hex).expect("Failed to convert hex to U256")
 }
 pub fn prevhash_from_hex<'a>(hex: &str) -> PrevHash<'a> {
     let data = utils::decode_hex(hex).unwrap();

--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -333,10 +333,7 @@ pub trait IsClient<'a> {
                 // so it doesnt really matter what the server sets the extranonce to in the mining.configure handler
                 debug!("NOTICE: Subscribe extranonce is hardcoded by server");
                 let subscribe = self
-                    .subscribe(
-                        configure.id,
-                        Some(Extranonce::try_from(hex::decode("08000002")?)?),
-                    )
+                    .subscribe(configure.id, Some(Extranonce::try_from("08000002")?))
                     .ok();
                 Ok(subscribe)
             }

--- a/protocols/v1/src/methods/client_to_server.rs
+++ b/protocols/v1/src/methods/client_to_server.rs
@@ -173,7 +173,7 @@ impl<'a> TryFrom<StandardRequest> for Submit<'a> {
                     [JString(a), JString(b), JString(c), JNumber(d), JNumber(e), JString(f)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(c.as_str())?,
                         HexU32Be(d.as_u64().unwrap() as u32),
                         HexU32Be(e.as_u64().unwrap() as u32),
                         Some((f.as_str()).try_into()?),
@@ -181,7 +181,7 @@ impl<'a> TryFrom<StandardRequest> for Submit<'a> {
                     [JString(a), JString(b), JString(c), JString(d), JString(e), JString(f)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(c.as_str())?,
                         (d.as_str()).try_into()?,
                         (e.as_str()).try_into()?,
                         Some((f.as_str()).try_into()?),
@@ -189,7 +189,7 @@ impl<'a> TryFrom<StandardRequest> for Submit<'a> {
                     [JString(a), JString(b), JString(c), JNumber(d), JNumber(e)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(c.as_str())?,
                         HexU32Be(d.as_u64().unwrap() as u32),
                         HexU32Be(e.as_u64().unwrap() as u32),
                         None,
@@ -197,7 +197,7 @@ impl<'a> TryFrom<StandardRequest> for Submit<'a> {
                     [JString(a), JString(b), JString(c), JString(d), JString(e)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(c.as_str())?,
                         (d.as_str()).try_into()?,
                         (e.as_str()).try_into()?,
                         None,
@@ -229,7 +229,7 @@ impl Arbitrary for Submit<'static> {
         println!("\nEXTRA: {:?}\n", extra);
         let bits = Option::<u32>::arbitrary(g);
         println!("\nBITS: {:?}\n", bits);
-        let extra: Extranonce = extra.try_into().unwrap();
+        let extra: Extranonce = hex::encode(extra).as_str().try_into().unwrap();
         let bits = bits.map(|x| HexU32Be(x));
         println!("\nBITS: {:?}\n", bits);
         Submit {
@@ -319,9 +319,7 @@ impl<'a> TryFrom<StandardRequest> for Subscribe<'a> {
                 let (agent_signature, extranonce1) = match &params[..] {
                     // bosminer subscribe message
                     [JString(a), Null, JString(_), Null] => (a.into(), None),
-                    [JString(a), JString(b)] => {
-                        (a.into(), Some(Extranonce::try_from(hex::decode(b)?)?))
-                    }
+                    [JString(a), JString(b)] => (a.into(), Some(Extranonce::try_from(b.as_str())?)),
                     [JString(a)] => (a.into(), None),
                     [] => ("".to_string(), None),
                     _ => return Err(ParsingMethodError::wrong_args_from_value(msg.params)),

--- a/protocols/v1/src/methods/client_to_server.rs
+++ b/protocols/v1/src/methods/client_to_server.rs
@@ -714,3 +714,36 @@ fn test_version_extension_with_no_bit_count() {
         _ => panic!(),
     };
 }
+
+#[test]
+fn test_mining_subscribe_even_sized_extranonce() {
+    let client_message = r#"{"id":0,
+            "method": "mining.subscribe",
+            "params": ["user agent/version", "aaeeffdd"]
+        }"#;
+    let client_message: StandardRequest = serde_json::from_str(&client_message).unwrap();
+    Subscribe::try_from(client_message).unwrap();
+}
+
+#[test]
+fn test_mining_subscribe_odd_sized_extranonce() {
+    let client_message = r#"{"id":0,
+            "method": "mining.subscribe",
+            "params": ["user agent/version", "aeeffdd"]
+        }"#;
+    let client_message: StandardRequest = serde_json::from_str(&client_message).unwrap();
+    Subscribe::try_from(client_message).unwrap();
+}
+
+#[test]
+#[should_panic(
+    expected = "called `Result::unwrap()` on an `Err` value: HexError(InvalidHexCharacter { c: 'z', index: 0 })"
+)]
+fn test_mining_subscribe_invalid_extranonce() {
+    let client_message = r#"{"id":0,
+            "method": "mining.subscribe",
+            "params": ["user agent/version", "zxczxc"]
+        }"#;
+    let client_message: StandardRequest = serde_json::from_str(&client_message).unwrap();
+    Subscribe::try_from(client_message).unwrap();
+}

--- a/protocols/v1/src/methods/server_to_client.rs
+++ b/protocols/v1/src/methods/server_to_client.rs
@@ -221,7 +221,7 @@ impl<'a> TryFrom<Notification> for SetExtranonce<'a> {
             .ok_or_else(|| ParsingMethodError::not_array_from_value(msg.params.clone()))?;
         let (extra_nonce1, extra_nonce2_size) = match &params[..] {
             [JString(a), JNumber(b)] => (
-                Extranonce::try_from(hex::decode(a)?)?,
+                Extranonce::try_from(a.as_str())?,
                 b.as_u64()
                     .ok_or_else(|| ParsingMethodError::not_unsigned_from_value(b.clone()))?
                     as usize,


### PR DESCRIPTION
This PR fixes 
`ERROR translator_sv2::lib::status: Error: V1Protocol(Method(ParsingMethodError((HexError(OddLength), StandardRequest(StandardRequest { id: 150166, method: "mining.subscribe", params: Array [String("bmminer/2.0.0"), String("265800001")] })))))`
errors.

I'm new to Rust and made this PR with the help of ChatGPT, so I'm not sure it's fully correct. Nevertheless, it fixes the actual error in my case.

This error happens when the miner sends an odd-sized extranonce.