### PR TITLE
Custom transactions from JDC removed from mempool during update

### DIFF
--- a/roles/jd-server/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-server/src/lib/job_declarator/message_handler.rs
@@ -17,7 +17,7 @@ use crate::mempool::JDsMempool;
 use super::{signed_token, TransactionState};
 use roles_logic_sv2::{errors::Error, parsers::PoolMessages as AllMessages};
 use stratum_common::bitcoin::consensus::Decodable;
-use tracing::{info, debug};
+use tracing::{debug, info};
 
 use super::JobDeclaratorDownstream;
 

--- a/roles/jd-server/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-server/src/lib/job_declarator/message_handler.rs
@@ -111,11 +111,9 @@ impl ParseClientJobDeclarationMessages for JobDeclaratorDownstream {
     }
 
     fn handle_declare_mining_job(&mut self, message: DeclareMiningJob) -> Result<SendTo, Error> {
-        {
-            // Clone the old declared mining job to retain its data
-            if let Some(old_declare_mining_job_) = self.declared_mining_job.0.clone() {
-                clear_declared_mining_job(old_declare_mining_job_, self.mempool.clone())?;
-            }
+        // Clone the old declared mining job to retain its data
+        if let Some(old_declare_mining_job_) = self.declared_mining_job.0.clone() {
+            clear_declared_mining_job(old_declare_mining_job_, self.mempool.clone())?;
         }
 
         // the transactions that are present in the mempool are stored here, that is sent to the

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -136,7 +136,7 @@ impl JobDeclaratorDownstream {
         let mut transactions_list: Vec<Transaction> = Vec::new();
         for tx_with_state in transactions_with_state.iter().enumerate() {
             if let TransactionState::PresentInMempool(txid) = tx_with_state.1 {
-                let tx = mempool
+                let (tx, _) = mempool
                     .safe_lock(|x| x.mempool.get(txid).cloned())
                     .map_err(|e| JdsError::PoisonLock(e.to_string()))?
                     .ok_or(Box::new(JdsError::ImpossibleToReconstructBlock(

--- a/roles/jd-server/src/lib/mempool/mod.rs
+++ b/roles/jd-server/src/lib/mempool/mod.rs
@@ -95,12 +95,11 @@ impl JDsMempool {
     }
 
     pub async fn update_mempool(self_: Arc<Mutex<Self>>) -> Result<(), JdsMempoolError> {
-
-        let mut new_jds_mempool: HashMap<Txid, Option<Transaction>> = self_.safe_lock(|x| x.mempool.clone())?;
+        let mut new_jds_mempool: HashMap<Txid, Option<Transaction>> =
+            self_.safe_lock(|x| x.mempool.clone())?;
         // the fat transactions in the jds-mempool are those declared by some downstream and we
         // don't want to remove them, but we can get rid of the others
         new_jds_mempool.retain(|_, val| val.is_some());
-
 
         let client = self_
             .safe_lock(|x| x.get_client())?


### PR DESCRIPTION
### What does this PR do?
- Closes #840 
- It reads transactions from the jds mempool and the node's mempool, compares them and adds them to the new mempool that is updated. In cases where the txids are unknown it adds the fat transactions to the updated mempool as well.
- To prevent an overflow, old fat transactions are cleared before a new minning job is declared