### PR TITLE
Fix network helper panic if peer close connection

### DIFF
--- a/examples/ping-pong-with-noise/Cargo.toml
+++ b/examples/ping-pong-with-noise/Cargo.toml
@@ -15,7 +15,7 @@ async-std="1.8.0"
 bytes = "1.0.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 codec_sv2 = { version = "^1.0.0", path = "../../protocols/v2/codec-sv2", features=["noise_sv2"] }
-network_helpers_sv2 = { version = "^1.0.0", path = "../../roles/roles-utils/network-helpers", features=["async_std"] }
+network_helpers_sv2 = { version = "^2.0.0", path = "../../roles/roles-utils/network-helpers", features=["async_std"] }
 key-utils = { version = "^1.0.0", path = "../../utils/key-utils" }
 
 [features]

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
@@ -507,9 +507,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cfg-if"
@@ -583,7 +583,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -892,7 +892,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1201,7 +1201,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jd_client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel 1.9.0",
  "binary_sv2",
@@ -1338,7 +1338,7 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mining-device"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "mining_proxy_sv2"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-std",
@@ -1456,11 +1456,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1476,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1566,7 +1565,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1648,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 1.1.1",
@@ -1691,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1815,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
@@ -1848,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
@@ -1914,7 +1913,7 @@ checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2081,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2144,21 +2143,20 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2218,7 +2216,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2258,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-compat",
@@ -2381,7 +2379,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -2415,7 +2413,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/roles/jd-client/Cargo.toml
+++ b/roles/jd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "TODO"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 framing_sv2 = { version = "^1.0.0", path = "../../protocols/v2/framing-sv2" }
-network_helpers_sv2 = { version = "1.0.0", path = "../roles-utils/network-helpers", features=["with_tokio", "with_buffer_pool"] }
+network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["with_tokio", "with_buffer_pool"] }
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 futures = "0.3.25"

--- a/roles/jd-server/Cargo.toml
+++ b/roles/jd-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/stratum-mining/stratum"
@@ -16,7 +16,7 @@ binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
 const_sv2 = { version = "^1.0.0", path = "../../protocols/v2/const-sv2" }
-network_helpers_sv2 = { version = "1.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio"] }
+network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }

--- a/roles/mining-proxy/Cargo.toml
+++ b/roles/mining-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_proxy_sv2"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["user"]
 edition = "2018"
 description = "SV2 mining proxy role"
@@ -20,7 +20,7 @@ buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 const_sv2 = { version = "^1.0.0", path = "../../protocols/v2/const-sv2" }
 futures = "0.3.19"
-network_helpers_sv2 = {version = "1.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio","with_buffer_pool"] }
+network_helpers_sv2 = {version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio","with_buffer_pool"] }
 once_cell = "1.12.0"
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pool_sv2"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 description = "SV2 pool role"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
 const_sv2 = { version = "^1.0.0", path = "../../protocols/v2/const-sv2" }
-network_helpers_sv2 = { version = "1.0.0", path = "../roles-utils/network-helpers", features =["with_tokio","with_buffer_pool"] }
+network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features =["with_tokio","with_buffer_pool"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network_helpers_sv2"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Networking utils for SV2 roles"

--- a/roles/roles-utils/network-helpers/src/lib.rs
+++ b/roles/roles-utils/network-helpers/src/lib.rs
@@ -30,6 +30,8 @@ pub enum Error {
     CodecError(CodecError),
     RecvError,
     SendError,
+    // This means that a socket that was supposed to be opened have been closed, likley by the peer
+    SocketClosed,
 }
 
 impl From<CodecError> for Error {

--- a/roles/roles-utils/network-helpers/src/noise_connection_async_std.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection_async_std.rs
@@ -47,7 +47,7 @@ impl Connection {
         ),
         Error,
     > {
-        let address = stream.peer_addr().unwrap();
+        let address = stream.peer_addr().map_err(|_| Error::SocketClosed)?;
         let (mut reader, writer) = (stream.clone(), stream.clone());
 
         let (sender_incoming, receiver_incoming): (

--- a/roles/roles-utils/network-helpers/src/noise_connection_tokio.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection_tokio.rs
@@ -48,7 +48,7 @@ impl Connection {
         ),
         Error,
     > {
-        let address = stream.peer_addr().unwrap();
+        let address = stream.peer_addr().map_err(|_| Error::SocketClosed)?;
 
         let (mut reader, mut writer) = stream.into_split();
 

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining-device"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 publish = false
 
@@ -14,7 +14,7 @@ const_sv2 = { version = "1.0.0", path = "../../../protocols/v2/const-sv2" }
 async-channel = "1.5.1"
 async-std={version = "1.8.0", features = ["attributes"]}
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
-network_helpers_sv2 = { version = "1.0.0", path = "../../roles-utils/network-helpers", features=["async_std"] }
+network_helpers_sv2 = { version = "2.0.0", path = "../../roles-utils/network-helpers", features=["async_std"] }
 buffer_sv2 = { version = "1.0.0", path = "../../../utils/buffer"}
 async-recursion = "0.3.2"
 rand = "0.8.4"

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "translator_sv2"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Server used to bridge SV1 miners to SV2 pools"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 framing_sv2 = { version = "^1.0.0", path = "../../protocols/v2/framing-sv2" }
-network_helpers_sv2 = { version = "1.0.0", path = "../roles-utils/network-helpers", features=["async_std", "with_buffer_pool"] }
+network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["async_std", "with_buffer_pool"] }
 once_cell = "1.12.0"
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }

--- a/utils/message-generator/Cargo.toml
+++ b/utils/message-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message_generator_sv2"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ binary_sv2 = { version = "1.0.0", path = "../../protocols/v2/binary-sv2/binary-s
 codec_sv2 = { version = "1.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2","with_buffer_pool","with_serde"] }
 const_sv2 = { version = "1.0.0", path = "../../protocols/v2/const-sv2" }
 load_file = "1.0.1"
-network_helpers_sv2 = { version = "1.0.0", path = "../../roles/roles-utils/network-helpers", features = ["with_tokio","with_serde"] }
+network_helpers_sv2 = { version = "2.0.0", path = "../../roles/roles-utils/network-helpers", features = ["with_tokio","with_serde"] }
 roles_logic_sv2 = { version = "1.0.0", path = "../../protocols/v2/roles-logic-sv2", features = ["with_serde"] }
 v1 = { version = "^1.0.0", path = "../../protocols/v1", package="sv1_api" }
 serde = { version = "*", features = ["derive", "alloc"], default-features = false }


### PR DESCRIPTION
    Fix network helper panic if peer close connection

    When the remote peer try to open an encrypted sv2 connection and then
    immediatly close the tcp connection, the helper for async std and tokio
    it panic, mostly of the time we don't want to panic in this situation.
    This commit add an error for this case and return it.
