### PR TITLE
Add missing doc comments for subprotocols messages

### DIFF
--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -389,8 +389,11 @@ name = "job_declaration_sv2"
 version = "1.0.0"
 dependencies = [
  "binary_sv2",
+ "common_messages_sv2",
  "const_sv2",
+ "mining_sv2",
  "serde",
+ "template_distribution_sv2",
 ]
 
 [[package]]
@@ -416,6 +419,7 @@ name = "mining_sv2"
 version = "1.0.0"
 dependencies = [
  "binary_sv2",
+ "common_messages_sv2",
  "const_sv2",
  "quickcheck",
  "quickcheck_macros",
@@ -800,6 +804,7 @@ version = "1.0.0"
 dependencies = [
  "binary_sv2",
  "const_sv2",
+ "mining_sv2",
  "quickcheck",
  "quickcheck_macros",
  "serde",

--- a/protocols/v2/subprotocols/common-messages/src/channel_endpoint_changed.rs
+++ b/protocols/v2/subprotocols/common-messages/src/channel_endpoint_changed.rs
@@ -6,13 +6,11 @@ use binary_sv2::{Deserialize, Serialize};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## ChannelEndpointChanged (Server -> Client)
 /// When a channel’s upstream or downstream endpoint changes and that channel had previously
 /// sent messages with [channel_msg] bitset of unknown extension_type, the intermediate proxy
 /// MUST send a [`ChannelEndpointChanged`] message. Upon receipt thereof, any extension state
 /// (including version negotiation and the presence of support for a given extension) MUST be
 /// reset and version/presence negotiation must begin again.
-///
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ChannelEndpointChanged {

--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -16,7 +16,6 @@ use core::convert::TryInto;
 #[cfg(feature = "with_serde")]
 use serde_repr::*;
 
-/// ## SetupConnection (Client -> Server)
 /// Initiates the connection. This MUST be the first message sent by the client on the newly
 /// opened connection. Server MUST respond with either a [`SetupConnectionSuccess`] or
 /// [`SetupConnectionError`] message. Clients that are not configured to provide telemetry data to
@@ -24,7 +23,6 @@ use serde_repr::*;
 /// vendor to a string describing the manufacturer/developer and firmware version and SHOULD
 /// always set hardware_version to a string describing, at least, the particular hardware/software
 /// package in use.
-///
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetupConnection<'decoder> {
     /// [`Protocol`]
@@ -198,7 +196,6 @@ impl<'a> From<SetupConnection<'a>> for CSetupConnection {
     }
 }
 
-/// ## SetupConnection.Success (Server -> Client)
 /// Response to [`SetupConnection`] message if the server accepts the connection. The client is
 /// required to verify the set of feature flags that the server supports and act accordingly.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Copy)]
@@ -213,7 +210,6 @@ pub struct SetupConnectionSuccess {
     pub flags: u32,
 }
 
-/// ## SetupConnection.Error (Server -> Client)
 /// When protocol version negotiation fails (or there is another reason why the upstream node
 /// cannot setup the connection) the server sends this message with a particular error code prior
 /// to closing the connection.

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/stratum-mining/stratum"
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/binary-sv2" }
 const_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
+mining_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/subprotocols/mining"}
+common_messages_sv2 = { version = "^1.0.0", path = "../../../../protocols/v2/subprotocols/common-messages"}
+template_distribution_sv2 = { version = "^1.0.0", path = "../../../../protocols/v2/subprotocols/template-distribution"}
 
 [features]
 with_serde = ["binary_sv2/with_serde", "serde"]

--- a/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
@@ -6,21 +6,32 @@ use binary_sv2::{Deserialize, Serialize, Str0255, B0255, B064K};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## AllocateMiningJobToken (Client -> Server)
+#[cfg(doc)]
+use crate::{DeclareMiningJob, DeclareMiningJobSuccess};
+#[cfg(doc)]
+use common_messages_sv2::SetupConnection;
+#[cfg(doc)]
+use mining_sv2::SetCustomMiningJob;
+#[cfg(doc)]
+use template_distribution_sv2::CoinbaseOutputDataSize;
+
 /// A request to get an identifier for a future-submitted mining job.
 /// Rate limited to a rather slow rate and only available on connections where this has been
-/// negotiated. Otherwise, only `mining_job_token(s)` from `CreateMiningJob.Success` are valid.
+/// negotiated. Otherwise, only `mining_job_token(s)` from [`AllocateMiningJobTokenSuccess`] are valid.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct AllocateMiningJobToken<'decoder> {
+    /// Unconstrained sequence of bytes. Whatever is needed by the pool to identify/authenticate
+    /// the client, e.g. "braiinstest". Additional restrictions can be imposed by the pool. It is
+    /// highly recommended that UTF-8 encoding is used.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub user_identifier: Str0255<'decoder>,
+    /// Unique identifier for pairing the response
     pub request_id: u32,
 }
 
-/// ## AllocateMiningJobTokenSuccess (Server -> Clien)
 /// The Server MUST NOT change the value of `coinbase_output_max_additional_size` in
-/// `AllocateMiningJobToken.Success` messages unless required for changes to the pool’
+/// [`AllocateMiningJobTokenSuccess`] messages unless required for changes to the pool’
 /// configuration.
 /// Notably, if the pool intends to change the space it requires for coinbase transaction outputs
 /// regularly, it should simply prefer to use the maximum of all such output sizes as the
@@ -28,12 +39,24 @@ pub struct AllocateMiningJobToken<'decoder> {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct AllocateMiningJobTokenSuccess<'decoder> {
+    /// Unique identifier for pairing the response
     pub request_id: u32,
+    /// Token that makes the client eligible for committing a mining job for approval/transaction
+    /// declaration or for identifying custom mining job on mining connection.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub mining_job_token: B0255<'decoder>,
+    /// The maximum additional serialized bytes which the pool will add in coinbase transaction
+    /// outputs. See discussion in the Template Distribution Protocol's
+    /// [`CoinbaseOutputDataSize`] message for more details.
     pub coinbase_output_max_additional_size: u32,
     #[cfg_attr(feature = "with_serde", serde(borrow))]
+    /// Bitcoin transaction outputs added by the pool
     pub coinbase_output: B064K<'decoder>,
+    /// If true, the [`mining_job_token`](#structfield.mining_job_token) can be used immediately on a mining connection in the
+    /// [`SetCustomMiningJob`] message, even before [`DeclareMiningJob`] and [`DeclareMiningJobSuccess`]
+    /// messages have been sent and received. If false, Job Declarator MUST use this token for
+    /// [`DeclareMiningJob`] only.
+    /// This MUST be true when [`SetupConnection`] flags had REQUIRES_ASYNC_JOB_MINING set.
     pub async_mining_allowed: bool,
 }
 

--- a/protocols/v2/subprotocols/job-declaration/src/declare_mining_job.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/declare_mining_job.rs
@@ -6,44 +6,70 @@ use binary_sv2::{Deserialize, Seq064K, Serialize, ShortTxId, Str0255, B0255, B06
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## DeclareMiningJob (Client -> Server)
+#[cfg(doc)]
+use crate::AllocateMiningJobTokenSuccess;
+
 /// A request sent by the Job Declarator that proposes a selected set of transactions to the upstream (pool) node.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct DeclareMiningJob<'decoder> {
+    /// Unique identifier for pairing the response
     pub request_id: u32,
+    /// Previously reserved mining job token received by [`AllocateMiningJobTokenSuccess`]
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub mining_job_token: B0255<'decoder>,
+    /// Version header field. To be later modified by BIP320-consistent changes.
     pub version: u32,
+    /// The coinbase transaction nVersion field
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub coinbase_prefix: B064K<'decoder>,
+    /// Up to 8 bytes (not including the length byte) which are to be placed at the beginning of the coinbase
+    /// field in the coinbase transaction
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub coinbase_suffix: B064K<'decoder>,
+    /// A unique nonce used to ensure tx_short_hash collisions are uncorrelated across the network
     pub tx_short_hash_nonce: u64,
+    /// Sequence of SHORT_TX_IDs. Inputs to the SipHash functions are transaction hashes from the mempool.
+    /// Secret keys k0, k1 are derived from the first two little-endian 64-bit integers from the
+    /// SHA256(tx_short_hash_nonce), respectively (see bip-0152 for more information). Upstream node
+    /// checks the list against its mempool. Does not include the coinbase transaction (as there is
+    /// no corresponding full data for it yet).
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub tx_short_hash_list: Seq064K<'decoder, ShortTxId<'decoder>>,
+    /// Hash of the full sequence of SHA256(transaction_data) contained in the transaction_hash_list
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub tx_hash_list_hash: U256<'decoder>,
+    /// Extra data which the Pool may require to validate the work (as defined in the Template Distribution Protocol)
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub excess_data: B064K<'decoder>,
 }
 
-/// ## DeclareMiningJobSuccess (Server -> Client)
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct DeclareMiningJobSuccess<'decoder> {
+    /// Identifier of the original request
     pub request_id: u32,
+    /// Unique identifier provided by the pool of the job that the Job Declarator has declared with the pool.
+    /// It MAY be the same token as [`DeclareMiningJob`]::mining_job_token if the pool allows to start mining on
+    /// not yet declared job. If the token is different from the one in the corresponding [`DeclareMiningJob`]
+    /// message (irrespective of if the client is already mining using the original token), the client MUST
+    /// send a [`SetCustomMiningJob`] message on each Mining Protocol client which wishes to mine using the declared job.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub new_mining_job_token: B0255<'decoder>,
 }
 
