### PR TITLE
update deprecated Node.js 16 

### DIFF
--- a/.github/workflows/clippy-lint.yaml
+++ b/.github/workflows/clippy-lint.yaml
@@ -25,7 +25,7 @@ jobs:
             target: x86_64-unknown-linux-musl
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -25,7 +25,7 @@ jobs:
             target: x86_64-unknown-linux-musl
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/run-and-track-benchmarks-on-main.yaml
+++ b/.github/workflows/run-and-track-benchmarks-on-main.yaml
@@ -76,7 +76,7 @@ jobs:
           toolchain: 1.75.0
           override: true
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Valgrind
         run: |
             sudo apt-get update

--- a/.github/workflows/sv2-header-check.yaml
+++ b/.github/workflows/sv2-header-check.yaml
@@ -19,7 +19,7 @@ jobs:
             target: x86_64-unknown-linux-musl
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
 
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Install stable toolchain & components
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           profile: minimal
           toolchain: nightly


### PR DESCRIPTION
This PR is addressing Node.js deprecation in Github Action workflow as shown below:
<img width="1043" alt="Screenshot 2024-05-30 at 21 52 46" src="https://github.com/stratum-mining/stratum/assets/15778219/8e739153-7661-4096-85fe-d1c3d90667da">
