### PR TITLE
Make mg GitHub actions more stable moving compilation before running tests

### DIFF
--- a/message-generator-tests.sh
+++ b/message-generator-tests.sh
@@ -6,17 +6,33 @@ else
     RUST_LOG="debug"
 fi
 
-search_dir="../../test/message-generator/test/"
 message_generator_dir="./utils/message-generator/"
-
 cd $message_generator_dir
 cargo llvm-cov clean
+
+cd ../../roles
+cargo build -p mining-device
+cargo llvm-cov -p pool_sv2
+cargo llvm-cov -p jd_server
+cargo llvm-cov -p jd_client
+cargo llvm-cov -p translator_sv2 
+cargo llvm-cov -p mining_proxy_sv2 
+cd ./roles-utils
+cargo llvm-cov 
+cd ../../
+
+search_dir="../../test/message-generator/test/"
+
+cd $message_generator_dir
+cargo build
 
 for entry in `ls $search_dir`; do
     if [ "$entry" = "interop-jdc-change-upstream.json" ]; then
         echo "Skipping $entry"
         continue
     fi
+
+    sleep 10
 
     echo $entry
     RUST_LOG=$RUST_LOG cargo run -- $search_dir$entry || { echo 'mg test failed' ; exit 1; }

--- a/test/config/tproxy-config-no-jd-sv1-cpu-md.toml
+++ b/test/config/tproxy-config-no-jd-sv1-cpu-md.toml
@@ -37,12 +37,12 @@ coinbase_reward_sat = 5_000_000_000
 # hashes/s of the weakest miner that will be connecting
 min_individual_miner_hashrate=100_000.0
 # minimum number of shares needed before a mining.set_difficulty is sent for updating targets
-miner_num_submits_before_update=5
+miner_num_submits_before_update=200
 # target number of shares per minute the miner should be sending
 shares_per_minute = 100.0
 
 [upstream_difficulty_config]
 # interval in seconds to elapse before updating channel hashrate with the pool
-channel_diff_update_interval = 60
+channel_diff_update_interval = 6000
 # estimated accumulated hashrate of all downstream miners
 channel_nominal_hashrate = 500.0

--- a/test/message-generator/test/interop-jd-translator.json
+++ b/test/message-generator/test/interop-jd-translator.json
@@ -125,6 +125,8 @@
         {
             "command": "cargo",
             "args": [
+                        "llvm-cov",
+                        "--no-report",
                         "run",
                         "-p",
                         "sv1-mining-device"

--- a/test/message-generator/test/pool-sri-test-1-standard.json
+++ b/test/message-generator/test/pool-sri-test-1-standard.json
@@ -145,54 +145,6 @@
            }
        },
        {
-            "command": "cargo",
-            "args": [
-                        "run",
-                        "../../../test/message-generator/mock/template-provider-mock0.json"
-            ],
-            "conditions": {
-                "WithConditions": {
-                    "conditions": [
-                        {
-                            "output_string": "Running `target/debug/message_generator_sv2 ../../../test/message-generator/mock/template-provider-mock0.json`",
-                            "output_location": "StdErr",
-                            "late_condition": false,
-                            "condition": true
-                        }
-                    ],
-                    "timer_secs": 320,
-                    "warn_no_panic": false
-                }
-            }
-        },
-        {
-            "command": "cargo",
-            "args": [
-                        "llvm-cov",
-                        "--no-report",
-                        "run",
-                        "-p",
-                        "pool_sv2",
-                        "--",
-                        "-c",
-                        "../test/config/pool-mock-tp.toml"
-            ],
-            "conditions": {
-                "WithConditions": {
-                    "conditions": [
-                        {
-                            "output_string": "Listening for encrypted connection on: 127.0.0.1:34254",
-                            "output_location": "StdOut",
-                            "late_condition": false,
-                            "condition": true
-                        }
-                    ],
-                    "timer_secs": 320,
-                    "warn_no_panic": false
-                }
-            }
-        },
-       {
            "command": "cargo",
            "args": [
                        "run",

--- a/test/message-generator/test/pool-sri-test-close-channel.json
+++ b/test/message-generator/test/pool-sri-test-close-channel.json
@@ -81,6 +81,8 @@
         {
             "command": "cargo",
             "args": [
+                "llvm-cov",
+                "--no-report",
                 "run",
                 "-p",
                 "translator_sv2",

--- a/test/message-generator/test/standard-coverage-test.json
+++ b/test/message-generator/test/standard-coverage-test.json
@@ -183,27 +183,6 @@
         },
         {
             "command": "cargo",
-            "args": [
-                        "run",
-                        "../../../test/message-generator/mock/template-provider-mock1.json"
-            ],
-            "conditions": {
-                "WithConditions": {
-                    "conditions": [
-                        {
-                            "output_string": "Running `target/debug/message_generator_sv2 ../../../test/message-generator/mock/template-provider-mock1.json`",
-                            "output_location": "StdErr",
-                            "late_condition": false,
-                            "condition": true
-                        }
-                    ],
-                    "timer_secs": 320,
-                    "warn_no_panic": false
-                }
-            }
-        },
-        {
-            "command": "cargo",
             "args": [   "llvm-cov",
                         "--no-report",
                         "run",

--- a/test/message-generator/test/sv1-test.json
+++ b/test/message-generator/test/sv1-test.json
@@ -87,6 +87,8 @@
         {
             "command": "cargo",
             "args": [
+                        "llvm-cov",
+                        "--no-report",
                         "run",
                         "-p",
                         "pool_sv2",
@@ -112,6 +114,8 @@
         {
             "command": "cargo",
             "args": [
+                        "llvm-cov",
+                        "--no-report",
                         "run",
                         "-p",
                         "translator_sv2",

--- a/test/message-generator/test/translation-proxy-broke-pool.json
+++ b/test/message-generator/test/translation-proxy-broke-pool.json
@@ -64,6 +64,8 @@
        {
             "command": "cargo",
             "args": [
+                        "llvm-cov",
+                        "--no-report",
                         "run",
                         "-p",
                         "translator_sv2",

--- a/test/message-generator/test/translation-proxy.json
+++ b/test/message-generator/test/translation-proxy.json
@@ -159,6 +159,8 @@
        {
             "command": "cargo",
             "args": [
+                        "llvm-cov",
+                        "--no-report",
                         "run",
                         "-p",
                         "translator_sv2",


### PR DESCRIPTION
In the message-generator.sh script the binaries are pre-compiled so that the MG-tests do not take forever for run, reducing probability of timeouts