-/// ## DeclareMiningJobError (Server -> Client)
+/// Possible error codes values:
+/// - `invalid-mining-job-token`
+/// - `invalid-job-param-value-{}` - {} is replaced by a particular field name from DeclareMiningJob message
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct DeclareMiningJobError<'decoder> {
+    /// Identifier of the original request
     pub request_id: u32,
+    /// Human-readable error code(s).
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub error_code: Str0255<'decoder>,
+    /// Optional data providing further details to given error
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub error_details: B064K<'decoder>,
 }

--- a/protocols/v2/subprotocols/job-declaration/src/identify_transactions.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/identify_transactions.rs
@@ -6,18 +6,25 @@ use binary_sv2::{Deserialize, Seq064K, Serialize, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// TODO: comment
+#[cfg(doc)]
+use crate::DeclareMiningJob;
+
+/// Sent by the Server in response to a [`DeclareMiningJob`] message indicating it detected a
+/// collision in the `tx_short_hash_list`, or was unable to reconstruct the `tx_hash_list_hash`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct IdentifyTransactions {
+    /// Unique identifier for the pairing response to the [`DeclareMiningJob`] message
     pub request_id: u32,
 }
 
-/// TODO: comment
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct IdentifyTransactionsSuccess<'decoder> {
+    /// Unique identifier for the pairing response to the [`DeclareMiningJob`]/[`IdentifyTransactions`] message
     pub request_id: u32,
+    /// The full list of transaction data hashes used to build the mining job in the
+    /// corresponding [`DeclareMiningJob`] message
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub tx_data_hashes: Seq064K<'decoder, U256<'decoder>>,
 }

--- a/protocols/v2/subprotocols/job-declaration/src/provide_missing_transactions.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/provide_missing_transactions.rs
@@ -10,22 +10,31 @@ use core::convert::TryInto;
 // block template. These transactions are provided by the JDclient to the JDserver as a sequence
 // of short hashes (in the message DeclareMiningJob). The JDserver has a mempool, which uses to identify the transactions from this
 // list. If there is some transaction that it is not in the JDserver memppol, the JDserver sends
-// this message to ask for them. They are specified by their position in the original DeclareMiningJob message, 0-indexed not including the coinbase transaction transaction.
-
+// this message to ask for them. They are specified by their position in the original DeclareMiningJob
+// message, 0-indexed not including the coinbase transaction transaction.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct ProvideMissingTransactions<'decoder> {
+    /// Identifier of the original CreateMiningJob request
     pub request_id: u32,
+    /// A list of unrecognized transactions that need to be supplied by the Job Declarator in full.
+    /// They are specified by their position in the original DeclareMiningJob message, 0-indexed
+    /// not including the coinbase transaction transaction.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub unknown_tx_position_list: Seq064K<'decoder, u16>,
 }
 
 // List of full transactions as requested by ProvideMissingTransactions, in the order they were requested in ProvideMissingTransactions
 
