### PR TITLE
MG test for JDC on quick templates

### DIFF
--- a/test/config/jdc-quick-template-update/jdc-config.toml
+++ b/test/config/jdc-quick-template-update/jdc-config.toml
@@ -1,0 +1,50 @@
+# Local Mining Device Downstream Connection
+downstream_address = "127.0.0.1"
+downstream_port = 34265
+
+# Version support
+max_supported_version = 2
+min_supported_version = 2
+
+# Minimum extranonce2 size for downstream
+# Max value: 16 (leaves 0 bytes for search space splitting of downstreams)
+# Max value for CGminer: 8
+# Min value: 2
+min_extranonce2_size = 8
+
+# Withhold
+withhold = false
+
+# Auth keys for open encrypted connection downstream
+authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+cert_validity_sec = 3600
+
+# How many time the JDC try to reinitialize itself after a failure 
+retry = 10
+
+tp_address = "127.0.0.1:8442"
+tp_authority_pub_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+
+
+
+coinbase_outputs = [
+     { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+]
+
+[timeout]
+unit = "secs"
+value = 1
+
+[[upstreams]]
+authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+pool_address = "127.0.0.1:34254"
+jd_address = "127.0.0.1:34264"
+pool_signature = "Stratum v2 SRI Pool"
+
+[[upstreams]]
+authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+pool_address = "127.0.0.1:44255"
+jd_address = "127.0.0.1:34264"
+pool_signature = "Stratum v2 SRI Pool"
+

--- a/test/config/pool-config-local-tp.toml
+++ b/test/config/pool-config-local-tp.toml
@@ -1,0 +1,14 @@
+listen_address = "127.0.0.1:34254"
+tp_address = "127.0.0.1:8442"
+listen_jd_address = "127.0.0.1:34264"
+authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+cert_validity_sec = 3600
+test_only_listen_adress_plain =  "0.0.0.0:34250"
+# list of coinbase outputs used to build the coinbase tx
+# ! right now only one output is supported, so comment all the ones you don't need !
+coinbase_outputs = [
+    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+]
+# Pool signature (string to be included in coinbase tx)
+pool_signature = "Stratum v2 SRI Pool"

--- a/test/message-generator/mock/jds-mock-quick-templates.json
+++ b/test/message-generator/mock/jds-mock-quick-templates.json
@@ -1,0 +1,146 @@
+{
+    "version": "2",
+    "doc": [
+        "This test does",
+        "Mock a JDS",
+        "Start listen to the port 34264",
+        "Receive SetupConnection and reply SetupConnection.Success",
+        "(template1) Await for AllocateMiningJobToken and reply AllocateMiningJobToken.Success",
+        "(template2) Await for AllocateMiningJobToken and reply AllocateMiningJobToken.Success",
+        "(template1) Await for DeclareMiningJob and reply DeclareMiningJob.Success",
+        "(template2) Await for DeclareMiningJob and reply DeclareMiningJob.Success"
+    ],
+    "jd_messages": [
+        {
+            "message": {
+                "type": "AllocateMiningJobTokenSuccess",
+                "mining_job_token": [0, 0, 0, 0, 0],
+                "coinbase_output_max_additional_size": 0,
+                "async_mining_allowed": false
+            },
+            "id": "allocate_mining_job_token_success_0"
+        },
+        {
+            "message": {
+                "type": "AllocateMiningJobTokenSuccess",
+                "mining_job_token": [0, 0, 0, 0, 1],
+                "coinbase_output_max_additional_size": 0,
+                "async_mining_allowed": false
+            },
+            "id": "allocate_mining_job_token_success_1"
+        },
+        {
+            "message": {
+                "type": "DeclareMiningJob.Success",
+                "request_id": 0,
+                "new_mining_job_token": [0, 0, 0, 0, 0]
+            },
+            "id": "declare_mining_job_success_0"
+        },
+        {
+            "message": {
+                "type": "DeclareMiningJob.Success",
+                "request_id": 1,
+                "new_mining_job_token": [0, 0, 0, 0, 0]
+            },
+            "id": "declare_mining_job_success_1"
+        }
+    ],
+    "frame_builders": [
+        {
+            "type": "automatic",
+            "message_id": "allocate_mining_job_token_success_0"
+        },
+        {
+            "type": "automatic",
+            "message_id": "allocate_mining_job_token_success_1"
+        },
+        {
+            "type": "automatic",
+            "message_id": "declare_mining_job_success_0"
+        },
+        {
+            "type": "automatic",
+            "message_id": "declare_mining_job_success_1"
+        },
+        {
+            "type": "automatic",
+            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_tproxy"
+        }
+    ],
+    "actions": [
+       {
+            "message_ids": ["setup_connection_success_tproxy"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x00"
+                }
+            ],
+            "actiondoc": "This action checks that a SetupConnection message is received, and sends back a SetupConnection.Success (setup_connection_success_tproxy)"
+        },
+        {
+            "message_ids": ["allocate_mining_job_token_success_0"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x50"
+                }
+            ],
+            "actiondoc": "This action checks that a AllocateMiningJobToken message is received, and sends back a AllocateMiningJobToken.Success (allocate_mining_job_token_success_0)"
+        },
+        {
+            "message_ids": ["allocate_mining_job_token_success_1"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x50"
+                }
+            ],
+            "actiondoc": "This action checks that a AllocateMiningJobToken message is received, and sends back a AllocateMiningJobToken.Success (allocate_mining_job_token_success_1)"
+        },
+        {
+            "message_ids": ["declare_mining_job_success_0"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x57"
+                }
+            ],
+            "actiondoc": "This action checks that a DeclareMiningJob message is received, and sends back a DeclareMiningJob.Success (declare_mining_job_success_0)"
+        },
+        {
+            "message_ids": ["declare_mining_job_success_1"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x57"
+                }
+            ],
+            "actiondoc": "This action checks that a DeclareMiningJob message is received, and sends back a DeclareMiningJob.Success (declare_mining_job_success_1)"
+        }
+    ],
+    "setup_commands": [
+    ],
+    "execution_commands": [
+    ],
+    "cleanup_commands": [
+        {
+            "command": "sleep",
+            "args": ["10000000"],
+            "conditions": "None"
+        }
+    ],
+    "role": "server",
+    "upstream": {
+        "ip": "127.0.0.1",
+        "port": 34264,
+        "pub_key": "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72",
+        "secret_key": "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+    }
+}

