### PR TITLE
make `no_std` into an optional feature on `protocols` crates

### DIFF
--- a/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
@@ -13,3 +13,6 @@ repository = "https://github.com/stratum-mining/stratum"
 [dependencies]
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 buffer_sv2 = {version = "^1.0.0",  path = "../../../../utils/buffer"}
+
+[features]
+no_std = []

--- a/protocols/v2/binary-sv2/serde-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/lib.rs
@@ -72,7 +72,7 @@
 //! [rkyv1]: https://docs.rs/rkyv/0.4.3/rkyv
 //! [rkyv2]: https://davidkoloski.me/blog/rkyv-is-faster-than/
 
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 
 #[macro_use]
 extern crate alloc;

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -21,3 +21,4 @@ tracing = { version = "0.1"}
 [features]
 with_serde = ["binary_sv2/with_serde", "serde", "framing_sv2/with_serde", "buffer_sv2/with_serde"]
 with_buffer_pool = ["framing_sv2/with_buffer_pool"]
+no_std = []

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 
 extern crate alloc;
 

--- a/protocols/v2/const-sv2/Cargo.toml
+++ b/protocols/v2/const-sv2/Cargo.toml
@@ -14,3 +14,6 @@ secp256k1 = { version = "0.28.2", default-features = false, features =["hashes",
 
 #[dev-dependencies]
 #cbindgen = "0.16.0"
+
+[features]
+no_std = []

--- a/protocols/v2/const-sv2/src/lib.rs
+++ b/protocols/v2/const-sv2/src/lib.rs
@@ -1,5 +1,5 @@
 //! Central repository for all the sv2 constants
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 
 pub const EXTENSION_TYPE_NO_EXTENSION: u16 = 0;
 

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -17,5 +17,6 @@ binary_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/bina
 buffer_sv2 = { version = "^1.0.0", path = "../../../utils/buffer", optional=true }
 
 [features]
+no_std = []
 with_serde = ["binary_sv2/with_serde", "serde", "buffer_sv2/with_serde"]
 with_buffer_pool = ["binary_sv2/with_buffer_pool", "buffer_sv2"]

--- a/protocols/v2/framing-sv2/src/lib.rs
+++ b/protocols/v2/framing-sv2/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! The `with_serde` feature flag is only used for the Message Generator, and deprecated for any other kind of usage. It will likely be fully deprecated in the future.
 
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 extern crate alloc;
 
 /// SV2 framing types

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -18,5 +18,6 @@ quickcheck_macros = { version = "1", optional=true }
 serde_repr = {version= "0.1.10", optional=true}
 
 [features]
+no_std = []
 with_serde = ["binary_sv2/with_serde", "serde", "serde_repr"]
 prop_test = ["quickcheck"]

--- a/protocols/v2/subprotocols/common-messages/src/lib.rs
+++ b/protocols/v2/subprotocols/common-messages/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 
 //! Common messages for [stratum v2][Sv2]
 //! The following protocol messages are common across all of the sv2 (sub)protocols.

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -14,4 +14,5 @@ binary_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/bi
 const_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
 
 [features]
+no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]

--- a/protocols/v2/subprotocols/job-declaration/src/lib.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 
 //! # Job Declaration Protocol
 //!

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -20,4 +20,5 @@ quickcheck = "1.0.3"
 quickcheck_macros = "1"
 
 [features]
+no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]

--- a/protocols/v2/subprotocols/mining/src/lib.rs
+++ b/protocols/v2/subprotocols/mining/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 
 //! # Mining Protocol
 //! ## Channels

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -17,5 +17,6 @@ quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
 
 [features]
+no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]
 prop_test = ["quickcheck"]

--- a/protocols/v2/subprotocols/template-distribution/src/lib.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 
 //! # Template Distribution Protocol
 //! The Template Distribution protocol is used to receive updates of the block template to use in


### PR DESCRIPTION
Many of the low level libs under `protocols` are `no_std`. That is great, since it allows for potential firmware integrations using `rust-embedded` and targets without MMUs (e.g.: Xtensa ESP32, ARM Cortex-M, etc).

Some projects in the community even have some potential to leverage SRI `protocols` crates for firmware integration, e.g.: https://github.com/bitaxeorg/esp-miner-rs

However, for most common deployment scenarios (e.g.: x86-64), high level application code (e.g.: `roles`) has no hard requirement for `no_std`. Also, having it as a mandatory feature becomes a blocker to many desirable changes.