+/// This is a message to push transactions that the server did not recognize and requested them to
+/// be supplied in [`ProvideMissingTransactions`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct ProvideMissingTransactionsSuccess<'decoder> {
+    /// Identifier of the original CreateMiningJob request
     pub request_id: u32,
+    /// List of full transactions as requested by [`ProvideMissingTransactions`], in the order they were
+    /// requested in [`ProvideMissingTransactions`]
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub transaction_list: Seq064K<'decoder, B016M<'decoder>>,
 }

--- a/protocols/v2/subprotocols/job-declaration/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/submit_solution.rs
@@ -6,17 +6,23 @@ use binary_sv2::{Deserialize, Serialize, B032, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// TODO: comment
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct SubmitSolutionJd<'decoder> {
+    /// Extranonce bytes which need to be added to coinbase to form a fully valid submission.
+    /// (This is the full extranonce)
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub extranonce: B032<'decoder>,
+    /// Hash of the last block
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub prev_hash: U256<'decoder>,
+    /// The nTime field in the block header.
     pub ntime: u32,
+    /// Nonce leading to the hash being submitted
     pub nonce: u32,
+    /// Block header field
     pub nbits: u32,
+    /// Header version field      
     pub version: u32,
 }
 

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/stratum-mining/stratum"
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/binary-sv2" }
 const_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
+common_messages_sv2 = { version = "^1.0.0", path = "../../../../protocols/v2/subprotocols/common-messages"}
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/subprotocols/mining/src/close_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/close_channel.rs
@@ -6,15 +6,16 @@ use binary_sv2::{Deserialize, Serialize, Str0255};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # CloseChannel (Client -> Server, Server -> Client)
-///
+#[cfg(doc)]
+use crate::UpdateChannel;
+
 /// Client sends this message when it ends its operation. The server MUST stop sending messages
 /// for the channel. A proxy MUST send this message on behalf of all opened channels from a
 /// downstream connection in case of downstream connection closure.
 ///
 /// If a proxy is operating in channel aggregating mode (translating downstream channels into
-/// aggregated extended upstream channels), it MUST send an UpdateChannel message when it
-/// receives CloseChannel or connection closure from a downstream connection. In general, proxy
+/// aggregated extended upstream channels), it MUST send an [`UpdateChannel`] message when it
+/// receives [`CloseChannel`] or connection closure from a downstream connection. In general, proxy
 /// servers MUST keep the upstream node notified about the real state of the downstream
 /// channels.
 ///

--- a/protocols/v2/subprotocols/mining/src/new_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/new_mining_job.rs
@@ -6,11 +6,18 @@ use binary_sv2::{Deserialize, Seq0255, Serialize, Sv2Option, B032, B064K, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # NewMiningJob (Server -> Client)
-///
-/// The server provides an updated mining job to the client through a standard channel. This MUST be the first message after the channel has been successfully opened. This first message will have min_ntime unset (future job).
-/// If the `min_ntime` field is set, the client MUST start to mine on the new job immediately after receiving this message, and use the value for the initial nTime.
+#[cfg(doc)]
+use crate::OpenExtendedMiningChannelSuccess;
+#[cfg(doc)]
+use crate::SetNewPrevHash;
+#[cfg(doc)]
+use common_messages_sv2::SetupConnection;
 
+/// The server provides an updated mining job to the client through a standard channel.
+/// This MUST be the first message after the channel has been successfully opened.
+/// This first message will have [`min_ntime`](#structfield.min_ntime) unset (future job).
+/// If the [`min_ntime`](#structfield.min_ntime) field is set, the client MUST start to mine
+/// on the new job immediately after receiving this message, and use the value for the initial nTime.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct NewMiningJob<'decoder> {
@@ -20,10 +27,10 @@ pub struct NewMiningJob<'decoder> {
     /// to the server when shares are submitted later in the mining process.
     pub job_id: u32,
     /// Smallest nTime value available for hashing for the new mining job. An empty value indicates
-    /// this is a future job to be activated once a SetNewPrevHash message is received with a
-    /// matching job_id. This SetNewPrevHash message provides the new prev_hash and min_ntime.
-    /// If the min_ntime value is set, this mining job is active and miner must start mining on it
-    /// immediately. In this case, the new mining job uses the prev_hash from the last received SetNewPrevHash message.
+    /// this is a future job to be activated once a [`SetNewPrevHash`] message is received with a
+    /// matching job_id. This [`SetNewPrevHash`] message provides the new `prev_hash` and [`min_ntime`](#structfield.min_ntime).
+    /// If the [`min_ntime`](#structfield.min_ntime) value is set, this mining job is active and miner must start mining on it
+    /// immediately. In this case, the new mining job uses the `prev_hash` from the last received [`SetNewPrevHash`] message.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub min_ntime: Sv2Option<'decoder, u32>,
     /// Valid version field that reflects the current network consensus. The
@@ -48,21 +55,19 @@ impl<'d> NewMiningJob<'d> {
     }
 }
 
-/// NewExtendedMiningJob (Server -> Client)
-///
 /// (Extended and group channels only)
 /// For an *extended channel*: The whole search space of the job is owned by the specified
-/// channel. If the future_job field is set to *False,* the client MUST start to mine on the new job as
+/// channel. If the `future_job` field is set to *False,* the client MUST start to mine on the new job as
 /// soon as possible after receiving this message.
-/// For a *group channel*: This is a broadcast variant of NewMiningJob message with the
-/// merkle_root field replaced by merkle_path and coinbase TX prefix and suffix, for further traffic
+/// For a *group channel*: This is a broadcast variant of [`NewMiningJob`] message with the
+/// `merkle_root` field replaced by `merkle_path` and coinbase TX prefix and suffix, for further traffic
 /// optimization. The Merkle root is then defined deterministically for each channel by the
-/// common merkle_path and unique extranonce_prefix serialized into the coinbase. The full
-/// coinbase is then constructed as follows: *coinbase_tx_prefix* + *extranonce_prefix* + *coinbase_tx_suffix*.
+/// common `merkle_path` and unique `extranonce_prefix` serialized into the coinbase. The full
+/// coinbase is then constructed as follows: `coinbase_tx_prefix` + `extranonce_prefix` + `coinbase_tx_suffix`.
 /// The proxy MAY transform this multicast variant for downstream standard channels into
