### PR TITLE
Better management of LastDeclareJobs - no more wrong fallback-system activations

### DIFF
--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -289,8 +289,13 @@ impl DownstreamMiningNode {
                 // pool's job_id. The below return as soon as we have a pairable job id for the
                 // template_id associated with this share.
                 let last_template_id = self_mutex.safe_lock(|s| s.last_template_id).unwrap();
-                let job_id =
-                    UpstreamMiningNode::get_job_id(&upstream_mutex, last_template_id).await;
+                let job_id_future = UpstreamMiningNode::get_job_id(&upstream_mutex, last_template_id);
+                let job_id = match timeout(Duration::from_secs(10), job_id_future).await {
+                    Ok(job_id) => job_id,
+                    Err(_) => {
+                        return;
+                    },
+                };
                 share.job_id = job_id;
                 debug!(
                     "Sending valid block solution upstream, with job_id {}",
@@ -643,7 +648,7 @@ impl ParseDownstreamCommonMessages<roles_logic_sv2::routing_logic::NoRouting>
 
 use network_helpers_sv2::noise_connection_tokio::Connection;
 use std::net::SocketAddr;
-use tokio::{net::TcpListener, task::AbortHandle};
+use tokio::{net::TcpListener, task::AbortHandle, time::{Duration, timeout}};
 
 /// Strat listen for downstream mining node. Return as soon as one downstream connect.
 #[allow(clippy::too_many_arguments)]

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -289,12 +289,13 @@ impl DownstreamMiningNode {
                 // pool's job_id. The below return as soon as we have a pairable job id for the
                 // template_id associated with this share.
                 let last_template_id = self_mutex.safe_lock(|s| s.last_template_id).unwrap();
-                let job_id_future = UpstreamMiningNode::get_job_id(&upstream_mutex, last_template_id);
+                let job_id_future =
+                    UpstreamMiningNode::get_job_id(&upstream_mutex, last_template_id);
                 let job_id = match timeout(Duration::from_secs(10), job_id_future).await {
                     Ok(job_id) => job_id,
                     Err(_) => {
                         return;
-                    },
+                    }
                 };
                 share.job_id = job_id;
                 debug!(
@@ -648,7 +649,11 @@ impl ParseDownstreamCommonMessages<roles_logic_sv2::routing_logic::NoRouting>
 
 use network_helpers_sv2::noise_connection_tokio::Connection;
 use std::net::SocketAddr;
-use tokio::{net::TcpListener, task::AbortHandle, time::{Duration, timeout}};
+use tokio::{
+    net::TcpListener,
+    task::AbortHandle,
+    time::{timeout, Duration},
+};
 
 /// Strat listen for downstream mining node. Return as soon as one downstream connect.
 #[allow(clippy::too_many_arguments)]

--- a/roles/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-client/src/lib/job_declarator/message_handler.rs
@@ -54,7 +54,9 @@ impl ParseServerJobDeclarationMessages for JobDeclarator {
         message: ProvideMissingTransactions,
     ) -> Result<SendTo, Error> {
         let tx_list = self
-            .last_declare_mining_job_sent
+            .last_declare_mining_jobs_sent
+            .get(&message.request_id)
+            .unwrap()
             .clone()
             .unwrap()
             .tx_list

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -377,14 +377,12 @@ impl JobDeclarator {
                 s.last_set_new_prev_hash = Some(set_new_prev_hash.clone());
                 s.set_new_prev_hash_counter += 1;
             });
-
-            let mut future_job_tuple_opt = None;
-
-            loop {
+            let (job, up, merkle_path, template, mut pool_outs) = loop {
                 match self_mutex
                     .safe_lock(|s| {
                         if s.set_new_prev_hash_counter > 1
                             && s.last_set_new_prev_hash != Some(set_new_prev_hash.clone())
+                        //it means that a new prev_hash is arrived while the previous hasn't exited the loop yet
                         {
                             s.set_new_prev_hash_counter -= 1;
                             Some(None)
@@ -401,39 +399,31 @@ impl JobDeclarator {
                     })
                     .unwrap()
                 {
-                    Some(Some(future_job_tuple)) => {
-                        future_job_tuple_opt = Some(future_job_tuple);
-                        break;
-                    }
-                    Some(None) => {
-                        break;
-                    }
+                    Some(Some(future_job_tuple)) => break future_job_tuple,
+                    Some(None) => return,
                     None => {}
                 };
                 tokio::task::yield_now().await;
-            }
-
-            if let Some((job, up, merkle_path, template, mut pool_outs)) = future_job_tuple_opt {
-                let signed_token = job.mining_job_token.clone();
-                let mut template_outs = template.coinbase_tx_outputs.to_vec();
-                pool_outs.append(&mut template_outs);
-                Upstream::set_custom_jobs(
-                    &up,
-                    job,
-                    set_new_prev_hash,
-                    merkle_path,
-                    signed_token,
-                    template.coinbase_tx_version,
-                    template.coinbase_prefix,
-                    template.coinbase_tx_input_sequence,
-                    template.coinbase_tx_value_remaining,
-                    pool_outs,
-                    template.coinbase_tx_locktime,
-                    template.template_id,
-                )
-                .await
-                .unwrap();
-            }
+            };
+            let signed_token = job.mining_job_token.clone();
+            let mut template_outs = template.coinbase_tx_outputs.to_vec();
+            pool_outs.append(&mut template_outs);
+            Upstream::set_custom_jobs(
+                &up,
+                job,
+                set_new_prev_hash,
+                merkle_path,
+                signed_token,
+                template.coinbase_tx_version,
+                template.coinbase_prefix,
+                template.coinbase_tx_input_sequence,
+                template.coinbase_tx_value_remaining,
+                pool_outs,
+                template.coinbase_tx_locktime,
+                template.template_id,
+            )
+            .await
+            .unwrap();
         });
     }
 

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -140,7 +140,11 @@ impl JobDeclarator {
             .unwrap()
     }
 
-    fn update_last_declare_job_sent(self_mutex: &Arc<Mutex<Self>>, request_id: u32, j: LastDeclareJob) {
+    fn update_last_declare_job_sent(
+        self_mutex: &Arc<Mutex<Self>>,
+        request_id: u32,
+        j: LastDeclareJob,
+    ) {
         self_mutex
             .safe_lock(|s| s.last_declare_mining_jobs_sent.insert(request_id, Some(j)))
             .unwrap();
@@ -274,7 +278,8 @@ impl JobDeclarator {
                     match next_message_to_send {
                         Ok(SendTo::None(Some(JobDeclaration::DeclareMiningJobSuccess(m)))) => {
                             let new_token = m.new_mining_job_token;
-                            let last_declare = Self::get_last_declare_job_sent(&self_mutex, m.request_id);
+                            let last_declare =
+                                Self::get_last_declare_job_sent(&self_mutex, m.request_id);
                             let mut last_declare_mining_job_sent = last_declare.declare_job;
                             let is_future = last_declare.template.future_template;
                             let id = last_declare.template.template_id;

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -152,9 +152,10 @@ impl JobDeclarator {
                 //check hashmap size in order to not let it grow indefinetely
                 if s.last_declare_mining_jobs_sent.len() < 10 {
                     s.last_declare_mining_jobs_sent.insert(request_id, Some(j));
-                } else if let Some(min_key) = s.last_declare_mining_jobs_sent.keys().min().cloned() {
-                        s.last_declare_mining_jobs_sent.remove(&min_key);
-                        s.last_declare_mining_jobs_sent.insert(request_id, Some(j));
+                } else if let Some(min_key) = s.last_declare_mining_jobs_sent.keys().min().cloned()
+                {
+                    s.last_declare_mining_jobs_sent.remove(&min_key);
+                    s.last_declare_mining_jobs_sent.insert(request_id, Some(j));
                 }
             })
             .unwrap();

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -148,7 +148,17 @@ impl JobDeclarator {
         j: LastDeclareJob,
     ) {
         self_mutex
-            .safe_lock(|s| s.last_declare_mining_jobs_sent.insert(request_id, Some(j)))
+            .safe_lock(|s| {
+                //check hashmap size in order to not let it grow indefinetely
+                if s.last_declare_mining_jobs_sent.len() < 10 {
+                    s.last_declare_mining_jobs_sent.insert(request_id, Some(j));
+                } else {
+                    if let Some(min_key) = s.last_declare_mining_jobs_sent.keys().min().cloned() {
+                        s.last_declare_mining_jobs_sent.remove(&min_key);
+                        s.last_declare_mining_jobs_sent.insert(request_id, Some(j));
+                    }
+                }
+            }) 
             .unwrap();
     }
 

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -152,13 +152,11 @@ impl JobDeclarator {
                 //check hashmap size in order to not let it grow indefinetely
                 if s.last_declare_mining_jobs_sent.len() < 10 {
                     s.last_declare_mining_jobs_sent.insert(request_id, Some(j));
-                } else {
-                    if let Some(min_key) = s.last_declare_mining_jobs_sent.keys().min().cloned() {
+                } else if let Some(min_key) = s.last_declare_mining_jobs_sent.keys().min().cloned() {
                         s.last_declare_mining_jobs_sent.remove(&min_key);
                         s.last_declare_mining_jobs_sent.insert(request_id, Some(j));
-                    }
                 }
-            }) 
+            })
             .unwrap();
     }
 
@@ -383,9 +381,10 @@ impl JobDeclarator {
                     .safe_lock(|s| {
                         if s.set_new_prev_hash_counter > 1
                             && s.last_set_new_prev_hash != Some(set_new_prev_hash.clone())
+                        //it means that a new prev_hash is arrived while the previous hasn't exited the loop yet
                         {
                             s.set_new_prev_hash_counter -= 1;
-                            return Some(None);
+                            Some(None)
                         } else {
                             s.future_jobs.remove(&id).map(
                                 |(job, merkle_path, template, pool_outs)| {


### PR DESCRIPTION
This PR addresses the way `last_declare_mining_jobs_sent` are managed by JDC. 
Before this PR, we could end up in a situation in which we were not able to exit from the loop inside `on_set_new_prev_hash` function because of this line: https://github.com/stratum-mining/stratum/blob/0b131916f8bbc739a57b739c059fe887bc538931/roles/jd-client/src/lib/job_declarator/mod.rs#L362 
The situation occured every time a new job was created and declared right after the future job linked to the new prev_hash. Because of [this line](https://github.com/stratum-mining/stratum/blob/0b131916f8bbc739a57b739c059fe887bc538931/roles/jd-client/src/lib/job_declarator/mod.rs#L275) the second job (not future) was extracted in this scenario (instead of the right previous one, the future one). In this way the future_job was not able to be inserted into `future_jobs` through [this line](https://github.com/stratum-mining/stratum/blob/0b131916f8bbc739a57b739c059fe887bc538931/roles/jd-client/src/lib/job_declarator/mod.rs#L289) and so we never exited from the loop.

This implied that that specific prev_hash was constantly set by the loop, causing the behaviour described under issue #901.

Fixes #901 