### PR TITLE
Add error for non-existent configuration file

### DIFF
--- a/roles/jd-client/src/args.rs
+++ b/roles/jd-client/src/args.rs
@@ -44,7 +44,16 @@ impl Args {
                             Some(ArgsResult::None)
                         }
                     },
-                    ArgsState::ExpectPath => Some(ArgsResult::Config(PathBuf::from(item))),
+                    ArgsState::ExpectPath => {
+                        let path = PathBuf::from(item.clone());
+                        if !path.exists() {
+                            return Some(ArgsResult::Help(format!(
+                                "Error: File '{}' does not exist!",
+                                path.display()
+                            )));
+                        }
+                        Some(ArgsResult::Config(path))
+                    }
                     ArgsState::Done => None,
                 }
             })

--- a/roles/translator/src/args.rs
+++ b/roles/translator/src/args.rs
@@ -44,7 +44,16 @@ impl Args {
                             Some(ArgsResult::None)
                         }
                     },
-                    ArgsState::ExpectPath => Some(ArgsResult::Config(PathBuf::from(item))),
+                    ArgsState::ExpectPath => {
+                        let path = PathBuf::from(item.clone());
+                        if !path.exists() {
+                            return Some(ArgsResult::Help(format!(
+                                "Error: File '{}' does not exist!",
+                                path.display()
+                            )));
+                        }
+                        Some(ArgsResult::Config(path))
+                    }
                     ArgsState::Done => None,
                 }
             })


### PR DESCRIPTION
Fixed the issue raised in issue #695

### How to test
Do the following:
- cd to `roles/jd-client`
- run `cargo run -- -c ~/no-such-file.toml`