-/// NewMiningJob messages by computing the derived Merkle root for them. A proxy MUST
+/// [`NewMiningJob`] messages by computing the derived Merkle root for them. A proxy MUST
 /// translate the message for all downstream channels belonging to the group which don’t signal
-/// that they accept extended mining jobs in the SetupConnection message (intended and
+/// that they accept extended mining jobs in the [`SetupConnection`] message (intended and
 /// expected behaviour for end mining devices).
 ///
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -74,10 +79,11 @@ pub struct NewExtendedMiningJob<'decoder> {
     /// Server’s identification of the mining job.
     pub job_id: u32,
     /// Smallest nTime value available for hashing for the new mining job. An empty value indicates
-    /// this is a future job to be activated once a SetNewPrevHash message is received with a
-    /// matching job_id. This SetNewPrevHash message provides the new prev_hash and min_ntime.
-    /// If the min_ntime value is set, this mining job is active and miner must start mining on it
-    /// immediately. In this case, the new mining job uses the prev_hash from the last received SetNewPrevHash message.
+    /// this is a future job to be activated once a [`SetNewPrevHash`] message is received with a
+    /// matching `job_id`. This [`SetNewPrevHash`] message provides the new `prev_hash` and `min_ntime`.
+    /// If the `min_ntime` value is set, this mining job is active and miner must start mining on it
+    /// immediately. In this case, the new mining job uses the `prev_hash` from the last received
+    /// [`SetNewPrevHash`] message.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub min_ntime: Sv2Option<'decoder, u32>,
     /// Valid version field that reflects the current network consensus.
@@ -94,9 +100,9 @@ pub struct NewExtendedMiningJob<'decoder> {
     pub merkle_path: Seq0255<'decoder, U256<'decoder>>,
     /// Prefix part of the coinbase transaction.
     /// The full coinbase is constructed by inserting one of the following:
-    /// * For a *standard channel*: extranonce_prefix
-    /// * For an *extended channel*: extranonce_prefix + extranonce (=N bytes), where N is the
-    ///   negotiated extranonce space for the channel (OpenMiningChannel.Success.extranonce_size)
+    /// * For a *standard channel*: `extranonce_prefix`
+    /// * For an *extended channel*: `extranonce_prefix` + `extranonce`j (=N bytes), where N is the
+    ///   negotiated extranonce space for the channel [`OpenExtendedMiningChannelSuccess`].extranonce_size)
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub coinbase_tx_prefix: B064K<'decoder>,
     #[cfg_attr(feature = "with_serde", serde(borrow))]

--- a/protocols/v2/subprotocols/mining/src/open_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/open_channel.rs
@@ -9,9 +9,13 @@ use core::convert::TryInto;
 #[cfg(feature = "with_serde")]
 use core::convert::TryInto;
 
-/// # OpenStandardMiningChannel (Client -> Server)
+#[cfg(doc)]
+use crate::NewExtendedMiningJob;
+#[cfg(doc)]
+use common_messages_sv2::SetupConnectionSuccess;
+
 /// This message requests to open a standard channel to the upstream node.
-/// After receiving a SetupConnection.Success message, the client SHOULD respond by opening
+/// After receiving a [`SetupConnectionSuccess`] message, the client SHOULD respond by opening
 /// channels on the connection. If no channels are opened within a reasonable period the server
 /// SHOULD close the connection for inactivity.
 /// Every client SHOULD start its communication with an upstream node by opening a channel,
@@ -43,7 +47,7 @@ pub struct OpenStandardMiningChannel<'decoder> {
     pub nominal_hash_rate: f32,
     /// Maximum target which can be accepted by the connected device or
     /// devices. Server MUST accept the target or respond by sending
-    /// OpenMiningChannel.Error message.
+    /// [`OpenMiningChannelError`] message.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub max_target: U256<'decoder>,
 }
@@ -77,20 +81,18 @@ impl<'decoder> OpenStandardMiningChannel<'decoder> {
     }
 }
 
-/// # OpenStandardMiningChannel.Success (Server -> Client)
 /// Sent as a response for opening a standard channel, if successful.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct OpenStandardMiningChannelSuccess<'decoder> {
-    /// Client-specified request ID from OpenStandardMiningChannel message,
+    /// Client-specified request ID from [`OpenStandardMiningChannel`] message,
     /// so that the client can pair responses with open channel requests.
     #[cfg(not(feature = "with_serde"))]
     pub request_id: U32AsRef<'decoder>,
     #[cfg(feature = "with_serde")]
     pub request_id: u32,
     /// Newly assigned identifier of the channel, stable for the whole lifetime of
-    /// the connection. E.g. it is used for broadcasting new jobs by
-    /// NewExtendedMiningJob.
+    /// the connection. E.g. it is used for broadcasting new jobs by [`NewExtendedMiningJob`].
     pub channel_id: u32,
     /// Initial target for the mining channel.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
@@ -134,9 +136,8 @@ impl<'decoder> OpenStandardMiningChannelSuccess<'decoder> {
     }
 }
 
-/// # OpenExtendedMiningChannel (Client -> Server)
-/// Similar to *OpenStandardMiningChannel* but requests to open an extended channel instead of
-/// standard channel.
+/// Similar to [`OpenStandardMiningChannel`] but requests to open an extended channel
+/// instead of standard channel.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct OpenExtendedMiningChannel<'decoder> {
     /// Client-specified identifier for matching responses from upstream server.
@@ -157,10 +158,10 @@ pub struct OpenExtendedMiningChannel<'decoder> {
     pub nominal_hash_rate: f32,
     /// Maximum target which can be accepted by the connected device or
     /// devices. Server MUST accept the target or respond by sending
-    /// OpenMiningChannel.Error message.
+    /// [`OpenMiningChannelError`] message.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub max_target: U256<'decoder>,
-    /// Minimum size of extranonce needed by the device/node.
+    /// Minimum size (in bytes) of extranonce needed by the device/node.
     pub min_extranonce_size: u16,
 }
 impl<'decoder> OpenExtendedMiningChannel<'decoder> {
@@ -169,16 +170,15 @@ impl<'decoder> OpenExtendedMiningChannel<'decoder> {
     }
 }
 
