### PR TITLE
Add missing messages errors  constructors

### DIFF
--- a/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
@@ -1,9 +1,9 @@
+use alloc::string::ToString;
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::binary_codec_sv2;
 use binary_sv2::{Deserialize, Seq0255, Serialize, Str0255, B0255, B064K, U256};
-#[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
 /// # SetCustomMiningJob (Client -> Server)
@@ -135,11 +135,35 @@ impl<'a> SetCustomMiningJob<'a> {
         panic!("This function shouldn't be called by the Message Generator");
     }
 }
-#[cfg(feature = "with_serde")]
 impl<'a> SetCustomMiningJobError<'a> {
+    pub fn new_invalid_channel_id(channel_id: u32, request_id: u32) -> Self {
+        Self {
+            channel_id,
+            request_id,
+            error_code: "invalid-channel-id".to_string().try_into().unwrap(),
+        }
+    }
+    pub fn new_invalid_mining_job_token(channel_id: u32, request_id: u32) -> Self {
+        Self {
+            channel_id,
+            request_id,
+            error_code: "invalid-mining-job-token".to_string().try_into().unwrap(),
+        }
+    }
+    pub fn new_invalid_job_param_value(channel_id: u32, request_id: u32, field_name: &str) -> Self {
+        Self {
+            channel_id,
+            request_id,
+            error_code: format!("invalid-job-param-value-{}", field_name)
+                .try_into()
+                .unwrap(),
+        }
+    }
+    #[cfg(feature = "with_serde")]
     pub fn into_static(self) -> SetCustomMiningJobError<'static> {
         panic!("This function shouldn't be called by the Message Generator");
     }
+    #[cfg(feature = "with_serde")]
     pub fn as_static(&self) -> SetCustomMiningJobError<'static> {
         panic!("This function shouldn't be called by the Message Generator");
     }

--- a/protocols/v2/subprotocols/mining/src/update_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/update_channel.rs
@@ -1,9 +1,9 @@
+use alloc::string::ToString;
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::binary_codec_sv2;
 use binary_sv2::{Deserialize, Serialize, Str0255, U256};
-#[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
 /// # UpdateChannel (Client -> Server)
@@ -67,11 +67,25 @@ impl<'a> UpdateChannel<'a> {
         panic!("This function shouldn't be called by the Message Generator");
     }
 }
-#[cfg(feature = "with_serde")]
+
 impl<'a> UpdateChannelError<'a> {
+    pub fn new_max_target_out_of_range(channel_id: u32) -> Self {
+        Self {
+            channel_id,
+            error_code: "max-target-out-of-range".to_string().try_into().unwrap(),
+        }
+    }
+    pub fn invalid_channel_id(channel_id: u32) -> Self {
+        Self {
+            channel_id,
+            error_code: "invalid-channel-id".to_string().try_into().unwrap(),
+        }
+    }
+    #[cfg(feature = "with_serde")]
     pub fn into_static(self) -> UpdateChannelError<'static> {
         panic!("This function shouldn't be called by the Message Generator");
     }
+    #[cfg(feature = "with_serde")]
     pub fn as_static(&self) -> UpdateChannelError<'static> {
         panic!("This function shouldn't be called by the Message Generator");
     }

--- a/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
@@ -1,3 +1,4 @@
+use alloc::string::ToString;
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]
@@ -5,7 +6,6 @@ use binary_sv2::binary_codec_sv2::{self, free_vec, free_vec_2, CVec, CVec2};
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::Error;
 use binary_sv2::{Deserialize, Seq064K, Serialize, Str0255, B016M, B064K};
-#[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
 
 /// ## RequestTransactionData (Client -> Server)
@@ -120,6 +120,21 @@ pub struct RequestTransactionDataError<'decoder> {
     /// * template-id-not-found
     #[cfg_attr(feature = "with_serde", serde(borrow))]
     pub error_code: Str0255<'decoder>,
+}
+
+impl<'a> RequestTransactionDataError<'a> {
+    pub fn new_template_id_not_found(template_id: u64) -> Self {
+        Self {
+            template_id,
+            error_code: "template-id-not-found".to_string().try_into().unwrap(),
+        }
+    }
+    pub fn new_stale_template_id(template_id: u64) -> Self {
+        Self {
+            template_id,
+            error_code: "stale-template-id".to_string().try_into().unwrap(),
+        }
+    }
 }
 
 #[repr(C)]


### PR DESCRIPTION
This PR implement some missing messages errors 'constructor' in order to have all errors types from specs implemented.