--- a/test/message-generator/mock/tp-mock-quick-template.json
+++ b/test/message-generator/mock/tp-mock-quick-template.json
@@ -1,0 +1,182 @@
+{
+    "version": "2",
+    "doc": [
+        "This test does",
+        "Soft mocking of template provider that sends two templates (NewTemplate message) with very little time in between",
+        "Listen to port 8442",
+        "Awaits for other roles setup (5s)",
+        "Awaits for SetupConnection message (pool)",
+        "Responds with SetupConnection.Success (pool)",
+        "Awaits for SetupConnection message (jdc)",
+        "Responds with SetupConnection.Success (jdc)",
+        "Sends NewTemplate (new_template)",
+        "Sends SetNewPrevHash (set_new_prev_hash2)",
+        "Awaits for RequestTransactionData",
+        "Responds with RequestTransactionData.Success",
+        "Sleep for 100ms (very fast time between templates)",
+        "Sends NewTemplate (new_template2)",
+        "Sends SetNewPrevHash (set_new_prev_hash2)",
+        "Awaits for RequestTransactionData",
+        "Responds with RequestTransactionData.Success"
+    ],
+    "template_distribution_messages": [
+        {
+            "message": {
+                "type": "NewTemplate",
+                "template_id": 29,
+                "future_template": true,
+                "version": 536870912,
+                "coinbase_tx_version": 2,
+                "coinbase_prefix": [3, 76, 163, 38, 0],
+                "coinbase_tx_input_sequence": 4294967295,
+                "coinbase_tx_value_remaining": 625000000,
+                "coinbase_tx_outputs_count": 0,
+                "coinbase_tx_outputs": [],
+                "coinbase_tx_locktime": 0,
+                "merkle_path": []
+            },
+            "id": "new_template"
+        },
+        {
+            "message": {
+                "type": "SetNewPrevHash",
+                "template_id": 29,
+                "prev_hash": [145, 77, 225, 26, 186, 5, 16, 125, 174, 40, 238, 200, 210, 191, 188, 87, 191, 246, 242, 221, 8, 20, 202, 200, 97, 139, 241, 73, 137, 201, 28, 0],
+                "header_timestamp": 1671039088,
+                "n_bits": 545259519,
+                "target": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,255,255,127]
+            },
+            "id": "set_new_prev_hash"
+        },
+        {
+            "message": {
+                "type": "NewTemplate",
+                "template_id": 30,
+                "future_template": true,
+                "version": 536870912,
+                "coinbase_tx_version": 2,
+                "coinbase_prefix": [3, 76, 163, 38, 0],
+                "coinbase_tx_input_sequence": 4294967295,
+                "coinbase_tx_value_remaining": 625000000,
+                "coinbase_tx_outputs_count": 0,
+                "coinbase_tx_outputs": [],
+                "coinbase_tx_locktime": 0,
+                "merkle_path": []
+            },
+            "id": "new_template2"
+        },
+        {
+            "message": {
+                "type": "SetNewPrevHash",
+                "template_id": 30,
+                "prev_hash": [145, 77, 225, 26, 186, 5, 16, 125, 174, 40, 238, 200, 210, 191, 188, 87, 191, 246, 242, 221, 8, 20, 202, 200, 97, 139, 241, 73, 137, 201, 28, 0],
+                "header_timestamp": 1671039088,
+                "n_bits": 545259519,
+                "target": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,255,255,127]
+            },
+            "id": "set_new_prev_hash2"
+        }
+    ],
+    "frame_builders": [
+        {
+            "type": "automatic",
+            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_template_distribution"
+        },
+        {
+            "type": "automatic",
+            "message_id": "new_template"
+        },
+        {
+            "type": "automatic",
+            "message_id": "set_new_prev_hash"
+        },
+        {
+            "type": "automatic",
+            "message_id": "new_template2"
+        },
+        {
+            "type": "automatic",
+            "message_id": "set_new_prev_hash2"
+        }
+
+    ],
+    "actions": [
+        {
+            "message_ids": [],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x00"
+                }
+            ],
+            "actiondoc": "(pool) This action checks that a SetupConnection message is received"
+        },
+        {
+            "message_ids": ["setup_connection_success_template_distribution"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x70"
+                }
+            ],
+          "actiondoc": "(pool) This action sends SetupConnection.Success with flag 2 (TD protocol) and checks that a message SetCoinbaseDataSize is received"
+        },
+        {
+            "message_ids": [],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x00"
+                }
+            ],
+            "actiondoc": "(jdc) This action checks that a SetupConnection message is received"
+        },
+        {
+            "message_ids": ["setup_connection_success_template_distribution"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x70"
+                }
+            ],
+            "actiondoc": "(jdc) This action sends SetupConnection.Success with flag 2 (TD protocol) and checks that a message SetCoinbaseDataSize is received"
+        },
+        {
+            "message_ids": ["new_template","set_new_prev_hash"],
+            "role": "server",
+            "results": [],
+            "actiondoc": "This action sends NewTemplate and SetNewPrevHash"
+        },
+        {
+            "message_ids": ["new_template2","set_new_prev_hash2"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x76"
+                }
+            ],
+            "actiondoc": "This action checks that new template2 and new prev hash2 is received"
+        }
+    ],
+    "setup_commands": [],
+    "execution_commands": [],
+    "cleanup_commands": [
+        {
+            "command": "sleep",
+            "args": ["10"],
+            "conditions": "None"
+        }
+    ],
+    "role": "server",
+    "upstream": {
+        "ip": "127.0.0.1",
+        "port": 8442,
+        "pub_key": "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72",
+        "secret_key": "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+    }
+}