-/// # OpenExtendedMiningChannel.Success (Server -> Client)
 /// Sent as a response for opening an extended channel.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct OpenExtendedMiningChannelSuccess<'decoder> {
-    /// Client-specified request ID from OpenStandardMiningChannel message,
+    /// Client-specified request ID from [`OpenStandardMiningChannel`] message,
     /// so that the client can pair responses with open channel requests.
     pub request_id: u32,
     /// Newly assigned identifier of the channel, stable for the whole lifetime of
     /// the connection. E.g. it is used for broadcasting new jobs by
-    /// NewExtendedMiningJob.
+    /// [`NewExtendedMiningJob`].
     pub channel_id: u32,
     /// Initial target for the mining channel.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
@@ -190,10 +190,9 @@ pub struct OpenExtendedMiningChannelSuccess<'decoder> {
     pub extranonce_prefix: B032<'decoder>,
 }
 
-/// # OpenMiningChannel.Error (Server -> Client)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OpenMiningChannelError<'decoder> {
-    /// Client-specified request ID from OpenMiningChannel message.
+    /// Client-specified request ID from [`OpenStandardMiningChannel`] or [`OpenExtendedMiningChannel`] message.
     pub request_id: u32,
     /// Human-readable error code(s).
     /// Possible error codes:

--- a/protocols/v2/subprotocols/mining/src/reconnect.rs
+++ b/protocols/v2/subprotocols/mining/src/reconnect.rs
@@ -6,8 +6,6 @@ use binary_sv2::{Deserialize, Serialize, Str0255};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # Reconnect (Server -> Client)
-///
 /// This message allows clients to be redirected to a new upstream node.
 ///
 /// This message is connection-related so that it should not be propagated downstream by
@@ -22,8 +20,7 @@ use core::convert::TryInto;
 /// instructed to send reconnects to a new location.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Reconnect<'decoder> {
-    /// When empty, downstream node attempts to reconnect to its present
-    /// host.
+    /// When empty, downstream node attempts to reconnect to its present host.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub new_host: Str0255<'decoder>,
     /// When 0, downstream node attempts to reconnect to its present port.

--- a/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
@@ -6,14 +6,14 @@ use binary_sv2::{Deserialize, Seq0255, Serialize, Str0255, B0255, B064K, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # SetCustomMiningJob (Client -> Server)
-///
-/// Can be sent only on extended channel. SetupConnection.flags MUST contain
+#[cfg(doc)]
+use common_messages_sv2::SetupConnection;
+
+/// Can be sent only on extended channel. [`SetupConnection`].flags MUST contain
 /// *REQUIRES_WORK_SELECTION* flag (work selection feature successfully negotiated).
 /// The downstream node has a custom job negotiated by a trusted external Job Declarator. The
-/// mining_job_token provides the information for the pool to authorize the custom job that has
+/// `mining_job_token` provides the information for the pool to authorize the custom job that has
 /// been or will be negotiated between the Job Declarator and Pool.
-///
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetCustomMiningJob<'decoder> {
     /// Extended channel identifier.
@@ -58,11 +58,8 @@ pub struct SetCustomMiningJob<'decoder> {
     pub extranonce_size: u16,
 }
 
-/// # SetCustomMiningJob.Success (Server -> Client)
-///
 /// Response from the server when it accepts the custom mining job. Client can start to mine on
