### PR TITLE
Refactor `Framing` crate

### DIFF
--- a/benches/benches/src/sv2/iai_sv2_benchmark.rs
+++ b/benches/benches/src/sv2/iai_sv2_benchmark.rs
@@ -1,4 +1,4 @@
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardFrame, StandardSv2Frame};
 use iai::{black_box, main};
 use roles_logic_sv2::{
     handlers::{common::ParseUpstreamCommonMessages, mining::ParseUpstreamMiningMessages, SendTo_},
@@ -18,7 +18,7 @@ use crate::client::{create_client, open_channel, Device, SetupConnectionHandler}
 
 pub type Message = MiningDeviceMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
-pub type EitherFrame = StandardEitherFrame<Message>;
+pub type EitherFrame = StandardFrame<Message>;
 
 fn client_sv2_setup_connection() {
     let address: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 34254);
@@ -46,8 +46,10 @@ fn client_sv2_setup_connection_serialize_deserialize() {
     let mut dst = vec![0; size];
     frame.serialize(&mut dst);
     let mut frame = StdFrame::from_bytes(black_box(dst.clone().into())).unwrap();
-    let type_ = frame.get_header().unwrap().msg_type().clone();
-    let payload = frame.payload();
+    let type_ = frame.header().msg_type();
+    let payload = frame.payload().unwrap();
+    let mut payload = payload.to_owned();
+    let payload = payload.as_mut();
     black_box(AnyMessage::try_from((type_, payload)));
 }
 
@@ -77,8 +79,10 @@ fn client_sv2_open_channel_serialize_deserialize() {
     let mut dst = vec![0; size];
     frame.serialize(&mut dst);
     let mut frame = StdFrame::from_bytes(black_box(dst.clone().into())).unwrap();
-    let type_ = frame.get_header().unwrap().msg_type().clone();
-    let payload = frame.payload();
+    let type_ = frame.header().msg_type();
+    let payload = frame.payload().unwrap();
+    let mut payload = payload.to_owned();
+    let payload = payload.as_mut();
     black_box(AnyMessage::try_from((type_, payload)));
 }
 
@@ -127,8 +131,10 @@ fn client_sv2_mining_message_submit_standard_serialize_deserialize() {
     let mut dst = vec![0; size];
     frame.serialize(&mut dst);
     let mut frame = StdFrame::from_bytes(black_box(dst.clone().into())).unwrap();
-    let type_ = frame.get_header().unwrap().msg_type().clone();
-    let payload = frame.payload();
+    let type_ = frame.header().msg_type();
+    let payload = frame.payload().unwrap();
+    let mut payload = payload.to_owned();
+    let payload = payload.as_mut();
     black_box(AnyMessage::try_from((type_, payload)));
 }
 

--- a/benches/benches/src/sv2/lib/client.rs
+++ b/benches/benches/src/sv2/lib/client.rs
@@ -5,7 +5,7 @@ use bitcoin::{
 use async_channel::{Receiver, Sender};
 use async_std::channel::unbounded;
 use binary_sv2::u256_from_int;
-use codec_sv2::{buffer_sv2::Slice, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{buffer_sv2::Slice, StandardFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess},
     common_properties::{IsMiningUpstream, IsUpstream},
@@ -23,7 +23,7 @@ use roles_logic_sv2::{
 use std::{net::SocketAddr, sync::Arc};
 pub type Message = MiningDeviceMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
-pub type EitherFrame = StandardEitherFrame<Message>;
+pub type EitherFrame = StandardFrame<Message>;
 
 pub fn create_client() -> Device {
     let (sender, receiver) = unbounded();

--- a/examples/interop-cpp/src/main.rs
+++ b/examples/interop-cpp/src/main.rs
@@ -12,7 +12,7 @@ mod main_ {
 
 #[cfg(not(feature = "with_serde"))]
 mod main_ {
-    use codec_sv2::{Encoder, Frame, StandardDecoder, StandardSv2Frame};
+    use codec_sv2::{Encoder, StandardDecoder, StandardSv2Frame};
     use common_messages_sv2::{Protocol, SetupConnection, SetupConnectionError};
     use const_sv2::{
         CHANNEL_BIT_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION,
@@ -124,10 +124,15 @@ mod main_ {
 
             loop {
                 let buffer = decoder.writable();
-                stream.read_exact(buffer).unwrap();
-                if let Ok(mut f) = decoder.next_frame() {
-                    let msg_type = f.get_header().unwrap().msg_type();
-                    let payload = f.payload();
+                match stream.read_exact(buffer) {
+                    Ok(_) => {}
+                    Err(_) => continue,
+                };
+                if let Ok(f) = decoder.next_frame() {
+                    let msg_type = f.header().msg_type();
+                    let payload = f.payload().unwrap();
+                    let mut payload = payload.to_owned();
+                    let payload = payload.as_mut();
                     let message: Sv2Message = (msg_type, payload).try_into().unwrap();
                     match message {
                         Sv2Message::SetupConnection(_) => panic!(),

--- a/examples/ping-pong-without-noise/src/node.rs
+++ b/examples/ping-pong-without-noise/src/node.rs
@@ -10,7 +10,7 @@ use async_std::{
     task,
 };
 
-use codec_sv2::{Frame, StandardDecoder, StandardSv2Frame};
+use codec_sv2::{StandardDecoder, StandardSv2Frame};
 
 #[derive(Debug)]
 enum Expected {
@@ -83,11 +83,14 @@ impl Node {
 
     fn handle_message(
         &mut self,
-        mut frame: StandardSv2Frame<Message<'static>>,
+        frame: StandardSv2Frame<Message<'static>>,
     ) -> Message<'static> {
         match self.expected {
             Expected::Ping => {
-                let ping: Result<Ping, _> = from_bytes(frame.payload());
+                let payload = frame.payload().unwrap();
+                let mut payload = payload.to_owned();
+                let payload = payload.as_mut();
+                let ping: Result<Ping, _> = from_bytes(payload);
                 match ping {
                     Ok(ping) => {
                         println!("Node {} received:", self.name);
@@ -107,7 +110,10 @@ impl Node {
                 }
             }
             Expected::Pong => {
-                let pong: Result<Pong, _> = from_bytes(frame.payload());
+                let payload = frame.payload().unwrap();
+                let mut payload = payload.to_owned();
+                let payload = payload.as_mut();
+                let pong: Result<Pong, _> = from_bytes(payload);
                 match pong {
                     Ok(pong) => {
                         println!("Node {} received:", self.name);

--- a/examples/template-provider-test/src/main.rs
+++ b/examples/template-provider-test/src/main.rs
@@ -1,6 +1,6 @@
 use async_channel::{Receiver, Sender};
 use async_std::net::TcpStream;
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame, Sv2Frame};
+use codec_sv2::{StandardFrame, StandardSv2Frame, Sv2Frame};
 use network_helpers::PlainConnection;
 use roles_logic_sv2::{
     parsers::{IsSv2Message, TemplateDistribution},
@@ -13,7 +13,7 @@ use std::{
 
 pub type Message = TemplateDistribution<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
-pub type EitherFrame = StandardEitherFrame<Message>;
+pub type EitherFrame = StandardFrame<Message>;
 
 #[async_std::main]
 async fn main() {

--- a/protocols/fuzz-tests/src/main.rs
+++ b/protocols/fuzz-tests/src/main.rs
@@ -2,7 +2,7 @@
 use libfuzzer_sys::fuzz_target;
 use binary_codec_sv2::{Seq064K,U256,B0255,Seq0255};
 use binary_codec_sv2::from_bytes;
-use codec_sv2::{StandardDecoder,Sv2Frame,Frame};
+use codec_sv2::{StandardDecoder,Sv2Frame};
 use roles_logic_sv2::parsers::PoolMessages;
 
 type F = Sv2Frame<PoolMessages<'static>,Vec<u8>>;

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -12,7 +12,7 @@ use framing_sv2::framing2::HandShakeFrame;
 #[cfg(feature = "noise_sv2")]
 use framing_sv2::header::{NOISE_HEADER_ENCRYPTED_SIZE, NOISE_HEADER_SIZE};
 use framing_sv2::{
-    framing2::{EitherFrame, Frame as F_, Sv2Frame},
+    framing2::{EitherFrame, Sv2Frame},
     header::Header,
 };
 #[cfg(feature = "noise_sv2")]

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -5,9 +5,9 @@ pub use const_sv2::{AEAD_MAC_LEN, SV2_FRAME_CHUNK_SIZE, SV2_FRAME_HEADER_SIZE};
 #[cfg(feature = "noise_sv2")]
 use core::convert::TryInto;
 use core::marker::PhantomData;
+use framing_sv2::framing2::Sv2Frame;
 #[cfg(feature = "noise_sv2")]
 use framing_sv2::framing2::{EitherFrame, HandShakeFrame};
-use framing_sv2::framing2::Sv2Frame;
 #[allow(unused_imports)]
 pub use framing_sv2::header::NOISE_HEADER_ENCRYPTED_SIZE;
 
@@ -106,7 +106,7 @@ impl<T: Serialize + GetSize> NoiseEncoder<T> {
             error!("Error while encoding 2 frame - while_handshaking: {:?}", e);
             Error::FramingError(e)
         })?;
-        let payload = i.get_payload_when_handshaking();
+        let payload = i.payload().to_vec();
         let wrtbl = self.noise_buffer.get_writable(payload.len());
         for (i, b) in payload.iter().enumerate() {
             wrtbl[i] = *b;

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -7,7 +7,7 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 #[cfg(feature = "noise_sv2")]
 use framing_sv2::framing2::{EitherFrame, HandShakeFrame};
-use framing_sv2::framing2::{Frame as F_, Sv2Frame};
+use framing_sv2::framing2::Sv2Frame;
 #[allow(unused_imports)]
 pub use framing_sv2::header::NOISE_HEADER_ENCRYPTED_SIZE;
 

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 use framing_sv2::framing2::{EitherFrame, HandShakeFrame};
 use framing_sv2::framing2::{Frame as F_, Sv2Frame};
 #[allow(unused_imports)]
-pub use framing_sv2::header::NoiseHeader;
+pub use framing_sv2::header::NOISE_HEADER_ENCRYPTED_SIZE;
 
 #[cfg(feature = "noise_sv2")]
 use tracing::error;
@@ -76,7 +76,7 @@ impl<T: Serialize + GetSize> NoiseEncoder<T> {
                 } else {
                     SV2_FRAME_CHUNK_SIZE + start - AEAD_MAC_LEN
                 };
-                let mut encrypted_len = NoiseHeader::SIZE;
+                let mut encrypted_len = NOISE_HEADER_ENCRYPTED_SIZE;
 
                 while start < sv2.len() {
                     let to_encrypt = self.noise_buffer.get_writable(end - start);

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -23,7 +23,7 @@ pub use encoder::NoiseEncoder;
 
 #[cfg(feature = "noise_sv2")]
 pub use framing_sv2::framing2::HandShakeFrame;
-pub use framing_sv2::framing2::{Frame, Sv2Frame};
+pub use framing_sv2::framing2::Sv2Frame;
 
 #[cfg(feature = "noise_sv2")]
 pub use noise_sv2::{self, Initiator, NoiseCodec, Responder};

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -11,7 +11,7 @@ pub mod error;
 
 pub use error::{CError, Error, Result};
 
-pub use decoder::{StandardEitherFrame, StandardSv2Frame};
+pub use decoder::{StandardFrame, StandardSv2Frame};
 
 pub use decoder::StandardDecoder;
 #[cfg(feature = "noise_sv2")]

--- a/protocols/v2/framing-sv2/src/error.rs
+++ b/protocols/v2/framing-sv2/src/error.rs
@@ -24,8 +24,13 @@ impl fmt::Display for Error {
             ExpectedSv2Frame => {
                 write!(f, "Expected `Sv2Frame`, received `HandshakeFrame`")
             }
-            UnexpectedHeaderLength(i) => {
-                write!(f, "Unexpected `Header` length: `{}`", i)
+            UnexpectedHeaderLength(actual_size) => {
+                write!(
+                    f,
+                    "Unexpected `Header` length: `{}`, should be equal or more to {}",
+                    actual_size,
+                    const_sv2::SV2_FRAME_HEADER_SIZE
+                )
             }
         }
     }

--- a/protocols/v2/framing-sv2/src/error.rs
+++ b/protocols/v2/framing-sv2/src/error.rs
@@ -1,7 +1,4 @@
-// use crate::framing2::EitherFrame;
 use core::fmt;
-
-// pub type FramingResult<T> = core::result::Result<T, Error>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -1,13 +1,11 @@
 #![allow(dead_code)]
 use crate::{
-    header::{Header, NOISE_HEADER_LEN_OFFSET, NOISE_HEADER_SIZE},
+    header::{Header, NOISE_HEADER_SIZE},
     Error,
 };
 use alloc::vec::Vec;
 use binary_sv2::{to_writer, GetSize, Serialize};
 use core::convert::TryFrom;
-
-const NOISE_MAX_LEN: usize = const_sv2::NOISE_FRAME_MAX_SIZE;
 
 #[cfg(not(feature = "with_buffer_pool"))]
 type Slice = Vec<u8>;
@@ -15,46 +13,98 @@ type Slice = Vec<u8>;
 #[cfg(feature = "with_buffer_pool")]
 type Slice = buffer_sv2::Slice;
 
-impl<A, B> Sv2Frame<A, B> {
-    /// Maps a `Sv2Frame<A, B>` to `Sv2Frame<C, B>` by applying `fun`,
-    /// which is assumed to be a closure that converts `A` to `C`
-    pub fn map<C>(self, fun: fn(A) -> C) -> Sv2Frame<C, B> {
-        let serialized = self.serialized;
-        let header = self.header;
-        let payload = self.payload.map(fun);
-        Sv2Frame {
-            header,
-            payload,
-            serialized,
+/// Represents different types of frames that can be sent over the wire.
+#[derive(Debug)]
+pub enum Frame<T, B> {
+    /// Abstraction for a Noise Handshake Frame Contains only a `Slice` payload with a fixed length
+    /// Only used during Noise Handshake process
+    HandShake(HandShakeFrame),
+    /// Abstraction for a SV2 Frame.
+    /// `T` represents the deserialized payload, `B` the serialized payload.
+    Sv2(Sv2Frame<T, B>),
+}
+
+impl<T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<T, B> {
+    pub fn encoded_length(&self) -> usize {
+        match &self {
+            Self::HandShake(frame) => frame.encoded_length(),
+            Self::Sv2(frame) => frame.encoded_length(),
         }
+    }
+}
+
+impl<T, B> TryFrom<Frame<T, B>> for HandShakeFrame {
+    type Error = Error;
+
+    fn try_from(v: Frame<T, B>) -> Result<Self, Error> {
+        match v {
+            Frame::HandShake(frame) => Ok(frame),
+            Frame::Sv2(_) => Err(Error::ExpectedHandshakeFrame),
+        }
+    }
+}
+
+impl<T, B> TryFrom<Frame<T, B>> for Sv2Frame<T, B> {
+    type Error = Error;
+
+    fn try_from(v: Frame<T, B>) -> Result<Self, Error> {
+        match v {
+            Frame::Sv2(frame) => Ok(frame),
+            Frame::HandShake(_) => Err(Error::ExpectedSv2Frame),
+        }
+    }
+}
+
+impl<T, B> From<HandShakeFrame> for Frame<T, B> {
+    fn from(v: HandShakeFrame) -> Self {
+        Self::HandShake(v)
+    }
+}
+
+impl<T, B> From<Sv2Frame<T, B>> for Frame<T, B> {
+    fn from(v: Sv2Frame<T, B>) -> Self {
+        Self::Sv2(v)
     }
 }
 
 /// Abstraction for a SV2 Frame.
 #[derive(Debug, Clone)]
 pub struct Sv2Frame<T, B> {
+    /// Frame header
     header: Header,
+    /// Deserialized payload
     payload: Option<T>,
     /// Serialized header + payload
     serialized: Option<B>,
 }
 
-/// Abstraction for a Noise Handshake Frame
-/// Contains only a `Slice` payload with a fixed length
-/// Only used during Noise Handshake process
-#[derive(Debug)]
-pub struct HandShakeFrame {
-    payload: Slice,
-}
-
-impl HandShakeFrame {
-    /// Returns payload of `HandShakeFrame` as a `Vec<u8>`
-    pub fn get_payload_when_handshaking(&self) -> Vec<u8> {
-        self.payload[0..].to_vec()
-    }
-}
-
 impl<T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Sv2Frame<T, B> {
+    /// Tries to build a `Sv2Frame` from a non-serialized payload.
+    /// Returns a `Sv2Frame` if the size of the payload fits in the frame, `None` otherwise.
+    pub fn from_message(
+        message: T,
+        message_type: u8,
+        extension_type: u16,
+        channel_msg: bool,
+    ) -> Option<Self> {
+        let extension_type = update_extension_type(extension_type, channel_msg);
+        let len = message.get_size() as u32;
+        Header::from_len(len, message_type, extension_type).map(|header| Self {
+            header,
+            payload: Some(message),
+            serialized: None,
+        })
+    }
+
+    pub fn from_bytes(mut bytes: B) -> Result<Self, Error> {
+        let header = Header::from_bytes(bytes.as_mut())?;
+        Ok(Self {
+            header,
+            payload: None,
+            serialized: Some(bytes),
+        })
+    }
+
     /// Write the serialized `Sv2Frame` into `dst`.
     /// This operation when called on an already serialized frame is very cheap.
     /// When called on a non serialized frame, it is not so cheap (because it serializes it).
@@ -80,48 +130,24 @@ impl<T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Sv2Frame<T, B> {
         }
     }
 
-    /// `self` can be either serialized (`self.serialized` is `Some()`) or
-    /// deserialized (`self.serialized` is `None`, `self.payload` is `Some()`).
-    /// This function is only intended as a fast way to get a reference to an
-    /// already serialized payload. If the frame has not yet been
-    /// serialized, this function should never be used (it will panic).
-    pub fn payload<'a>(&'a mut self) -> &'a mut [u8] {
-        if let Some(serialized) = self.serialized.as_mut() {
-            &mut serialized.as_mut()[Header::SIZE..]
+    /// Returns the payload of the `Sv2Frame` as a byte slice.
+    ///
+    /// Will return None if the `Sv2Frame` is not yet serialized.
+    ///
+    /// You can serialize the frame by calling [`Sv2Frame::serialize`].
+    ///
+    /// [`Sv2Frame::serialize`]: crate::framing2::Sv2Frame::serialize
+    pub fn payload(&self) -> Option<&[u8]> {
+        if let Some(serialized) = self.serialized.as_ref() {
+            Some(serialized.as_ref()[Header::SIZE..].as_ref())
         } else {
-            // panic here is the expected behaviour
-            panic!("Sv2Frame is not yet serialized.")
+            None // Sv2Frame is not yet serialized.
         }
     }
 
-    /// `Sv2Frame` always returns `Some(self.header)`.
-    pub fn get_header(&self) -> Option<crate::header::Header> {
-        Some(self.header)
-    }
-
-    /// Tries to build a `Sv2Frame` from raw bytes, assuming they represent a serialized `Sv2Frame` frame (`Self.serialized`).
-    /// Returns a `Sv2Frame` on success, or the number of the bytes needed to complete the frame
-    /// as an error. `Self.serialized` is `Some`, but nothing is assumed or checked about the correctness of the payload.
-    #[inline]
-    fn from_bytes(mut bytes: B) -> Result<Self, isize> {
-        let hint = Self::size_hint(bytes.as_mut());
-
-        if hint == 0 {
-            Ok(Self::from_bytes_unchecked(bytes))
-        } else {
-            Err(hint)
-        }
-    }
-
-    #[inline]
-    pub fn from_bytes_unchecked(mut bytes: B) -> Self {
-        // Unchecked function caller is supposed to already know that the passed bytes are valid
-        let header = Header::from_bytes(bytes.as_mut()).expect("Invalid header");
-        Self {
-            header,
-            payload: None,
-            serialized: Some(bytes),
-        }
+    /// Returns the header of the `Sv2Frame`.
+    pub fn header(&self) -> crate::header::Header {
+        self.header
     }
 
     /// After parsing `bytes` into a `Header`, this function helps to determine if the `msg_length`
@@ -163,101 +189,49 @@ impl<T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Sv2Frame<T, B> {
             panic!("Impossible state")
         }
     }
+}
 
-    /// Tries to build a `Sv2Frame` from a non-serialized payload.
-    /// Returns a `Sv2Frame` if the size of the payload fits in the frame, `None` otherwise.
-    pub fn from_message(
-        message: T,
-        message_type: u8,
-        extension_type: u16,
-        channel_msg: bool,
-    ) -> Option<Self> {
-        let extension_type = update_extension_type(extension_type, channel_msg);
-        let len = message.get_size() as u32;
-        Header::from_len(len, message_type, extension_type).map(|header| Self {
+impl<A, B> Sv2Frame<A, B> {
+    /// Maps a `Sv2Frame<A, B>` to `Sv2Frame<C, B>` by applying `fun`,
+    /// which is assumed to be a closure that converts `A` to `C`
+    pub fn map<C>(self, fun: fn(A) -> C) -> Sv2Frame<C, B> {
+        let serialized = self.serialized;
+        let header = self.header;
+        let payload = self.payload.map(fun);
+        Sv2Frame {
             header,
-            payload: Some(message),
-            serialized: None,
-        })
+            payload,
+            serialized,
+        }
     }
 }
 
+/// Abstraction for a Noise Handshake Frame.
+///
+/// Contains only a `Slice` payload with a fixed length.
+///
+/// Only used during Noise Handshake process.
+#[derive(Debug)]
+pub struct HandShakeFrame {
+    payload: Slice,
+}
+
 impl HandShakeFrame {
-    /// Put the Noise Frame payload into `dst`
-    #[inline]
-    fn serialize(mut self, dst: &mut [u8]) -> Result<(), Error> {
-        dst.swap_with_slice(self.payload.as_mut());
-        Ok(())
-    }
-
-    /// Get the Noise Frame payload
-    #[inline]
-    fn payload<'a>(&'a mut self) -> &'a mut [u8] {
-        &mut self.payload[NOISE_HEADER_SIZE..]
-    }
-
-    /// `HandShakeFrame` always returns `None`.
-    fn get_header(&self) -> Option<crate::header::Header> {
-        None
-    }
-
-    /// Builds a `HandShakeFrame` from raw bytes. Nothing is assumed or checked about the correctness of the payload.
-    fn from_bytes(bytes: Slice) -> Result<Self, isize> {
-        Ok(Self::from_bytes_unchecked(bytes))
-    }
-
-    #[inline]
-    pub fn from_bytes_unchecked(bytes: Slice) -> Self {
+    /// Builds a `HandShakeFrame` from raw bytes.
+    ///
+    /// Nothing is assumed or checked about the correctness of the payload.
+    pub fn from_bytes(bytes: Slice) -> Self {
         Self { payload: bytes }
     }
 
-    /// After parsing the expected `HandShakeFrame` size from `bytes`, this function helps to determine if this value
-    /// correctly representing the size of the frame.
-    /// - Returns `0` if the byte slice is of the expected size according to the header.
-    /// - Returns a negative value if the byte slice is smaller than a Noise Frame header; this value
-    ///   represents how many bytes are missing.
-    /// - Returns a positive value if the byte slice is longer than expected; this value
-    ///   indicates the surplus of bytes beyond the expected size.
-    #[inline]
-    fn size_hint(bytes: &[u8]) -> isize {
-        if bytes.len() < NOISE_HEADER_SIZE {
-            return (NOISE_HEADER_SIZE - bytes.len()) as isize;
-        };
-
-        let len_b = &bytes[NOISE_HEADER_LEN_OFFSET..NOISE_HEADER_SIZE];
-        let expected_len = u16::from_le_bytes([len_b[0], len_b[1]]) as usize;
-
-        if bytes.len() - NOISE_HEADER_SIZE == expected_len {
-            0
-        } else {
-            expected_len as isize - (bytes.len() - NOISE_HEADER_SIZE) as isize
-        }
+    /// Get the Noise Frame payload
+    pub fn payload(&self) -> &[u8] {
+        &self.payload[NOISE_HEADER_SIZE..]
     }
 
     /// Returns the size of the `HandShakeFrame` payload.
-    #[inline]
     fn encoded_length(&self) -> usize {
         self.payload.len()
-    }
-
-    /// Tries to build a `HandShakeFrame` frame from a byte slice.
-    /// Returns a `HandShakeFrame` if the size of the payload fits in the frame, `None` otherwise.
-    /// This is quite inefficient, and should be used only to build `HandShakeFrames`
-    // TODO check if is used only to build `HandShakeFrames`
-    #[allow(clippy::useless_conversion)]
-    fn from_message(
-        message: Slice,
-        _message_type: u8,
-        _extension_type: u16,
-        _channel_msg: bool,
-    ) -> Option<Self> {
-        if message.len() <= NOISE_MAX_LEN {
-            Some(Self {
-                payload: message.into(),
-            })
-        } else {
-            None
-        }
     }
 }
 
@@ -285,66 +259,19 @@ fn update_extension_type(extension_type: u16, channel_msg: bool) -> u16 {
     }
 }
 
-/// A wrapper to be used in a context we need a generic reference to a frame
-/// but it doesn't matter which kind of frame it is (`Sv2Frame` or `HandShakeFrame`)
-#[derive(Debug)]
-pub enum EitherFrame<T, B> {
-    HandShake(HandShakeFrame),
-    Sv2(Sv2Frame<T, B>),
-}
-
-impl<T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> EitherFrame<T, B> {
-    pub fn encoded_length(&self) -> usize {
-        match &self {
-            Self::HandShake(frame) => frame.encoded_length(),
-            Self::Sv2(frame) => frame.encoded_length(),
-        }
-    }
-}
-
-impl<T, B> TryFrom<EitherFrame<T, B>> for HandShakeFrame {
-    type Error = Error;
-
-    fn try_from(v: EitherFrame<T, B>) -> Result<Self, Error> {
-        match v {
-            EitherFrame::HandShake(frame) => Ok(frame),
-            EitherFrame::Sv2(_) => Err(Error::ExpectedHandshakeFrame),
-        }
-    }
-}
-
-impl<T, B> TryFrom<EitherFrame<T, B>> for Sv2Frame<T, B> {
-    type Error = Error;
-
-    fn try_from(v: EitherFrame<T, B>) -> Result<Self, Error> {
-        match v {
-            EitherFrame::Sv2(frame) => Ok(frame),
-            EitherFrame::HandShake(_) => Err(Error::ExpectedSv2Frame),
-        }
-    }
-}
-
-impl<T, B> From<HandShakeFrame> for EitherFrame<T, B> {
-    fn from(v: HandShakeFrame) -> Self {
-        Self::HandShake(v)
-    }
-}
-
-impl<T, B> From<Sv2Frame<T, B>> for EitherFrame<T, B> {
-    fn from(v: Sv2Frame<T, B>) -> Self {
-        Self::Sv2(v)
-    }
-}
-
 #[cfg(test)]
-use binary_sv2::binary_codec_sv2;
+mod tests {
+    use crate::framing2::Sv2Frame;
+    use alloc::vec::Vec;
+    use binary_sv2::{binary_codec_sv2, Serialize};
 
-#[cfg(test)]
-#[derive(Serialize)]
-struct T {}
+    #[cfg(test)]
+    #[derive(Serialize)]
+    struct T {}
 
-#[test]
-fn test_size_hint() {
-    let h = Sv2Frame::<T, Vec<u8>>::size_hint(&[0, 128, 30, 46, 0, 0][..]);
-    assert!(h == 46);
+    #[test]
+    fn test_size_hint() {
+        let h = Sv2Frame::<T, Vec<u8>>::size_hint(&[0, 128, 30, 46, 0, 0][..]);
+        assert!(h == 46);
+    }
 }

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -1,5 +1,5 @@
 use crate::{
-    header::{Header, NoiseHeader},
+    header::{Header, NOISE_HEADER_LEN_OFFSET, NOISE_HEADER_SIZE},
     Error,
 };
 use alloc::vec::Vec;
@@ -81,16 +81,6 @@ pub struct Sv2Frame<T, B> {
     payload: Option<T>,
     /// Serialized header + payload
     serialized: Option<B>,
-}
-
-impl<T, B> Default for Sv2Frame<T, B> {
-    fn default() -> Self {
-        Sv2Frame {
-            header: Header::default(),
-            payload: None,
-            serialized: None,
-        }
-    }
 }
 
 /// Abstraction for a Noise Handshake Frame
@@ -253,7 +243,7 @@ impl<'a> Frame<'a, Slice> for HandShakeFrame {
     /// Get the Noise Frame payload
     #[inline]
     fn payload(&'a mut self) -> &'a mut [u8] {
-        &mut self.payload[NoiseHeader::HEADER_SIZE..]
+        &mut self.payload[NOISE_HEADER_SIZE..]
     }
 
     /// `HandShakeFrame` always returns `None`.
@@ -280,17 +270,17 @@ impl<'a> Frame<'a, Slice> for HandShakeFrame {
     ///   indicates the surplus of bytes beyond the expected size.
     #[inline]
     fn size_hint(bytes: &[u8]) -> isize {
-        if bytes.len() < NoiseHeader::HEADER_SIZE {
-            return (NoiseHeader::HEADER_SIZE - bytes.len()) as isize;
+        if bytes.len() < NOISE_HEADER_SIZE {
+            return (NOISE_HEADER_SIZE - bytes.len()) as isize;
         };
 
-        let len_b = &bytes[NoiseHeader::LEN_OFFSET..NoiseHeader::HEADER_SIZE];
+        let len_b = &bytes[NOISE_HEADER_LEN_OFFSET..NOISE_HEADER_SIZE];
         let expected_len = u16::from_le_bytes([len_b[0], len_b[1]]) as usize;
 
-        if bytes.len() - NoiseHeader::HEADER_SIZE == expected_len {
+        if bytes.len() - NOISE_HEADER_SIZE == expected_len {
             0
         } else {
-            expected_len as isize - (bytes.len() - NoiseHeader::HEADER_SIZE) as isize
+            expected_len as isize - (bytes.len() - NOISE_HEADER_SIZE) as isize
         }
     }
 

--- a/protocols/v2/framing-sv2/src/lib.rs
+++ b/protocols/v2/framing-sv2/src/lib.rs
@@ -5,12 +5,15 @@
 //!
 //! The message framing is outlined below ([according to SV2 specs](https://stratumprotocol.org/specification/03-Protocol-Overview/#32-framing)):
 //!
-//! | Protocol Type  | Byte Length | Description |
-//! |----------------|-------------|-------------|
-//! | `extension_type` | `U16` | Unique identifier of the extension describing this protocol message. <br><br> Most significant bit (i.e.bit `15`, `0`-indexed, aka `channel_msg`) indicates a message which is specific to a channel, whereas if the most significant bit is unset, the message is to be interpreted by the immediate receiving device. <br><br> Note that the `channel_msg` bit is ignored in the extension lookup, i.e.an `extension_type` of `0x8ABC` is for the same "extension" as `0x0ABC`. <br><br> If the `channel_msg` bit is set, the first four bytes of the payload field is a `U32` representing the `channel_id` this message is destined for (these bytes are repeated in the message framing descriptions below). <br><br> Note that for the Job Declaration and Template Distribution Protocols the `channel_msg` bit is always unset. |
-//! | `msg_type` | `U8` | Unique identifier of the extension describing this protocol message. |
-//! | `msg_length` | `U24` | Length of the protocol message, not including this header. |
-//! | `payload` | `BYTES` | Message-specific payload of length `msg_length`. If the MSB in `extension_type` (the `channel_msg` bit) is set the first four bytes are defined as a `U32` `"channel_id"`, though this definition is repeated in the message definitions below and these 4 bytes are included in `msg_length`. |
+//! | Protocol Type    | Byte Length | Description |
+//! |------------------|-------------|-------------|
+//! | `extension_type` | `U16`       | Unique identifier of the extension describing this protocol message. <br><br> Most significant bit (i.e.bit `15`, `0`-indexed, aka `channel_msg`) indicates a message which is specific to a channel, whereas if the most significant bit is unset, the message is to be interpreted by the immediate receiving device. <br><br> Note that the `channel_msg` bit is ignored in the extension lookup, i.e.an `extension_type` of `0x8ABC` is for the same "extension" as `0x0ABC`. <br><br> If the `channel_msg` bit is set, the first four bytes of the payload field is a `U32` representing the `channel_id` this message is destined for (these bytes are repeated in the message framing descriptions below). <br><br> Note that for the Job Declaration and Template Distribution Protocols the `channel_msg` bit is always unset. |
+//!
+//! | `msg_type`       | `U8`        | Unique identifier of the extension describing this protocol message. |
+//!
+//! | `msg_length`     | `U24`       | Length of the protocol message, not including this header. |
+//!
+//! | `payload`        | `BYTES`     | Message-specific payload of length `msg_length`. If the MSB in `extension_type` (the `channel_msg` bit) is set the first four bytes are defined as a `U32` `"channel_id"`, though this definition is repeated in the message definitions below and these 4 bytes are included in `msg_length`. |
 //!
 //! # Features
 //! This crate can be built with the following features:

--- a/protocols/v2/roles-logic-sv2/src/parsers.rs
+++ b/protocols/v2/roles-logic-sv2/src/parsers.rs
@@ -13,7 +13,7 @@ use binary_sv2::GetSize;
 
 use binary_sv2::{from_bytes, Deserialize};
 
-use framing_sv2::framing2::{Frame, Sv2Frame};
+use framing_sv2::framing2::Sv2Frame;
 
 use const_sv2::{
     CHANNEL_BIT_ALLOCATE_MINING_JOB_TOKEN, CHANNEL_BIT_ALLOCATE_MINING_JOB_TOKEN_SUCCESS,

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use codec_sv2::{Encoder, Frame, StandardDecoder, StandardSv2Frame};
+use codec_sv2::{Encoder, StandardDecoder, StandardSv2Frame};
 use common_messages_sv2::{
     CSetupConnection, CSetupConnectionError, ChannelEndpointChanged, SetupConnection,
     SetupConnectionError, SetupConnectionSuccess,

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -464,17 +464,17 @@ pub extern "C" fn next_frame(decoder: *mut DecoderWrapper) -> CResult<CSv2Messag
     let mut decoder = unsafe { Box::from_raw(decoder) };
 
     match decoder.0.next_frame() {
-        Ok(mut f) => {
-            let msg_type = match f.get_header() {
-                Some(header) => header.msg_type(),
+        Ok(f) => {
+            let msg_type = f.header();
+            let payload = match f.payload() {
+                Some(payload) => payload,
                 None => return CResult::Err(Sv2Error::InvalidSv2Frame),
             };
-            let payload = f.payload();
             let len = payload.len();
-            let ptr = payload.as_mut_ptr();
+            let ptr = payload.to_owned().as_mut_ptr();
             let payload = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
             Box::into_raw(decoder);
-            (msg_type, payload)
+            (msg_type.msg_type(), payload)
                 .try_into()
                 .map(|x: Sv2Message| x.into())
                 .map_err(|_| Sv2Error::Unknown)
@@ -760,8 +760,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::CoinbaseOutputDataSize(m) => m,
@@ -812,8 +814,10 @@ mod tests {
         let mut decoded = decoder.next_frame().unwrap();
 
         // Extract payload of the frame which is the NewTemplate message
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::NewTemplate(m) => m,
@@ -860,8 +864,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::RequestTransactionData(m) => m,
@@ -910,8 +916,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::RequestTransactionDataError(m) => m,
@@ -960,8 +968,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::RequestTransactionDataSuccess(m) => m,
@@ -1005,8 +1015,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::SetNewPrevHash(m) => m,
@@ -1050,8 +1062,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::SubmitSolution(m) => m,
@@ -1108,8 +1122,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::ChannelEndpointChanged(m) => m,
@@ -1144,8 +1160,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::SetupConnection(m) => m,
@@ -1193,8 +1211,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::SetupConnectionError(m) => m,
@@ -1242,8 +1262,10 @@ mod tests {
 
         let mut decoded = decoder.next_frame().unwrap();
 
-        let msg_type = decoded.get_header().unwrap().msg_type();
-        let payload = decoded.payload();
+        let msg_type = decoded.header().msg_type();
+        let payload = decoded.payload().unwrap();
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
             Sv2Message::SetupConnectionSuccess(m) => m,

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -21,7 +21,7 @@ use roles_logic_sv2::{
 };
 use tracing::{debug, error, info, warn};
 
-use codec_sv2::{Frame, HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 
 use stratum_common::bitcoin::{consensus::Decodable, TxOut};

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -17,7 +17,6 @@ use tokio::task::AbortHandle;
 use tracing::{error, info};
 
 use async_recursion::async_recursion;
-use codec_sv2::Frame;
 use nohash_hasher::BuildNoHashHasher;
 use roles_logic_sv2::{
     handlers::job_declaration::ParseServerJobDeclarationMessages,

--- a/roles/jd-client/src/lib/job_declarator/setup_connection.rs
+++ b/roles/jd-client/src/lib/job_declarator/setup_connection.rs
@@ -10,7 +10,6 @@ use roles_logic_sv2::{
 use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 pub type Message = PoolMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
-pub type EitherFrame = StandardEitherFrame<Message>;
 pub struct SetupConnectionHandler {}
 
 impl SetupConnectionHandler {
@@ -42,8 +41,8 @@ impl SetupConnectionHandler {
     }
 
     pub async fn setup(
-        receiver: &mut Receiver<EitherFrame>,
-        sender: &mut Sender<EitherFrame>,
+        receiver: &mut Receiver<StandardEitherFrame<Message>>,
+        sender: &mut Sender<StandardEitherFrame<Message>>,
         proxy_address: SocketAddr,
     ) -> Result<(), ()> {
         let setup_connection = Self::get_setup_connection_message(proxy_address);
@@ -55,10 +54,15 @@ impl SetupConnectionHandler {
 
         sender.send(sv2_frame).await.map_err(|_| ())?;
 
-        let mut incoming: StdFrame = receiver.recv().await.unwrap().try_into().unwrap();
+        let incoming: StdFrame = receiver.recv().await.unwrap().try_into().unwrap();
 
-        let message_type = incoming.get_header().unwrap().msg_type();
-        let payload = incoming.payload();
+        let message_type = incoming.header().msg_type();
+        let payload = match incoming.payload() {
+            Some(payload) => payload,
+            None => return Err(()),
+        };
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         ParseUpstreamCommonMessages::handle_message_common(
             Arc::new(Mutex::new(SetupConnectionHandler {})),
             message_type,

--- a/roles/jd-client/src/lib/job_declarator/setup_connection.rs
+++ b/roles/jd-client/src/lib/job_declarator/setup_connection.rs
@@ -1,5 +1,5 @@
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     handlers::common::{ParseUpstreamCommonMessages, SendTo},

--- a/roles/jd-client/src/lib/template_receiver/mod.rs
+++ b/roles/jd-client/src/lib/template_receiver/mod.rs
@@ -1,6 +1,6 @@
 use super::{job_declarator::JobDeclarator, status, PoolChangerTrigger};
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/jd-client/src/lib/template_receiver/setup_connection.rs
+++ b/roles/jd-client/src/lib/template_receiver/setup_connection.rs
@@ -1,5 +1,5 @@
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     handlers::common::{ParseUpstreamCommonMessages, SendTo},

--- a/roles/jd-client/src/lib/upstream_sv2/mod.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/mod.rs
@@ -1,4 +1,4 @@
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardFrame, StandardSv2Frame};
 use roles_logic_sv2::parsers::PoolMessages;
 
 pub mod upstream;
@@ -6,7 +6,7 @@ pub use upstream::Upstream;
 
 pub type Message = PoolMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
-pub type EitherFrame = StandardEitherFrame<Message>;
+pub type EitherFrame = StandardFrame<Message>;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Sv2MiningConnection {

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -11,7 +11,7 @@ use super::super::{
 };
 use async_channel::{Receiver, Sender};
 use binary_sv2::{Seq0255, U256};
-use codec_sv2::{Frame, HandshakeRole, Initiator};
+use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -2,7 +2,7 @@ pub mod message_handler;
 use super::{error::JdsError, mempool::JDsMempool, status, Configuration, EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};
 use binary_sv2::{B0255, U256};
-use codec_sv2::{Frame, HandshakeRole, Responder};
+use codec_sv2::{HandshakeRole, Responder};
 use error_handling::handle_result;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey, SignatureService};
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/jd-server/src/lib/mod.rs
+++ b/roles/jd-server/src/lib/mod.rs
@@ -3,7 +3,7 @@ pub mod job_declarator;
 pub mod mempool;
 pub mod status;
 
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardFrame, StandardSv2Frame};
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use roles_logic_sv2::{
     errors::Error, parsers::PoolMessages as JdsMessages, utils::CoinbaseOutput as CoinbaseOutput_,
@@ -17,7 +17,7 @@ use stratum_common::bitcoin::{Script, TxOut};
 
 pub type Message = JdsMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
-pub type EitherFrame = StandardEitherFrame<Message>;
+pub type EitherFrame = StandardFrame<Message>;
 
 pub fn get_coinbase_output(config: &Configuration) -> Result<Vec<TxOut>, Error> {
     let mut result = Vec::new();

--- a/roles/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/mining-proxy/src/lib/downstream_mining.rs
@@ -17,7 +17,7 @@ use roles_logic_sv2::{
 };
 use tracing::info;
 
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 
 pub type Message = MiningDeviceMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;

--- a/roles/mining-proxy/src/lib/error.rs
+++ b/roles/mining-proxy/src/lib/error.rs
@@ -1,22 +1,22 @@
 use async_channel::SendError;
-use codec_sv2::StandardEitherFrame;
+use codec_sv2::StandardFrame;
 use roles_logic_sv2::parsers::PoolMessages;
 use std::net::SocketAddr;
 
 pub type Message = PoolMessages<'static>;
-pub type EitherFrame = StandardEitherFrame<Message>;
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 #[allow(clippy::enum_variant_names)]
 pub enum Error {
-    SendError(SendError<EitherFrame>),
+    SendError(SendError<StandardFrame<Message>>),
     UpstreamNotAvailabe(SocketAddr),
     SetupConnectionError(String),
+    NoPayloadFound,
 }
 
-impl From<SendError<EitherFrame>> for Error {
-    fn from(error: SendError<EitherFrame>) -> Self {
+impl From<SendError<StandardFrame<Message>>> for Error {
+    fn from(error: SendError<StandardFrame<Message>>) -> Self {
         Error::SendError(error)
     }
 }

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -6,7 +6,7 @@ use roles_logic_sv2::utils::Id;
 use super::downstream_mining::{Channel, DownstreamMiningNode, StdFrame as DownstreamFrame};
 use async_channel::{Receiver, SendError, Sender};
 use async_recursion::async_recursion;
-use codec_sv2::{Frame, HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
 use network_helpers_sv2::noise_connection_tokio::Connection;
 use nohash_hasher::BuildNoHashHasher;
 use roles_logic_sv2::{

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use async_channel::{Receiver, Sender};
 use binary_sv2::U256;
-use codec_sv2::{Frame, HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
 use error_handling::handle_result;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey, SignatureService};
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/pool/src/lib/mining_pool/setup_connection.rs
@@ -3,7 +3,6 @@ use super::super::{
     mining_pool::{EitherFrame, StdFrame},
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::Frame;
 use roles_logic_sv2::{
     common_messages_sv2::{
         has_requires_std_job, has_version_rolling, has_work_selection, SetupConnection,

--- a/roles/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/pool/src/lib/mining_pool/setup_connection.rs
@@ -40,7 +40,7 @@ impl SetupConnectionHandler {
     ) -> PoolResult<CommonDownstreamData> {
         // read stdFrame from receiver
 
-        let mut incoming: StdFrame = match receiver.recv().await {
+        let incoming: StdFrame = match receiver.recv().await {
             Ok(EitherFrame::Sv2(s)) => {
                 debug!("Got sv2 message: {:?}", s);
                 s
@@ -58,11 +58,12 @@ impl SetupConnectionHandler {
             }
         };
 
-        let message_type = incoming
-            .get_header()
-            .ok_or_else(|| PoolError::Custom(String::from("No header set")))?
-            .msg_type();
-        let payload = incoming.payload();
+        let message_type = incoming.header().msg_type();
+        let payload = incoming
+            .payload()
+            .ok_or(PoolError::Custom(String::from("No payload set")))?;
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
         let response = ParseDownstreamCommonMessages::handle_message_common(
             self_.clone(),
             message_type,

--- a/roles/pool/src/lib/template_receiver/mod.rs
+++ b/roles/pool/src/lib/template_receiver/mod.rs
@@ -4,7 +4,7 @@ use super::{
     status,
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, HandshakeRole, Initiator};
+use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/pool/src/lib/template_receiver/setup_connection.rs
+++ b/roles/pool/src/lib/template_receiver/setup_connection.rs
@@ -3,7 +3,6 @@ use super::super::{
     mining_pool::{EitherFrame, StdFrame},
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::Frame;
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     errors::Error,

--- a/roles/roles-utils/network-helpers/src/lib.rs
+++ b/roles/roles-utils/network-helpers/src/lib.rs
@@ -14,7 +14,7 @@ pub mod noise_connection_tokio;
 pub mod plain_connection_tokio;
 
 use async_channel::{Receiver, RecvError, SendError, Sender};
-use codec_sv2::{Error as CodecError, HandShakeFrame, HandshakeRole, StandardEitherFrame};
+use codec_sv2::{Error as CodecError, HandShakeFrame, HandshakeRole, StandardFrame};
 use const_sv2::{
     INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE, RESPONDER_EXPECTED_HANDSHAKE_MESSAGE_SIZE,
 };
@@ -61,8 +61,8 @@ async fn initialize_as_downstream<
 >(
     self_: Arc<Mutex<T>>,
     role: HandshakeRole,
-    sender_outgoing: Sender<StandardEitherFrame<Message>>,
-    receiver_incoming: Receiver<StandardEitherFrame<Message>>,
+    sender_outgoing: Sender<StandardFrame<Message>>,
+    receiver_incoming: Receiver<StandardFrame<Message>>,
 ) -> Result<(), Error> {
     let mut state = codec_sv2::State::initialized(role);
 
@@ -76,7 +76,7 @@ async fn initialize_as_downstream<
         .try_into()
         .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
     let second_message: [u8; INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE] = second_message
-        .get_payload_when_handshaking()
+        .payload()
         .try_into()
         .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
 
@@ -93,8 +93,8 @@ async fn initialize_as_downstream<
 async fn initialize_as_upstream<'a, Message: Serialize + Deserialize<'a> + GetSize, T: SetState>(
     self_: Arc<Mutex<T>>,
     role: HandshakeRole,
-    sender_outgoing: Sender<StandardEitherFrame<Message>>,
-    receiver_incoming: Receiver<StandardEitherFrame<Message>>,
+    sender_outgoing: Sender<StandardFrame<Message>>,
+    receiver_incoming: Receiver<StandardFrame<Message>>,
 ) -> Result<(), Error> {
     let mut state = codec_sv2::State::initialized(role);
 
@@ -105,7 +105,7 @@ async fn initialize_as_upstream<'a, Message: Serialize + Deserialize<'a> + GetSi
         .try_into()
         .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
     let first_message: [u8; RESPONDER_EXPECTED_HANDSHAKE_MESSAGE_SIZE] = first_message
-        .get_payload_when_handshaking()
+        .payload()
         .try_into()
         .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
 

--- a/roles/roles-utils/network-helpers/src/noise_connection_async_std.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection_async_std.rs
@@ -10,7 +10,7 @@ use std::{sync::Arc, time::Duration};
 use tracing::{debug, error};
 
 use binary_sv2::GetSize;
-use codec_sv2::{HandshakeRole, Initiator, Responder, StandardEitherFrame, StandardNoiseDecoder};
+use codec_sv2::{HandshakeRole, Initiator, Responder, StandardFrame, StandardNoiseDecoder};
 
 use crate::Error;
 
@@ -42,8 +42,8 @@ impl Connection {
         capacity: usize,
     ) -> Result<
         (
-            Receiver<StandardEitherFrame<Message>>,
-            Sender<StandardEitherFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
+            Sender<StandardFrame<Message>>,
         ),
         Error,
     > {
@@ -51,12 +51,12 @@ impl Connection {
         let (mut reader, writer) = (stream.clone(), stream.clone());
 
         let (sender_incoming, receiver_incoming): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(capacity);
         let (sender_outgoing, receiver_outgoing): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(capacity);
 
         let state = codec_sv2::State::not_initialized(&role);

--- a/roles/roles-utils/network-helpers/src/noise_connection_tokio.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection_tokio.rs
@@ -10,7 +10,7 @@ use tokio::{
 };
 
 use binary_sv2::GetSize;
-use codec_sv2::{HandshakeRole, Initiator, Responder, StandardEitherFrame, StandardNoiseDecoder};
+use codec_sv2::{HandshakeRole, Initiator, Responder, StandardFrame, StandardNoiseDecoder};
 
 use tracing::{debug, error};
 
@@ -41,8 +41,8 @@ impl Connection {
         role: HandshakeRole,
     ) -> Result<
         (
-            Receiver<StandardEitherFrame<Message>>,
-            Sender<StandardEitherFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
+            Sender<StandardFrame<Message>>,
             AbortHandle,
             AbortHandle,
         ),
@@ -53,12 +53,12 @@ impl Connection {
         let (mut reader, mut writer) = stream.into_split();
 
         let (sender_incoming, receiver_incoming): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(10); // TODO caller should provide this param
         let (sender_outgoing, receiver_outgoing): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(10); // TODO caller should provide this param
 
         let state = codec_sv2::State::not_initialized(&role);

--- a/roles/roles-utils/network-helpers/src/plain_connection_async_std.rs
+++ b/roles/roles-utils/network-helpers/src/plain_connection_async_std.rs
@@ -9,7 +9,7 @@ use core::convert::TryInto;
 use tracing::error;
 
 use binary_sv2::GetSize;
-use codec_sv2::{StandardDecoder, StandardEitherFrame};
+use codec_sv2::{StandardDecoder, StandardFrame};
 
 #[derive(Debug)]
 pub struct PlainConnection {}
@@ -20,18 +20,18 @@ impl PlainConnection {
         stream: TcpStream,
         capacity: usize,
     ) -> (
-        Receiver<StandardEitherFrame<Message>>,
-        Sender<StandardEitherFrame<Message>>,
+        Receiver<StandardFrame<Message>>,
+        Sender<StandardFrame<Message>>,
     ) {
         let (mut reader, writer) = (stream.clone(), stream);
 
         let (sender_incoming, receiver_incoming): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(capacity);
         let (sender_outgoing, receiver_outgoing): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(capacity);
 
         // RECEIVE AND PARSE INCOMING MESSAGES FROM TCP STREAM

--- a/roles/roles-utils/network-helpers/src/plain_connection_tokio.rs
+++ b/roles/roles-utils/network-helpers/src/plain_connection_tokio.rs
@@ -8,7 +8,7 @@ use tokio::{
 };
 
 use binary_sv2::GetSize;
-use codec_sv2::{Error::MissingBytes, StandardDecoder, StandardEitherFrame};
+use codec_sv2::{Error::MissingBytes, StandardDecoder, StandardFrame};
 use tracing::{error, trace};
 
 #[derive(Debug)]
@@ -25,20 +25,20 @@ impl PlainConnection {
     pub async fn new<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
         stream: TcpStream,
     ) -> (
-        Receiver<StandardEitherFrame<Message>>,
-        Sender<StandardEitherFrame<Message>>,
+        Receiver<StandardFrame<Message>>,
+        Sender<StandardFrame<Message>>,
     ) {
         const NOISE_HANDSHAKE_SIZE_HINT: usize = 3363412;
 
         let (mut reader, mut writer) = stream.into_split();
 
         let (sender_incoming, receiver_incoming): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(10); // TODO caller should provide this param
         let (sender_outgoing, receiver_outgoing): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
+            Sender<StandardFrame<Message>>,
+            Receiver<StandardFrame<Message>>,
         ) = bounded(10); // TODO caller should provide this param
 
         // RECEIVE AND PARSE INCOMING MESSAGES FROM TCP STREAM

--- a/roles/test-utils/mining-device/src/main.rs
+++ b/roles/test-utils/mining-device/src/main.rs
@@ -110,7 +110,7 @@ async fn main() {
 
 use async_channel::{Receiver, Sender};
 use binary_sv2::u256_from_int;
-use codec_sv2::{Frame, Initiator, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{Initiator, StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess},
     common_properties::{IsMiningUpstream, IsUpstream},

--- a/roles/translator/src/lib/upstream_sv2/mod.rs
+++ b/roles/translator/src/lib/upstream_sv2/mod.rs
@@ -1,4 +1,4 @@
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardFrame, StandardSv2Frame};
 use roles_logic_sv2::parsers::PoolMessages;
 
 pub mod diff_management;
@@ -9,7 +9,7 @@ pub use upstream_connection::UpstreamConnection;
 
 pub type Message = PoolMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
-pub type EitherFrame = StandardEitherFrame<Message>;
+pub type EitherFrame = StandardFrame<Message>;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Sv2MiningConnection {

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -194,7 +194,7 @@ impl Upstream {
 
         // Wait for the SV2 Upstream to respond with either a `SetupConnectionSuccess` or a
         // `SetupConnectionError` inside a SV2 binary message frame
-        let mut incoming: StdFrame = match connection.receiver.recv().await {
+        let incoming: StdFrame = match connection.receiver.recv().await {
             Ok(frame) => frame.try_into()?,
             Err(e) => {
                 error!("Upstream connection closed: {}", e);
@@ -205,13 +205,13 @@ impl Upstream {
         };
 
         // Gets the binary frame message type from the message header
-        let message_type = if let Some(header) = incoming.get_header() {
-            header.msg_type()
-        } else {
-            return Err(framing_sv2::Error::ExpectedHandshakeFrame.into());
-        };
+        let message_type = incoming.header().msg_type();
         // Gets the message payload
-        let payload = incoming.payload();
+        let payload = incoming
+            .payload()
+            .ok_or(framing_sv2::Error::ExpectedHandshakeFrame)?;
+        let mut payload = payload.to_owned();
+        let payload = payload.as_mut();
 
         // Handle the incoming message (should be either `SetupConnectionSuccess` or
         // `SetupConnectionError`)
@@ -294,19 +294,27 @@ impl Upstream {
             loop {
                 // Waiting to receive a message from the SV2 Upstream role
                 let incoming = handle_result!(tx_status, recv.recv().await);
-                let mut incoming: StdFrame = handle_result!(tx_status, incoming.try_into());
+                let incoming: StdFrame = handle_result!(tx_status, incoming.try_into());
                 // On message receive, get the message type from the message header and get the
                 // message payload
-                let message_type =
-                    incoming
-                        .get_header()
-                        .ok_or(super::super::error::Error::FramingSv2(
-                            framing_sv2::Error::ExpectedSv2Frame,
-                        ));
-
-                let message_type = handle_result!(tx_status, message_type).msg_type();
+                let message_type = incoming.header().msg_type();
 
                 let payload = incoming.payload();
+                let payload = match payload {
+                    Some(p) => p,
+                    None => {
+                        error!("Received empty payload from upstream!");
+                        handle_result!(
+                            tx_status,
+                            Err(CodecNoise(
+                                codec_sv2::noise_sv2::Error::ExpectedIncomingHandshakeMessage
+                            ))
+                        )
+                    }
+                };
+                let mut payload = payload.to_owned();
+                let payload = payload.as_mut();
+                // let payload = handle_result!(tx_status, payload).as_mut();
 
                 // Since this is not communicating with an SV2 proxy, but instead a custom SV1
                 // proxy where the routing logic is handled via the `Upstream`'s communication

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -11,7 +11,7 @@ use crate::{
 use async_channel::{Receiver, Sender};
 use async_std::{net::TcpStream, task};
 use binary_sv2::u256_from_int;
-use codec_sv2::{Frame, HandshakeRole, Initiator};
+use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::Connection;

--- a/test/scale/src/main.rs
+++ b/test/scale/src/main.rs
@@ -7,7 +7,7 @@ use tokio::{
 use async_channel::{bounded, Receiver, Sender};
 
 use clap::{App, Arg};
-use codec_sv2::{HandshakeRole, Initiator, Responder, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Initiator, Responder, StandardFrame, StandardSv2Frame};
 use std::time::Duration;
 
 use network_helpers::{
@@ -20,7 +20,7 @@ use roles_logic_sv2::{
     parsers::{Mining, MiningDeviceMessages},
 };
 
-pub type EitherFrame = StandardEitherFrame<Message>;
+pub type EitherFrame = StandardFrame<Message>;
 pub const AUTHORITY_PUBLIC_K: &str = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72";
 
 pub const AUTHORITY_PRIVATE_K: &str = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n";

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use async_channel::{Receiver, Sender};
 use binary_sv2::Serialize;
-use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
+use codec_sv2::{StandardFrame as EitherFrame, Sv2Frame};
 use roles_logic_sv2::parsers::{self, AnyMessage};
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
 
@@ -222,10 +222,12 @@ impl Executor {
                     }
                 };
 
-                let mut message: Sv2Frame<AnyMessage<'static>, _> = message.try_into().unwrap();
+                let message: Sv2Frame<AnyMessage<'static>, _> = message.try_into().unwrap();
                 debug!("RECV {:#?}", message);
-                let header = message.get_header().unwrap();
-                let payload = message.payload();
+                let header = message.header();
+                let payload = message.payload().unwrap();
+                let mut payload = payload.to_owned();
+                let payload = payload.as_mut();
                 match result {
                     ActionResult::MatchMessageType(message_type) => {
                         if header.msg_type() != *message_type {

--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -10,7 +10,7 @@ extern crate load_file;
 
 use crate::parser::sv2_messages::ReplaceField;
 use binary_sv2::{Deserialize, Serialize};
-use codec_sv2::StandardEitherFrame as EitherFrame;
+use codec_sv2::StandardFrame as EitherFrame;
 use external_commands::*;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use rand::Rng;
@@ -451,7 +451,7 @@ mod test {
         into_static::into_static,
         net::{setup_as_downstream, setup_as_upstream},
     };
-    use codec_sv2::{Frame, Sv2Frame};
+    use codec_sv2::Sv2Frame;
     use roles_logic_sv2::{
         mining_sv2::{
             CloseChannel, NewExtendedMiningJob, OpenExtendedMiningChannel,
@@ -657,10 +657,14 @@ mod test {
         let client_received = client_recv.recv().await.unwrap();
         match (server_received, client_received) {
             (EitherFrame::Sv2(mut frame1), EitherFrame::Sv2(mut frame2)) => {
-                let mt1 = frame1.get_header().unwrap().msg_type();
-                let mt2 = frame2.get_header().unwrap().msg_type();
-                let p1 = frame1.payload();
-                let p2 = frame2.payload();
+                let mt1 = frame1.header().msg_type();
+                let mt2 = frame2.header().msg_type();
+                let p1 = frame1.payload().unwrap();
+                let mut p1 = p1.to_owned();
+                let p1 = p1.as_mut();
+                let p2 = frame2.payload().unwrap();
+                let mut p2 = p2.to_owned();
+                let p2 = p2.as_mut();
                 let message1: Mining = (mt1, p1).try_into().unwrap();
                 let message2: Mining = (mt2, p2).try_into().unwrap();
                 match (message1, message2) {

--- a/utils/message-generator/src/net.rs
+++ b/utils/message-generator/src/net.rs
@@ -1,7 +1,7 @@
 use crate::{os_command, Command};
 use async_channel::{bounded, Receiver, Sender};
 use binary_sv2::{Deserialize, GetSize, Serialize};
-use codec_sv2::{HandshakeRole, Initiator, Responder, StandardEitherFrame as EitherFrame};
+use codec_sv2::{HandshakeRole, Initiator, Responder, StandardFrame as EitherFrame};
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use network_helpers_sv2::{
     noise_connection_tokio::Connection, plain_connection_tokio::PlainConnection,

--- a/utils/message-generator/src/parser/actions.rs
+++ b/utils/message-generator/src/parser/actions.rs
@@ -1,5 +1,5 @@
 use crate::{Action, ActionResult, Role, SaveField, Sv1Action, Sv1ActionResult, Sv2Type};
-use codec_sv2::{buffer_sv2::Slice, StandardEitherFrame, Sv2Frame};
+use codec_sv2::{buffer_sv2::Slice, StandardFrame, Sv2Frame};
 use roles_logic_sv2::parsers::AnyMessage;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
@@ -35,7 +35,7 @@ impl Sv2ActionParser {
                         panic!("Frame id not found: {} Impossible to parse action", id)
                     })
                     .clone();
-                let frame = StandardEitherFrame::Sv2(frame);
+                let frame = StandardFrame::Sv2(frame);
                 let message = messages.get(id.as_str().unwrap());
                 let message = message
                     .unwrap_or_else(|| {

--- a/utils/message-generator/src/parser/frames.rs
+++ b/utils/message-generator/src/parser/frames.rs
@@ -1,5 +1,5 @@
 use super::sv2_messages::{message_from_path, ReplaceField};
-use codec_sv2::{buffer_sv2::Slice, Frame as _Frame, Sv2Frame};
+use codec_sv2::{buffer_sv2::Slice, Sv2Frame};
 use roles_logic_sv2::parsers::AnyMessage;
 use serde_json::{Map, Value};
 use std::{collections::HashMap, convert::TryInto};


### PR DESCRIPTION
relates to #903 

This commit aims to refactor the `framing-sv2` crate. List of changes:
0. Cleand up `header.rs`
1. Removed `Frame` trait
2. Changed `EitherFrame` enum to `Frame`
3. Removed unused functions from `HandShakeFrame` and `Sv2Frame`
4. Added documentation where missing
5. Made sure there is consistency in function naming in `Frame`, i.e, in
   order to get the header you call `Frame::header`, for payload
   `Frame::payload` and so on.
6. Made sure we dont return mut data from `Frame` get functions(leave it
   to the caller to decide).
7. Fixed all the modules in `protocols` based on the above changes
8. Fixed all the modules in `roles` based on the above changes

For 7 & 8 its mainly removing the `Frame` trait import plus naming fixes
where I renamed `StandardEitherFrame` to `StandardFrame` and other name
fixes and also fixing the `header` and `payload` calls to align with the
new API.