### PR TITLE
Log Bitcoin target as hex, align targets

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -826,14 +826,17 @@ impl ChannelFactory {
         if tracing::level_enabled!(tracing::Level::DEBUG)
             || tracing::level_enabled!(tracing::Level::TRACE)
         {
-            debug!("Bitcoin target: {:?}", bitcoin_target);
+            let bitcoin_target_log: binary_sv2::U256 = bitcoin_target.clone().into();
+            let mut bitcoin_target_log = bitcoin_target_log.to_vec();
+            bitcoin_target_log.reverse();
+            debug!("Bitcoin target : {:?}", bitcoin_target_log.to_hex());
             let upstream_target: binary_sv2::U256 = upstream_target.clone().into();
             let mut upstream_target = upstream_target.to_vec();
             upstream_target.reverse();
             debug!("Upstream target: {:?}", upstream_target.to_vec().to_hex());
             let mut hash = hash;
             hash.reverse();
-            debug!("Hash: {:?}", hash.to_vec().to_hex());
+            debug!("Hash           : {:?}", hash.to_vec().to_hex());
         }
         let hash: Target = hash.into();
 


### PR DESCRIPTION
Make it easier to compare:

* Bitcoin target
* upstream target (if any)
* hash

The Bitcoin target was previously rendered as `{ head: 0, tail: ... }`, render it as hex instead.

Add spaces to align all three.

Before:

```
2024-06-07T18:01:37.745967Z DEBUG roles_logic_sv2::handlers::mining: Received SubmitSharesExtended message
2024-06-07T18:01:37.745979Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Checking target for share Extended(SubmitSharesExtended { channel_id: 1, sequence_number: 0, job_id: 1, nonce: 2355753102, ntime: 1717783221, version: 757661696, extranonce: Owned([0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]) })
2024-06-07T18:01:37.746007Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Bitcoin target: Target { head: 0, tail: 2409966232598499819520 }
2024-06-07T18:01:37.746013Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Upstream target: "0000000000000000000000000000000000000000000000000000000000000000"
2024-06-07T18:01:37.746020Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Hash: "0000000000100d4e3ed6db809dc40125d673486ffc6fc28c2210bad04c660eb9"
```

After:

```
2024-06-07T18:50:31.163609Z DEBUG roles_logic_sv2::handlers::mining: Received SubmitSharesExtended message
2024-06-07T18:50:31.163620Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Checking target for share Extended(SubmitSharesExtended { channel_id: 1, sequence_number: 0, job_id: 23, nonce: 39263235, ntime: 1717786207, version: 977739776, extranonce: Owned([0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]) })
2024-06-07T18:50:31.163648Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Bitcoin target : "0000000000000082a50000000000000000000000000000000000000000000000"
2024-06-07T18:50:31.163654Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Upstream target: "0000000000000000000000000000000000000000000000000000000000000000"
2024-06-07T18:50:31.163658Z DEBUG roles_logic_sv2::channel_logic::channel_factory: Hash           : "0000000000039c94e6f71a73861bb797c4343f550863f3b512c52670ca3b93cb"
```

The Rust code could probably be made prettier...