-/// the job immediately (by using the job_id provided within this response).
-///
+/// the job immediately (by using the `job_id` provided within this response).
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetCustomMiningJobSuccess {
     /// Extended channel identifier.
@@ -74,13 +71,10 @@ pub struct SetCustomMiningJobSuccess {
     pub job_id: u32,
 }
 
-/// # SetCustomMiningJob.Error (Server -> Client)
-///
 /// Possible errors:
 /// * ‘invalid-channel-id’
 /// * ‘invalid-mining-job-token’
-/// * ‘invalid-job-param-value-{}’ - {} is replaced by a particular field name from SetCustomMiningJob message
-///
+/// * ‘invalid-job-param-value-{}’ - {} is replaced by a particular field name from [`SetCustomMiningJob`] message
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetCustomMiningJobError<'decoder> {
     /// Extended channel identifier.

--- a/protocols/v2/subprotocols/mining/src/set_extranonce_prefix.rs
+++ b/protocols/v2/subprotocols/mining/src/set_extranonce_prefix.rs
@@ -6,11 +6,12 @@ use binary_sv2::{Deserialize, Serialize, B032};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # SetExtranoncePrefix (Server -> Client)
-///
+#[cfg(doc)]
+use crate::SetCustomMiningJob;
+
 /// Changes downstream node’s extranonce prefix. It is applicable for all jobs sent after this
 /// message on a given channel (both jobs provided by the upstream or jobs introduced by
-/// SetCustomMiningJob message). This message is applicable only for explicitly opened
+/// [`SetCustomMiningJob`] message). This message is applicable only for explicitly opened
 /// extended channels or standard channels (not group channels).
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetExtranoncePrefix<'decoder> {

--- a/protocols/v2/subprotocols/mining/src/set_group_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/set_group_channel.rs
@@ -6,18 +6,19 @@ use binary_sv2::{Deserialize, Seq064K, Serialize};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # SetGroupChannel (Server -> Client)
-///
+#[cfg(doc)]
+use crate::{NewExtendedMiningJob, NewMiningJob};
+
 /// Every standard channel is a member of a group of standard channels, addressed by the
 /// upstream server’s provided identifier. The group channel is used mainly for efficient job
 /// distribution to multiple standard channels at once.
 /// If we want to allow different jobs to be served to different standard channels (e.g. because of
 /// different BIP 8 version bits) and still be able to distribute the work by sending
-/// NewExtendendedMiningJob instead of a repeated NewMiningJob, we need a more
+/// [`NewExtendedMiningJob`] instead of a repeated [`NewMiningJob`], we need a more
 /// fine-grained grouping for standard channels.
 /// This message associates a set of standard channels with a group channel. A channel (identified
 /// by particular ID) becomes a group channel when it is used by this message as
-/// group_channel_id. The server MUST ensure that a group channel has a unique channel ID
+/// [`group_channel_id`](#structfield.group_channel_id). The server MUST ensure that a group channel has a unique channel ID
 /// within one connection. Channel reinterpretation is not allowed.
 /// This message can be sent only to connections that don’t have REQUIRES_STANDARD_JOBS
 /// flag in SetupConnection.

--- a/protocols/v2/subprotocols/mining/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/mining/src/set_new_prev_hash.rs
@@ -6,8 +6,6 @@ use binary_sv2::{Deserialize, Serialize, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # SetNewPrevHash (Server -> Client, broadcast)
-///
 /// Prevhash is distributed whenever a new block is detected in the network by an upstream node.
 /// This message MAY be shared by all downstream nodes (sent only once to each channel group).
 /// Clients MUST immediately start to mine on the provided prevhash. When a client receives this

--- a/protocols/v2/subprotocols/mining/src/set_target.rs
+++ b/protocols/v2/subprotocols/mining/src/set_target.rs
@@ -6,16 +6,14 @@ use binary_sv2::{Deserialize, Serialize, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # SetTarget (Server -> Client)
-///
 /// The server controls the submission rate by adjusting the difficulty target on a specified
 /// channel. All submits leading to hashes higher than the specified target will be rejected by the
 /// server.
-/// Maximum target is valid until the next *SetTarget* message is sent and is applicable for all jobs
+/// Maximum target is valid until the next [`SetTarget`] message is sent and is applicable for all jobs
 /// received on the channel in the future or already received with flag *future_job=True*. The
 /// message is not applicable for alrea
 ///
-/// When SetTarget is sent to a group channel, the maximum target is applicable to all channels in
+/// When [`SetTarget`] is sent to a group channel, the maximum target is applicable to all channels in
 /// the group.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetTarget<'decoder> {

--- a/protocols/v2/subprotocols/mining/src/submit_shares.rs
+++ b/protocols/v2/subprotocols/mining/src/submit_shares.rs
@@ -6,8 +6,9 @@ use binary_sv2::{Deserialize, Serialize, Str0255, B032};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # SubmitSharesStandard (Client -> Server)
-///
+#[cfg(doc)]
+use crate::{NewExtendedMiningJob, NewMiningJob, SetNewPrevHash};
+
 /// Client sends result of its hashing work to the server.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubmitSharesStandard {
@@ -15,21 +16,19 @@ pub struct SubmitSharesStandard {
     pub channel_id: u32,
     /// Unique sequential identifier of the submit within the channel.
     pub sequence_number: u32,
-    /// Identifier of the job as provided by *NewMiningJob* or
-    /// *NewExtendedMiningJob* message.
+    /// Identifier of the job as provided by [`NewMiningJob`] or [`NewExtendedMiningJob`] message.
     pub job_id: u32,
     /// Nonce leading to the hash being submitted.
     pub nonce: u32,
     /// The nTime field in the block header. This MUST be greater than or equal
-    /// to the header_timestamp field in the latest SetNewPrevHash message
+    /// to the `header_timestamp` field in the latest [`SetNewPrevHash`] message
     /// and lower than or equal to that value plus the number of seconds since
     /// the receipt of that message.
     pub ntime: u32,
     /// Full nVersion field.
     pub version: u32,
 }
-/// # SubmitSharesExtended (Client -> Server)
-/// Only relevant for extended channels. The message is the same as SubmitShares, with the
+/// Only relevant for extended channels. The message is the same as [`SubmitSharesStandard`], with the
 /// following additional field:
 /// * extranonce
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -38,32 +37,30 @@ pub struct SubmitSharesExtended<'decoder> {
     pub channel_id: u32,
     /// Unique sequential identifier of the submit within the channel.
     pub sequence_number: u32,
-    /// Identifier of the job as provided by *NewMiningJob* or
-    /// *NewExtendedMiningJob* message.
+    /// Identifier of the job as provided by [`NewMiningJob`] or
+    /// [`NewExtendedMiningJob`] message.
     pub job_id: u32,
     /// Nonce leading to the hash being submitted.
     pub nonce: u32,
     /// The nTime field in the block header. This MUST be greater than or equal
-    /// to the header_timestamp field in the latest SetNewPrevHash message
+    /// to the `header_timestamp` field in the latest [`SetNewPrevHash`] message
     /// and lower than or equal to that value plus the number of seconds since
     /// the receipt of that message.
     pub ntime: u32,
     /// Full nVersion field.
     pub version: u32,
     /// Extranonce bytes which need to be added to coinbase to form a fully
-    /// valid submission (full coinbase = coinbase_tx_prefix +
-    /// extranonce_prefix + extranonce + coinbase_tx_suffix). The size of the
+    /// valid submission (full coinbase = `coinbase_tx_prefix` +
+    /// `extranonce_prefix` + `extranonce` + `coinbase_tx_suffix`). The size of the
     /// provided extranonce MUST be equal to the negotiated extranonce size
     /// from channel opening.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub extranonce: B032<'decoder>,
 }
 
-/// # SubmitShares.Success (Server -> Client)
-///
-/// Response to SubmitShares or SubmitSharesExtended, accepting results from the miner.
+/// Response to [`SubmitSharesStandard`] or [`SubmitSharesExtended`], accepting results from the miner.
 /// Because it is a common case that shares submission is successful, this response can be
-/// provided for multiple SubmitShare messages aggregated together.
+/// provided for multiple [`SubmitSharesStandard`] or [`SubmitSharesExtended`] messages aggregated together.
 ///
 /// The server doesn’t have to double check that the sequence numbers sent by a client are
 /// actually increasing. It can simply use the last one received when sending a response. It is the
@@ -80,12 +77,10 @@ pub struct SubmitSharesSuccess {
     pub new_shares_sum: u64,
 }
 
-/// # SubmitShares.Error (Server -> Client)
-///
 /// An error is immediately submitted for every incorrect submit attempt. In case the server is not
 /// able to immediately validate the submission, the error is sent as soon as the result is known.
 /// This delayed validation can occur when a miner gets faster updates about a new prevhash than
-/// the server does (see NewPrevHash message for details).
+/// the server does (see [`SetNewPrevHash`] message for details).
 ///
 /// Possible error codes:
 /// * ‘invalid-channel-id’
@@ -94,8 +89,11 @@ pub struct SubmitSharesSuccess {
 /// * 'invalid-job-id'
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubmitSharesError<'decoder> {
+    /// Channel identifier
     pub channel_id: u32,
+    /// Submission sequence number for which this error is returned
     pub sequence_number: u32,
+    /// Human-readable error code(s)
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub error_code: Str0255<'decoder>,
 }

--- a/protocols/v2/subprotocols/mining/src/update_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/update_channel.rs
@@ -6,8 +6,9 @@ use binary_sv2::{Deserialize, Serialize, Str0255, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// # UpdateChannel (Client -> Server)
-///
+#[cfg(doc)]
+use crate::{OpenExtendedMiningChannel, OpenStandardMiningChannel, SetTarget};
+
 /// Client notifies the server about changes on the specified channel. If a client performs
 /// device/connection aggregation (i.e. it is a proxy), it MUST send this message when downstream
 /// channels change. This update can be debounced so that it is not sent more often than once in a
@@ -19,20 +20,19 @@ use core::convert::TryInto;
 pub struct UpdateChannel<'decoder> {
     /// Channel identification.
     pub channel_id: u32,
-    /// See Open*Channel for details.
+    /// See [`OpenStandardMiningChannel`] & [`OpenExtendedMiningChannel`] for details.
     pub nominal_hash_rate: f32,
-    /// Maximum target is changed by server by sending SetTarget. This
+    /// Maximum target is changed by server by sending [`SetTarget`]. This
     /// field is understood as device’s request. There can be some delay
-    /// between UpdateChannel and corresponding SetTarget messages,
+    /// between [`UpdateChannel`] and corresponding [`SetTarget`] messages,
     /// based on new job readiness on the server.
     ///
-    /// When maximum_target is smaller than currently used maximum target for the channel,
-    /// upstream node MUST reflect the client’s request (and send appropriate SetTarget message).
+    /// When `maximum_target` is smaller than currently used maximum target for the channel,
+    /// upstream node MUST reflect the client’s request (and send appropriate [`SetTarget`] message).
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub maximum_target: U256<'decoder>,
 }
 
-/// # Update.Error (Server -> Client)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UpdateChannelError<'decoder> {
     /// Channel identification.

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -15,6 +15,7 @@ binary_sv2 = { version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/b
 const_sv2 = { version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
 quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
+mining_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/subprotocols/mining"}
 
 [features]
 with_serde = ["binary_sv2/with_serde", "serde"]

--- a/protocols/v2/subprotocols/template-distribution/src/coinbase_output_data_size.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/coinbase_output_data_size.rs
@@ -6,7 +6,6 @@ use binary_sv2::{Deserialize, Serialize};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## CoinbaseOutputDataSize (Client -> Server)
 /// Ultimately, the pool is responsible for adding coinbase transaction outputs for payouts and
 /// other uses, and thus the Template Provider will need to consider this additional block size
 /// when selecting transactions for inclusion in a block (to not create an invalid, oversized block).

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -8,7 +8,9 @@ use binary_sv2::{Deserialize, Seq0255, Serialize, B0255, B064K, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## NewTemplate (Server -> Client)
+#[cfg(doc)]
+use crate::SetNewPrevHash;
+
 /// The primary template-providing function. Note that the coinbase_tx_outputs bytes will appear
 /// as is at the end of the coinbase transaction.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -16,9 +18,9 @@ pub struct NewTemplate<'decoder> {
     /// Server’s identification of the template. Strictly increasing, the
     /// current UNIX time may be used in place of an ID.
     pub template_id: u64,
-    /// True if the template is intended for future [`crate::SetNewPrevHash`]
+    /// True if the template is intended for future [`SetNewPrevHash`]
     /// message sent on the channel. If False, the job relates to the last
-    /// sent [`crate::SetNewPrevHash`] message on the channel and the miner
+    /// sent [`SetNewPrevHash`] message on the channel and the miner
     /// should start to work on the job immediately.
     pub future_template: bool,
     /// Valid header version field that reflects the current network
@@ -40,7 +42,8 @@ pub struct NewTemplate<'decoder> {
     /// added by the client. Includes both transaction fees and block
     /// subsidy.
     pub coinbase_tx_value_remaining: u64,
-    /// The number of transaction outputs included in coinbase_tx_outputs.
+    /// The number of transaction outputs included in
+    /// [`coinbase_tx_outputs`](#structfield.coinbase_tx_outputs).
     pub coinbase_tx_outputs_count: u32,
     /// Bitcoin transaction outputs to be included as the last outputs in the
     /// coinbase transaction.

--- a/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
@@ -8,18 +8,19 @@ use binary_sv2::{Deserialize, Seq064K, Serialize, Str0255, B016M, B064K};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## RequestTransactionData (Client -> Server)
+#[cfg(doc)]
+use crate::NewTemplate;
+
 /// A request sent by the Job Declarator to the Template Provider which requests the set of
 /// transaction data for all transactions (excluding the coinbase transaction) included in a block, as
 /// well as any additional data which may be required by the Pool to validate the work.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Copy)]
 #[repr(C)]
 pub struct RequestTransactionData {
-    /// The template_id corresponding to a NewTemplate message.
+    /// The template_id corresponding to a [`NewTemplate`] message.
     pub template_id: u64,
 }
 
-/// ## RequestTransactionData.Success (Server->Client)
 /// A response to [`RequestTransactionData`] which contains the set of full transaction data and
 /// excess data required for validation. For practical purposes, the excess data is usually the
 /// SegWit commitment, however the Job Declarator MUST NOT parse or interpret the excess data
@@ -30,18 +31,18 @@ pub struct RequestTransactionData {
 /// from the consensus serialization of Bitcoin transactions.
 /// Ultimately, having some method of negotiating the specific format of transactions between the
 /// Template Provider and the Pool’s Template verification node would be overly burdensome,
-/// thus the following requirements are made explicit. The RequestTransactionData.Success
+/// thus the following requirements are made explicit. The [`RequestTransactionDataSuccess`]
 /// sender MUST ensure that the data is provided in a forwards- and backwards-compatible way to
 /// ensure the end receiver of the data can interpret it, even in the face of new,
 /// consensus-optional data. This allows significantly more flexibility on both the
-/// RequestTransactionData.Success-generating and -interpreting sides during upgrades, at the
+/// [`RequestTransactionDataSuccess`]-generating and -interpreting sides during upgrades, at the
 /// cost of breaking some potential optimizations which would require version negotiation to
 /// provide support for previous versions. For practical purposes, and as a non-normative
 /// suggested implementation for Bitcoin Core, this implies that additional consensus-optional
 /// data be appended at the end of transaction data. It will simply be ignored by versions which do
 /// not understand it.
 /// To work around the limitation of not being able to negotiate e.g. a transaction compression
-/// scheme, the format of the opaque data in RequestTransactionData.Success messages MAY be
+/// scheme, the format of the opaque data in [`RequestTransactionDataSuccess`] messages MAY be
 /// changed in non-compatible ways at the time a fork activates, given sufficient time from
 /// code-release to activation (as any sane fork would have to have) and there being some
 /// in-Template Declaration Protocol signaling of support for the new fork (e.g. for soft-forks

--- a/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
@@ -8,11 +8,15 @@ use binary_sv2::{Deserialize, Serialize, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## SetNewPrevHash (Server -> Client)
+#[cfg(doc)]
+use crate::NewTemplate;
+#[cfg(doc)]
+use mining_sv2::NewMiningJob;
+
 /// Upon successful validation of a new best block, the server MUST immediately provide a
-/// SetNewPrevHash message. If a [NewWork] message has previously been sent with the
-/// [future_job] flag set, which is valid work based on the prev_hash contained in this message, the
-/// template_id field SHOULD be set to the job_id present in that NewTemplate message
+/// [`SetNewPrevHash`] message. If a [`NewMiningJob`] message has previously been sent with the
+/// `min_ntime` flag set, which is valid work based on the [prev_hash](#structfield.prev_hash) contained in this message, the
+/// template_id field SHOULD be set to the `job_id` present in that [`NewTemplate`] message
 /// indicating the client MUST begin mining on that template as soon as possible.
 /// TODO: Define how many previous works the client has to track (2? 3?), and require that the
 /// server reference one of those in SetNewPrevHash.

--- a/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
@@ -8,28 +8,30 @@ use binary_sv2::{Deserialize, Serialize, B064K};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
-/// ## SubmitSolution (Client -> Server)
+#[cfg(doc)]
+use crate::{NewTemplate, SetNewPrevHash};
+
 /// Upon finding a coinbase transaction/nonce pair which double-SHA256 hashes at or below
-/// [`crate::SetNewPrevHash.target`], the client MUST immediately send this message, and the server
+/// [`SetNewPrevHash`].target, the client MUST immediately send this message, and the server
 /// MUST then immediately construct the corresponding full block and attempt to propagate it to
 /// the Bitcoin network.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SubmitSolution<'decoder> {
-    /// The template_id field as it appeared in NewTemplate.
+    /// The template_id field as it appeared in [`NewTemplate`].
     pub template_id: u64,
     /// The version field in the block header. Bits not defined by [BIP320] as
-    /// additional nonce MUST be the same as they appear in the [NewWork]
+    /// additional nonce MUST be the same as they appear in the [NewWork?]
     /// message, other bits may be set to any value.
     pub version: u32,
     /// The nTime field in the block header. This MUST be greater than or equal
-    /// to the header_timestamp field in the latest [`crate::SetNewPrevHash`] message
-    /// and lower than or equal to that value plus the number of seconds since
-    /// the receipt of that message.
+    /// to the [`header_timestamp`](#structfield.header_timestamp) field in the latest
+    /// [`SetNewPrevHash`] message and lower than or equal to that value plus the number
+    /// of seconds since the receipt of that message.
     pub header_timestamp: u32,
     /// The nonce field in the header.
     pub header_nonce: u32,
     /// The full serialized coinbase transaction, meeting all the requirements of
-    /// the NewWork message, above.
+    /// the [NewWork?] message, above.
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub coinbase_tx: B064K<'decoder>,
 }

--- a/protocols/v2/sv2-ffi/sv2.h
+++ b/protocols/v2/sv2-ffi/sv2.h
@@ -281,19 +281,16 @@ enum class Protocol : uint8_t {
   JobDistributionProtocol = SV2_JOB_DISTR_PROTOCOL_DISCRIMINANT,
 };
 
-/// ## ChannelEndpointChanged (Server -> Client)
 /// When a channel’s upstream or downstream endpoint changes and that channel had previously
 /// sent messages with [channel_msg] bitset of unknown extension_type, the intermediate proxy
 /// MUST send a [`ChannelEndpointChanged`] message. Upon receipt thereof, any extension state
 /// (including version negotiation and the presence of support for a given extension) MUST be
 /// reset and version/presence negotiation must begin again.
-///
 struct ChannelEndpointChanged {
   /// The channel which has changed endpoint.
   uint32_t channel_id;
 };
 
-/// ## SetupConnection.Success (Server -> Client)
 /// Response to [`SetupConnection`] message if the server accepts the connection. The client is
 /// required to verify the set of feature flags that the server supports and act accordingly.
 struct SetupConnectionSuccess {
@@ -341,7 +338,6 @@ void free_setup_connection_error(CSetupConnectionError s);
 #include <ostream>
 #include <new>
 
-/// ## CoinbaseOutputDataSize (Client -> Server)
 /// Ultimately, the pool is responsible for adding coinbase transaction outputs for payouts and
 /// other uses, and thus the Template Provider will need to consider this additional block size
 /// when selecting transactions for inclusion in a block (to not create an invalid, oversized block).
@@ -361,12 +357,11 @@ struct CoinbaseOutputDataSize {
   uint32_t coinbase_output_max_additional_size;
 };
 
-/// ## RequestTransactionData (Client -> Server)
 /// A request sent by the Job Declarator to the Template Provider which requests the set of
 /// transaction data for all transactions (excluding the coinbase transaction) included in a block, as
 /// well as any additional data which may be required by the Pool to validate the work.
 struct RequestTransactionData {
-  /// The template_id corresponding to a NewTemplate message.
+  /// The template_id corresponding to a [`NewTemplate`] message.
   uint64_t template_id;
 };
 


### PR DESCRIPTION
This PR:
- Add some docs/comments that were missing
- Try to unify the style used in these doc/comments
- Add formatting in order the ref to others structs or fields are well rendered by rust docs
- Fix some naming error about some referenced messages