### PR TITLE
bump codec sv2 version

### DIFF
--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codec_sv2"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2 data format"


### PR DESCRIPTION
while fixing `check-versioning-lib-release.sh` (https://github.com/stratum-mining/stratum/pull/926) and preparing for Release `v1.0.1` (https://github.com/stratum-mining/stratum/pull/925), I noticed we were forgetting to bump `codec_sv2` crate version, as a result of a patch applied to one of it's dependencies (`framing_sv2`) via https://github.com/stratum-mining/stratum/pull/913

`framing_sv2` (which is a dependency of `codec_sv2`) had it's `MINOR` version bumped, which means `codec_sv2` also needs to bump it's `MINOR` version