--- a/test/message-generator/test/jdc-quick-template-update/jdc-quick-template-update.json
+++ b/test/message-generator/test/jdc-quick-template-update/jdc-quick-template-update.json
@@ -1,0 +1,187 @@
+{
+    "version": "2",
+    "doc": [
+        "This test does",
+        "Launch real pool",
+        "Launch real JDC",
+        "Mock TP",
+        "Mock JDS",
+        "todo: describe message sequence"
+    ],
+    "frame_builders": [
+        {
+            "type": "automatic",
+            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_tproxy"
+        },
+        {
+            "type": "automatic",
+            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_tproxy"
+        }
+    ],
+    "actions": [
+       {
+            "message_ids": [],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x00"
+                }
+            ],
+            "actiondoc": "This action checks that a Setupconnection message is received"
+        },
+        {
+            "message_ids": ["setup_connection_success_tproxy"],
+            "role": "server",
+            "results": [
+                {
+                    "type": "match_message_type",
+                    "value": "0x13"
+                }
+            ],
+          "actiondoc": "This action sends SetupConnection.Success and check that a open_extended_mining_channel is received"
+        }
+    ],
+    "setup_commands": [
+        {
+            "command": "cargo",
+            "args": [
+                "run",
+                "../../test/message-generator/mock/tp-mock-quick-template.json"
+            ],
+
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "",
+                            "output_location": "StdErr",
+                            "condition": true,
+                            "late_condition": false
+                        }
+                    ],
+                    "timer_secs": 600,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "cargo",
+            "args": [
+                "llvm-cov",
+                "--no-report",
+                "run",
+                "-p",
+                "pool_sv2",
+                "--",
+                "-c",
+                "../test/config/pool-config-local-tp.toml"
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "Pool INITIALIZING",
+                            "output_location": "StdOut",
+                            "late_condition": false,
+                            "condition": true
+                        }
+                    ],
+                    "timer_secs": 1000,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "cargo",
+            "args": [
+                "run",
+                "../../test/message-generator/mock/jds-mock-quick-templates.json"
+            ],
+
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "",
+                            "output_location": "StdErr",
+                            "condition": true,
+                            "late_condition": false
+                        }
+                    ],
+                    "timer_secs": 600,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "sleep",
+            "args": ["7000"],
+            "conditions": "None"
+        },
+        {
+            "command": "cargo",
+            "args": [
+                "llvm-cov",
+                "--no-report",
+                "run",
+                "-p",
+                "jd_client",
+                "--",
+                "-c",
+                "../test/config/jdc-quick-template-update/jdc-config.toml"
+            ],
+            "conditions": {
+                "WithConditions": {
+                    "conditions": [
+                        {
+                            "output_string": "JD INITIALIZED",
+                            "output_location": "StdOut",
+                            "late_condition": false,
+                            "condition": true
+                        }
+                    ],
+                    "timer_secs": 600,
+                    "warn_no_panic": false
+                }
+            }
+        },
+        {
+            "command": "sleep",
+            "args": ["10000"],
+            "conditions": "None"
+        }
+    ],
+    "execution_commands": [
+    ],
+    "cleanup_commands": [
+        {
+            "command": "pkill",
+            "args":  ["-f", "mining_device", "-SIGINT"],
+            "conditions": "None"
+        },
+        {
+            "command": "pkill",
+            "args":  ["-f", "jd_server", "-SIGINT"],
+            "conditions": "None"
+        },
+        {
+            "command": "pkill",
+            "args":  ["-f", "jd_client", "-SIGINT"],
+            "conditions": "None"
+        },
+        {
+            "command": "pkill",
+            "args":  ["-f", "mining_proxy_sv2", "-SIGINT"],
+            "conditions": "None"
+        }
+    ],
+    "role": "none",
+    "role": "server",
+    "upstream": {
+        "ip": "127.0.0.1",
+        "port": 44255,
+        "pub_key": "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72",
+        "secret_key": "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+    }
+}

