### PR TITLE
patch check-versioning-lib-release.sh

### DIFF
--- a/check-versioning-lib-release.sh
+++ b/check-versioning-lib-release.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-git fetch origin main
-git fetch origin dev
+git fetch --all
 
 crates=(
 "utils/buffer"
@@ -35,6 +34,10 @@ crates=(
 # Loop through each crate
 for crate in "${crates[@]}"; do
   cd "$crate"
+
+  # Check if the branches exist locally, if not, create them
+  git show-ref --verify --quiet refs/remotes/origin/main || { echo "Branch 'main' not found."; exit 1; }
+  git show-ref --verify --quiet refs/remotes/origin/dev || { echo "Branch 'dev' not found."; exit 1; }
 
   # Check if there were any changes between dev and main
   git diff --quiet "origin/dev" "origin/main" -- .


### PR DESCRIPTION
while preparing Release `v1.0.1` (https://github.com/stratum-mining/stratum/pull/925), I noticed that `check-versioning-lib-release.sh` wasn't working as expected

basically, the `git diff` command couldn't find the correct branches to compare:
https://github.com/stratum-mining/stratum/actions/runs/9210253269/job/25336804115#step:3:1

so I had to make some modifications to the script, which now seems to work correctly on a mock PR on my fork:
https://github.com/plebhash/stratum/actions/runs/9211103745/job/25339668933#step:3:1

as the action above indicates, we also need to bump version on `codec_sv2`, which is being done via https://github.com/stratum-mining/stratum/pull/927