### PR TITLE
tproxy: panic when failed to load config

### DIFF
--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     let proxy_config = match process_cli_args() {
         Ok(p) => p,
-        Err(_) => return,
+        Err(e) => panic!("failed to load config: {}", e),
     };
     info!("PC: {:?}", &proxy_config);
 


### PR DESCRIPTION
This patch adds a panic with an error description when tproxy fails to load the config file for any reason. It helps greatly to spot errors in the configuration file.