### PR TITLE
Specify version on filenames inside `Release Bin` CI

### DIFF
--- a/.github/workflows/release-bin.yaml
+++ b/.github/workflows/release-bin.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/pool_sv2
-          asset_name: pool_sv2-x86_64-linux-gnu
+          asset_name: pool-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
           tag: ${{ github.ref }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -58,7 +58,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/pool_sv2
-          asset_name: pool_sv2-x86_64-apple-darwin
+          asset_name: pool-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
           tag: ${{ github.ref }}
           
       - name: Upload Linux aarch64 binaries to release
@@ -67,7 +67,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/pool_sv2
-          asset_name: pool_sv2-aarch64-linux-gnu
+          asset_name: pool-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
           tag: ${{ github.ref }}
           
       - name: Upload Linux ARM binaries to release
@@ -76,7 +76,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/pool_sv2
-          asset_name: pool_sv2-arm-linux-gnueabi
+          asset_name: pool-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
           tag: ${{ github.ref }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -85,7 +85,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/pool_sv2
-          asset_name: pool_sv2-aarch64-apple-darwin
+          asset_name: pool-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
           tag: ${{ github.ref }}
 
   release_jdc:
@@ -128,7 +128,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_client
-          asset_name: jd_client-x86_64-linux-gnu
+          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
           tag: ${{ github.ref }}
           
       - name: Upload Linux aarch64 binaries to release
@@ -137,7 +137,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/jd_client
-          asset_name: jd_client-aarch64-linux-gnu
+          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
           tag: ${{ github.ref }}
           
       - name: Upload Linux ARM binaries to release
@@ -146,7 +146,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/jd_client
-          asset_name: jd_client-arm-linux-gnueabi
+          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
           tag: ${{ github.ref }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -155,7 +155,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_client
-          asset_name: jd_client-x86_64-apple-darwin
+          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
           tag: ${{ github.ref }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -164,7 +164,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/jd_client
-          asset_name: jd_client-aarch64-apple-darwin
+          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
           tag: ${{ github.ref }}
 
   release_jds:
@@ -207,7 +207,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_server
-          asset_name: jd_server-x86_64-linux-gnu
+          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
           tag: ${{ github.ref }}
           
       - name: Upload Linux aarch64 binaries to release
@@ -216,7 +216,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/jd_server
-          asset_name: jd_server-aarch64-linux-gnu
+          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
           tag: ${{ github.ref }}
 
       - name: Upload Linux ARM binaries to release
@@ -225,7 +225,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/jd_server
-          asset_name: jd_server-arm-linux-gnueabi
+          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
           tag: ${{ github.ref }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -234,7 +234,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_server
-          asset_name: jd_server-x86_64-apple-darwin
+          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
           tag: ${{ github.ref }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -243,7 +243,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/jd_server
-          asset_name: jd_server-aarch64-apple-darwin
+          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
           tag: ${{ github.ref }}
 
   release_proxy:
@@ -295,7 +295,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/mining_proxy_sv2
-          asset_name: mining_proxy_sv2-aarch64-linux-gnu
+          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
           tag: ${{ github.ref }}
           
       - name: Upload Linux ARM binaries to release
@@ -304,7 +304,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/mining_proxy_sv2
-          asset_name: mining_proxy_sv2-arm-linux-gnueabi
+          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
           tag: ${{ github.ref }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -313,7 +313,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/mining_proxy_sv2
-          asset_name: mining_proxy_sv2-x86_64-apple-darwin
+          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
           tag: ${{ github.ref }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -322,7 +322,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/mining_proxy_sv2
-          asset_name: mining_proxy_sv2-aarch64-apple-darwin
+          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
           tag: ${{ github.ref }}
 
   release_translator:
@@ -365,7 +365,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/translator_sv2
-          asset_name: translator_sv2-x86_64-linux-gnu
+          asset_name: translator-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
           tag: ${{ github.ref }}
              
       - name: Upload Linux aarch64 binaries to release
@@ -374,7 +374,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/translator_sv2
-          asset_name: translator_sv2-aarch64-linux-gnu
+          asset_name: translator-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
           tag: ${{ github.ref }}
           
       - name: Upload Linux ARM binaries to release
@@ -383,7 +383,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/translator_sv2
-          asset_name: translator_sv2-arm-linux-gnueabi
+          asset_name: translator-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
           tag: ${{ github.ref }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -392,7 +392,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/translator_sv2
-          asset_name: translator_sv2-x86_64-apple-darwin
+          asset_name: translator-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
           tag: ${{ github.ref }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -401,5 +401,5 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/translator_sv2
-          asset_name: translator_sv2-aarch64-apple-darwin
+          asset_name: translator-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
           tag: ${{ github.ref }}

--- a/.github/workflows/release-bin.yaml
+++ b/.github/workflows/release-bin.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           toolchain: stable
           override: true
-  
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Compile Native
         run: cargo build --release --locked --manifest-path=roles/pool/Cargo.toml
 
@@ -49,8 +52,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/pool_sv2
-          asset_name: pool-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -58,8 +61,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/pool_sv2
-          asset_name: pool-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -67,8 +70,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/pool_sv2
-          asset_name: pool-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -76,8 +79,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/pool_sv2
-          asset_name: pool-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
-          tag: ${{ github.ref }}
+          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -85,8 +88,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/pool_sv2
-          asset_name: pool-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
   release_jdc:
     runs-on: ${{ matrix.os }}
@@ -99,9 +102,11 @@ jobs:
         with:
           toolchain: stable
           override: true
-
       - name: Compile Native
         run: cargo build --release --locked --manifest-path=roles/jd-client/Cargo.toml
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       
       - name: Install cross
         run: cargo install cross
@@ -128,8 +133,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_client
-          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -137,8 +142,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/jd_client
-          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -146,8 +151,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/jd_client
-          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
-          tag: ${{ github.ref }}
+          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -155,8 +160,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_client
-          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -164,8 +169,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/jd_client
-          asset_name: jd-client-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
   release_jds:
     runs-on: ${{ matrix.os }}
@@ -178,6 +183,9 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Compile Native
         run: cargo build --release --locked --manifest-path=roles/jd-server/Cargo.toml
@@ -207,8 +215,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_server
-          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -216,8 +224,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/jd_server
-          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload Linux ARM binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -225,8 +233,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/jd_server
-          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
-          tag: ${{ github.ref }}
+          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -234,8 +242,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_server
-          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -243,8 +251,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/jd_server
-          asset_name: jd-server-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
   release_proxy:
     runs-on: ${{ matrix.os }}
@@ -257,6 +265,9 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Compile Native
         run: cargo build --release --locked --manifest-path=roles/mining-proxy/Cargo.toml
@@ -286,8 +297,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/mining_proxy_sv2
-          asset_name: mining_proxy_sv2-x86_64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -295,8 +306,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -304,8 +315,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
-          tag: ${{ github.ref }}
+          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -313,8 +324,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -322,8 +333,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
   release_translator:
     runs-on: ${{ matrix.os }}
@@ -336,6 +347,9 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Compile Native
         run: cargo build --release --locked --manifest-path=roles/translator/Cargo.toml
@@ -365,8 +379,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/translator_sv2
-          asset_name: translator-sri-v${{ env.GIT_TAG }}-x86_64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
              
       - name: Upload Linux aarch64 binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -374,8 +388,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/translator_sv2
-          asset_name: translator-sri-v${{ env.GIT_TAG }}-aarch64-linux-gnu
-          tag: ${{ github.ref }}
+          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
         if: matrix.os == 'ubuntu-20.04'
@@ -383,8 +397,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/translator_sv2
-          asset_name: translator-sri-v${{ env.GIT_TAG }}-arm-linux-gnueabi
-          tag: ${{ github.ref }}
+          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -392,8 +406,8 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/translator_sv2
-          asset_name: translator-sri-v${{ env.GIT_TAG }}-x86_64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
         if: matrix.os == 'macos-latest'
@@ -401,5 +415,5 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/translator_sv2
-          asset_name: translator-sri-v${{ env.GIT_TAG }}-aarch64-apple-darwin
-          tag: ${{ github.ref }}
+          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          tag: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release-bin.yaml
+++ b/.github/workflows/release-bin.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/pool_sv2
-          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          asset_name: pool-sv2-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -61,7 +61,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/pool_sv2
-          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          asset_name: pool-sv2-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
@@ -70,7 +70,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/pool_sv2
-          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          asset_name: pool-sv2-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
@@ -79,7 +79,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/pool_sv2
-          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          asset_name: pool-sv2-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -88,7 +88,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/pool_sv2
-          asset_name: pool-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          asset_name: pool-sv2-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
   release_jdc:
@@ -133,7 +133,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_client
-          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          asset_name: jd-client-sv2-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
@@ -142,7 +142,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/jd_client
-          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          asset_name: jd-client-sv2-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
@@ -151,7 +151,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/jd_client
-          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          asset_name: jd-client-sv2-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -160,7 +160,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_client
-          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          asset_name: jd-client-sv2-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -169,7 +169,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/jd_client
-          asset_name: jd-client-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          asset_name: jd-client-sv2-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
   release_jds:
@@ -215,7 +215,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_server
-          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          asset_name: jd-server-sv2-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
@@ -224,7 +224,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/jd_server
-          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          asset_name: jd-server-sv2-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload Linux ARM binaries to release
@@ -233,7 +233,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/jd_server
-          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          asset_name: jd-server-sv2-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -242,7 +242,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/jd_server
-          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          asset_name: jd-server-sv2-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -251,7 +251,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/jd_server
-          asset_name: jd-server-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          asset_name: jd-server-sv2-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
   release_proxy:
@@ -297,7 +297,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          asset_name: mining-proxy-sv2-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux aarch64 binaries to release
@@ -306,7 +306,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          asset_name: mining-proxy-sv2-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
@@ -315,7 +315,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          asset_name: mining-proxy-sv2-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -324,7 +324,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          asset_name: mining-proxy-sv2-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -333,7 +333,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/mining_proxy_sv2
-          asset_name: mining-proxy-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          asset_name: mining-proxy-sv2-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
   release_translator:
@@ -379,7 +379,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/translator_sv2
-          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
+          asset_name: translator-sv2-${{ env.RELEASE_VERSION }}-x86_64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
              
       - name: Upload Linux aarch64 binaries to release
@@ -388,7 +388,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-unknown-linux-gnu/release/translator_sv2
-          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
+          asset_name: translator-sv2-${{ env.RELEASE_VERSION }}-aarch64-linux-gnu
           tag: ${{ env.RELEASE_VERSION }}
           
       - name: Upload Linux ARM binaries to release
@@ -397,7 +397,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/arm-unknown-linux-gnueabi/release/translator_sv2
-          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
+          asset_name: translator-sv2-${{ env.RELEASE_VERSION }}-arm-linux-gnueabi
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS x86-64 binaries to release
@@ -406,7 +406,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/release/translator_sv2
-          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
+          asset_name: translator-sv2-${{ env.RELEASE_VERSION }}-x86_64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}
 
       - name: Upload MacOS ARM64 binaries to release
@@ -415,5 +415,5 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: roles/target/aarch64-apple-darwin/release/translator_sv2
-          asset_name: translator-sri-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
+          asset_name: translator-sv2-${{ env.RELEASE_VERSION }}-aarch64-apple-darwin
           tag: ${{ env.RELEASE_VERSION }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,6 +52,13 @@ Bugs are patched into separate branches that only live in the contributor's fork
 - merge back into: `dev`
 - naming convention: `patch-x`, where `x` describes the bug/patch
 
+## Release Branches
+
+Every new release, a branch is created.
+
+- branch off from: `main`
+- naming convention: `vMAJOR.MINOR.PATCH`
+
 # Releasing Roles Binaries
 
 The [release page of SRI repo](https://github.com/stratum-mining/stratum/releases) provides executable binaries for all SRI roles, targeting popular hardware architectures.
@@ -59,6 +66,8 @@ The [release page of SRI repo](https://github.com/stratum-mining/stratum/release
 The GitHub binary releases of the roles are handled in the `release-bin.yaml` workflow.
 
 This workflow is manually started by navigating to the "Actions" tab in the SRI repo, then navigating to the Release workflow section, and clicking "Run Workflow".
+
+Every time the workflow is manually triggered, the correct release branch must be chosen.
 
 Note: in order to be able to manually trigger the "Run Workflow" button, the user needs to have "Write" permissions on the repository, otherwise the button will not show up on the UI.
 


### PR DESCRIPTION
I was trying to release the binary executables and I noticed there was a naming clash with the previous release.

https://github.com/stratum-mining/stratum/actions/runs/9258045890/job/25467603017#step:13:46

This PR is adjusting the `Release Bin` CI Job so that each output executable has the Global Release version as a substring.

That way, there will be no name clashing in the future.

It starts from the assumption that the `Release Bin` Job was triggered from a branch named `vMAJOR.MINOR.PATCH`, which is highlighted on the changes to `RELEASE.md`