--- a/test/message-generator/test/jdc-quick-template-update/jdc-quick-template-update.sh
+++ b/test/message-generator/test/jdc-quick-template-update/jdc-quick-template-update.sh
@@ -1,0 +1,10 @@
+cd roles
+cargo llvm-cov --no-report -p jd_client
+cargo llvm-cov --no-report -p pool_sv2
+
+cd ../utils/message-generator/
+cargo build
+
+RUST_LOG=debug cargo run ../../test/message-generator/test/jdc-quick-template-update/jdc-quick-template-update.json || { echo 'mg test failed' ; exit 1; }
+
+sleep 10


### PR DESCRIPTION
eventually this will close #923

---
this is where I stopped:

- [ ] [`message-generator/mock/jds-mock-quick-templates.json`](https://github.com/plebhash/stratum/blob/mg-test-jdc-quick-templates/test/message-generator/mock/jds-mock-quick-templates.json) is creating `jd_messages` that are leading to broken `frame_builders`.
```
STD OUT: EXECUTING ../../test/message-generator/mock/jds-mock-quick-templates.json
STD OUT: 
STD ERR: thread 'main' panicked at src/parser/frames.rs:40:44:
STD ERR: Missing messages message_id allocate_mining_job_token_success_0
```

- [ ] [`test/message-generator/test/jdc-quick-template-update/jdc-quick-template-update.json`](https://github.com/plebhash/stratum/blob/mg-test-jdc-quick-templates/test/message-generator/test/jdc-quick-template-update/jdc-quick-template-update.json) needs:
  - [ ] finish `doc` description with a list of steps that the test performs
  - [ ] test action asserting `SubmitShares.Success` from pool
  - [ ] more stuff? maybe I'm missing something, this todo list should not be seen as complete
