### PR TITLE
`Framing` crate refactor: cleanup `header.rs` and remove `Frame` trait

### DIFF
--- a/benches/benches/src/sv2/criterion_sv2_benchmark.rs
+++ b/benches/benches/src/sv2/criterion_sv2_benchmark.rs
@@ -1,4 +1,4 @@
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use criterion::{black_box, Criterion};
 use roles_logic_sv2::{
     handlers::{common::ParseUpstreamCommonMessages, mining::ParseUpstreamMiningMessages},

--- a/benches/benches/src/sv2/iai_sv2_benchmark.rs
+++ b/benches/benches/src/sv2/iai_sv2_benchmark.rs
@@ -1,4 +1,4 @@
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use iai::{black_box, main};
 use roles_logic_sv2::{
     handlers::{common::ParseUpstreamCommonMessages, mining::ParseUpstreamMiningMessages, SendTo_},

--- a/examples/interop-cpp/src/main.rs
+++ b/examples/interop-cpp/src/main.rs
@@ -12,7 +12,7 @@ mod main_ {
 
 #[cfg(not(feature = "with_serde"))]
 mod main_ {
-    use codec_sv2::{Encoder, Frame, StandardDecoder, StandardSv2Frame};
+    use codec_sv2::{Encoder, StandardDecoder, StandardSv2Frame};
     use common_messages_sv2::{Protocol, SetupConnection, SetupConnectionError};
     use const_sv2::{
         CHANNEL_BIT_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION,

--- a/examples/ping-pong-with-noise/src/node.rs
+++ b/examples/ping-pong-with-noise/src/node.rs
@@ -11,7 +11,7 @@ use async_std::{
 };
 use core::convert::TryInto;
 
-use codec_sv2::{Frame, HandshakeRole, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, StandardEitherFrame, StandardSv2Frame};
 
 use std::time;
 

--- a/examples/ping-pong-without-noise/src/node.rs
+++ b/examples/ping-pong-without-noise/src/node.rs
@@ -10,7 +10,7 @@ use async_std::{
     task,
 };
 
-use codec_sv2::{Frame, StandardDecoder, StandardSv2Frame};
+use codec_sv2::{StandardDecoder, StandardSv2Frame};
 
 #[derive(Debug)]
 enum Expected {

--- a/examples/template-provider-test/src/main.rs
+++ b/examples/template-provider-test/src/main.rs
@@ -1,6 +1,6 @@
 use async_channel::{Receiver, Sender};
 use async_std::net::TcpStream;
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame, Sv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame, Sv2Frame};
 use network_helpers::PlainConnection;
 use roles_logic_sv2::{
     parsers::{IsSv2Message, TemplateDistribution},

--- a/protocols/fuzz-tests/src/main.rs
+++ b/protocols/fuzz-tests/src/main.rs
@@ -2,7 +2,7 @@
 use libfuzzer_sys::fuzz_target;
 use binary_codec_sv2::{Seq064K,U256,B0255,Seq0255};
 use binary_codec_sv2::from_bytes;
-use codec_sv2::{StandardDecoder,Sv2Frame,Frame};
+use codec_sv2::{StandardDecoder,Sv2Frame};
 use roles_logic_sv2::parsers::PoolMessages;
 
 type F = Sv2Frame<PoolMessages<'static>,Vec<u8>>;

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -12,7 +12,7 @@ use framing_sv2::framing2::HandShakeFrame;
 #[cfg(feature = "noise_sv2")]
 use framing_sv2::header::{NOISE_HEADER_ENCRYPTED_SIZE, NOISE_HEADER_SIZE};
 use framing_sv2::{
-    framing2::{EitherFrame, Frame as F_, Sv2Frame},
+    framing2::{EitherFrame, Sv2Frame},
     header::Header,
 };
 #[cfg(feature = "noise_sv2")]

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -5,9 +5,9 @@ pub use const_sv2::{AEAD_MAC_LEN, SV2_FRAME_CHUNK_SIZE, SV2_FRAME_HEADER_SIZE};
 #[cfg(feature = "noise_sv2")]
 use core::convert::TryInto;
 use core::marker::PhantomData;
+use framing_sv2::framing2::Sv2Frame;
 #[cfg(feature = "noise_sv2")]
 use framing_sv2::framing2::{EitherFrame, HandShakeFrame};
-use framing_sv2::framing2::{Frame as F_, Sv2Frame};
 #[allow(unused_imports)]
 pub use framing_sv2::header::NOISE_HEADER_ENCRYPTED_SIZE;
 

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 use framing_sv2::framing2::{EitherFrame, HandShakeFrame};
 use framing_sv2::framing2::{Frame as F_, Sv2Frame};
 #[allow(unused_imports)]
-pub use framing_sv2::header::NoiseHeader;
+pub use framing_sv2::header::NOISE_HEADER_ENCRYPTED_SIZE;
 
 #[cfg(feature = "noise_sv2")]
 use tracing::error;
@@ -76,7 +76,7 @@ impl<T: Serialize + GetSize> NoiseEncoder<T> {
                 } else {
                     SV2_FRAME_CHUNK_SIZE + start - AEAD_MAC_LEN
                 };
-                let mut encrypted_len = NoiseHeader::SIZE;
+                let mut encrypted_len = NOISE_HEADER_ENCRYPTED_SIZE;
 
                 while start < sv2.len() {
                     let to_encrypt = self.noise_buffer.get_writable(end - start);

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -23,7 +23,7 @@ pub use encoder::NoiseEncoder;
 
 #[cfg(feature = "noise_sv2")]
 pub use framing_sv2::framing2::HandShakeFrame;
-pub use framing_sv2::framing2::{Frame, Sv2Frame};
+pub use framing_sv2::framing2::Sv2Frame;
 
 #[cfg(feature = "noise_sv2")]
 pub use noise_sv2::{self, Initiator, NoiseCodec, Responder};

--- a/protocols/v2/framing-sv2/src/error.rs
+++ b/protocols/v2/framing-sv2/src/error.rs
@@ -24,8 +24,13 @@ impl fmt::Display for Error {
             ExpectedSv2Frame => {
                 write!(f, "Expected `Sv2Frame`, received `HandshakeFrame`")
             }
-            UnexpectedHeaderLength(i) => {
-                write!(f, "Unexpected `Header` length: `{}`", i)
+            UnexpectedHeaderLength(actual_size) => {
+                write!(
+                    f,
+                    "Unexpected `Header` length: `{}`, should be equal or more to {}",
+                    actual_size,
+                    const_sv2::SV2_FRAME_HEADER_SIZE
+                )
             }
         }
     }

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::{
     header::{Header, NOISE_HEADER_LEN_OFFSET, NOISE_HEADER_SIZE},
     Error,
@@ -29,51 +30,6 @@ impl<A, B> Sv2Frame<A, B> {
     }
 }
 
-pub trait Frame<'a, T: Serialize + GetSize>: Sized {
-    type Buffer: AsMut<[u8]>;
-    type Deserialized;
-
-    /// Write the serialized `Frame` into `dst`.
-    fn serialize(self, dst: &mut [u8]) -> Result<(), Error>;
-
-    /// Get the payload
-    fn payload(&'a mut self) -> &'a mut [u8];
-
-    /// Returns `Some(self.header)` when the frame has a header (`Sv2Frame`), returns `None` where it doesn't (`HandShakeFrame`).
-    fn get_header(&self) -> Option<crate::header::Header>;
-
-    /// Try to build a `Frame` from raw bytes.
-    /// Checks if the payload has the correct size (as stated in the `Header`).
-    /// Returns `Self` on success, or the number of the bytes needed to complete the frame
-    /// as an error. Nothing is assumed or checked about the correctness of the payload.
-    fn from_bytes(bytes: Self::Buffer) -> Result<Self, isize>;
-
-    /// Builds a `Frame` from raw bytes.
-    /// Does not check if the payload has the correct size (as stated in the `Header`).
-    /// Nothing is assumed or checked about the correctness of the payload.
-    fn from_bytes_unchecked(bytes: Self::Buffer) -> Self;
-
-    /// Helps to determine if the frame size encoded in a byte array correctly representing the size of the frame.
-    /// - Returns `0` if the byte slice is of the expected size according to the header.
-    /// - Returns a negative value if the byte slice is smaller than a Noise Frame header; this value
-    ///   represents how many bytes are missing.
-    /// - Returns a positive value if the byte slice is longer than expected; this value
-    ///   indicates the surplus of bytes beyond the expected size.
-    fn size_hint(bytes: &[u8]) -> isize;
-
-    /// Returns the size of the `Frame` payload.
-    fn encoded_length(&self) -> usize;
-
-    /// Try to build a `Frame` from a serializable payload.
-    /// Returns `Some(Self)` if the size of the payload fits in the frame, `None` otherwise.
-    fn from_message(
-        message: T,
-        message_type: u8,
-        extension_type: u16,
-        channel_msg: bool,
-    ) -> Option<Self>;
-}
-
 /// Abstraction for a SV2 Frame.
 #[derive(Debug, Clone)]
 pub struct Sv2Frame<T, B> {
@@ -98,15 +54,12 @@ impl HandShakeFrame {
     }
 }
 
-impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for Sv2Frame<T, B> {
-    type Buffer = B;
-    type Deserialized = B;
-
+impl<T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Sv2Frame<T, B> {
     /// Write the serialized `Sv2Frame` into `dst`.
     /// This operation when called on an already serialized frame is very cheap.
     /// When called on a non serialized frame, it is not so cheap (because it serializes it).
     #[inline]
-    fn serialize(self, dst: &mut [u8]) -> Result<(), Error> {
+    pub fn serialize(self, dst: &mut [u8]) -> Result<(), Error> {
         if let Some(mut serialized) = self.serialized {
             dst.swap_with_slice(serialized.as_mut());
             Ok(())
@@ -132,7 +85,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     /// This function is only intended as a fast way to get a reference to an
     /// already serialized payload. If the frame has not yet been
     /// serialized, this function should never be used (it will panic).
-    fn payload(&'a mut self) -> &'a mut [u8] {
+    pub fn payload(&mut self) -> &mut [u8] {
         if let Some(serialized) = self.serialized.as_mut() {
             &mut serialized.as_mut()[Header::SIZE..]
         } else {
@@ -142,7 +95,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     }
 
     /// `Sv2Frame` always returns `Some(self.header)`.
-    fn get_header(&self) -> Option<crate::header::Header> {
+    pub fn get_header(&self) -> Option<crate::header::Header> {
         Some(self.header)
     }
 
@@ -150,7 +103,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     /// Returns a `Sv2Frame` on success, or the number of the bytes needed to complete the frame
     /// as an error. `Self.serialized` is `Some`, but nothing is assumed or checked about the correctness of the payload.
     #[inline]
-    fn from_bytes(mut bytes: Self::Buffer) -> Result<Self, isize> {
+    pub fn from_bytes(mut bytes: B) -> Result<Self, isize> {
         let hint = Self::size_hint(bytes.as_mut());
 
         if hint == 0 {
@@ -161,7 +114,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     }
 
     #[inline]
-    fn from_bytes_unchecked(mut bytes: Self::Buffer) -> Self {
+    pub fn from_bytes_unchecked(mut bytes: B) -> Self {
         // Unchecked function caller is supposed to already know that the passed bytes are valid
         let header = Header::from_bytes(bytes.as_mut()).expect("Invalid header");
         Self {
@@ -179,7 +132,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     /// - Returns a positive value if the byte slice is longer than expected; this value
     ///   indicates the surplus of bytes beyond the expected size.
     #[inline]
-    fn size_hint(bytes: &[u8]) -> isize {
+    pub fn size_hint(bytes: &[u8]) -> isize {
         match Header::from_bytes(bytes) {
             Err(_) => {
                 // Returns how many bytes are missing from the expected frame size
@@ -200,7 +153,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     /// If `Sv2Frame` is serialized, returns the length of `self.serialized`,
     /// otherwise, returns the length of `self.payload`.
     #[inline]
-    fn encoded_length(&self) -> usize {
+    pub fn encoded_length(&self) -> usize {
         if let Some(serialized) = self.serialized.as_ref() {
             serialized.as_ref().len()
         } else if let Some(payload) = self.payload.as_ref() {
@@ -213,7 +166,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
 
     /// Tries to build a `Sv2Frame` from a non-serialized payload.
     /// Returns a `Sv2Frame` if the size of the payload fits in the frame, `None` otherwise.
-    fn from_message(
+    pub fn from_message(
         message: T,
         message_type: u8,
         extension_type: u16,
@@ -229,10 +182,7 @@ impl<'a, T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Frame<'a, T> for 
     }
 }
 
-impl<'a> Frame<'a, Slice> for HandShakeFrame {
-    type Buffer = Slice;
-    type Deserialized = &'a mut [u8];
-
+impl HandShakeFrame {
     /// Put the Noise Frame payload into `dst`
     #[inline]
     fn serialize(mut self, dst: &mut [u8]) -> Result<(), Error> {
@@ -242,7 +192,7 @@ impl<'a> Frame<'a, Slice> for HandShakeFrame {
 
     /// Get the Noise Frame payload
     #[inline]
-    fn payload(&'a mut self) -> &'a mut [u8] {
+    fn payload(&mut self) -> &mut [u8] {
         &mut self.payload[NOISE_HEADER_SIZE..]
     }
 
@@ -252,12 +202,12 @@ impl<'a> Frame<'a, Slice> for HandShakeFrame {
     }
 
     /// Builds a `HandShakeFrame` from raw bytes. Nothing is assumed or checked about the correctness of the payload.
-    fn from_bytes(bytes: Self::Buffer) -> Result<Self, isize> {
+    pub fn from_bytes(bytes: Slice) -> Result<Self, isize> {
         Ok(Self::from_bytes_unchecked(bytes))
     }
 
     #[inline]
-    fn from_bytes_unchecked(bytes: Self::Buffer) -> Self {
+    pub fn from_bytes_unchecked(bytes: Slice) -> Self {
         Self { payload: bytes }
     }
 

--- a/protocols/v2/framing-sv2/src/framing2.rs
+++ b/protocols/v2/framing-sv2/src/framing2.rs
@@ -1,5 +1,5 @@
 use crate::{
-    header::{Header, NoiseHeader},
+    header::{Header, NOISE_HEADER_LEN_OFFSET, NOISE_HEADER_SIZE},
     Error,
 };
 use alloc::vec::Vec;
@@ -81,16 +81,6 @@ pub struct Sv2Frame<T, B> {
     payload: Option<T>,
     /// Serialized header + payload
     serialized: Option<B>,
-}
-
-impl<T, B> Default for Sv2Frame<T, B> {
-    fn default() -> Self {
-        Sv2Frame {
-            header: Header::default(),
-            payload: None,
-            serialized: None,
-        }
-    }
 }
 
 /// Abstraction for a Noise Handshake Frame
@@ -253,7 +243,7 @@ impl<'a> Frame<'a, Slice> for HandShakeFrame {
     /// Get the Noise Frame payload
     #[inline]
     fn payload(&'a mut self) -> &'a mut [u8] {
-        &mut self.payload[NoiseHeader::HEADER_SIZE..]
+        &mut self.payload[NOISE_HEADER_SIZE..]
     }
 
     /// `HandShakeFrame` always returns `None`.
@@ -280,17 +270,17 @@ impl<'a> Frame<'a, Slice> for HandShakeFrame {
     ///   indicates the surplus of bytes beyond the expected size.
     #[inline]
     fn size_hint(bytes: &[u8]) -> isize {
-        if bytes.len() < NoiseHeader::HEADER_SIZE {
-            return (NoiseHeader::HEADER_SIZE - bytes.len()) as isize;
+        if bytes.len() < NOISE_HEADER_SIZE {
+            return (NOISE_HEADER_SIZE - bytes.len()) as isize;
         };
 
-        let len_b = &bytes[NoiseHeader::LEN_OFFSET..NoiseHeader::HEADER_SIZE];
+        let len_b = &bytes[NOISE_HEADER_LEN_OFFSET..NOISE_HEADER_SIZE];
         let expected_len = u16::from_le_bytes([len_b[0], len_b[1]]) as usize;
 
-        if bytes.len() - NoiseHeader::HEADER_SIZE == expected_len {
+        if bytes.len() - NOISE_HEADER_SIZE == expected_len {
             0
         } else {
-            expected_len as isize - (bytes.len() - NoiseHeader::HEADER_SIZE) as isize
+            expected_len as isize - (bytes.len() - NOISE_HEADER_SIZE) as isize
         }
     }
 

--- a/protocols/v2/framing-sv2/src/header.rs
+++ b/protocols/v2/framing-sv2/src/header.rs
@@ -7,68 +7,65 @@ use binary_sv2::{Deserialize, Serialize, U24};
 use const_sv2::{AEAD_MAC_LEN, SV2_FRAME_CHUNK_SIZE};
 use core::convert::TryInto;
 
+// Previously `NoiseHeader::SIZE`
+pub const NOISE_HEADER_ENCRYPTED_SIZE: usize = const_sv2::ENCRYPTED_SV2_FRAME_HEADER_SIZE;
+// Previously `NoiseHeader::LEN_OFFSET`
+pub const NOISE_HEADER_LEN_OFFSET: usize = const_sv2::NOISE_FRAME_HEADER_LEN_OFFSET;
+// Previously `NoiseHeader::HEADER_SIZE`
+pub const NOISE_HEADER_SIZE: usize = const_sv2::NOISE_FRAME_HEADER_SIZE;
+
 /// Abstraction for a SV2 Frame Header.
 #[derive(Debug, Serialize, Deserialize, Copy, Clone)]
 pub struct Header {
-    extension_type: u16, // TODO use specific type?
-    msg_type: u8,        // TODO use specific type?
+    /// Unique identifier of the extension describing this protocol message.  Most significant bit
+    /// (i.e.bit 15, 0-indexed, aka channel_msg) indicates a message which is specific to a channel,
+    /// whereas if the most significant bit is unset, the message is to be interpreted by the
+    /// immediate receiving device.  Note that the channel_msg bit is ignored in the extension
+    /// lookup, i.e.an extension_type of 0x8ABC is for the same "extension" as 0x0ABC.  If the
+    /// channel_msg bit is set, the first four bytes of the payload field is a U32 representing the
+    /// channel_id this message is destined for. Note that for the Job Declaration and Template
+    /// Distribution Protocols the channel_msg bit is always unset.
+    extension_type: u16, // fix: use U16 type
+    /// Unique identifier of the extension describing this protocol message
+    msg_type: u8, // fix: use specific type?
+    /// Length of the protocol message, not including this header
     msg_length: U24,
 }
 
-impl Default for Header {
-    fn default() -> Self {
-        Header {
-            extension_type: 0,
-            msg_type: 0,
-            // converting 0_32 into a U24 never panic
-            msg_length: 0_u32.try_into().unwrap(),
-        }
-    }
-}
-
 impl Header {
-    pub const LEN_OFFSET: usize = const_sv2::SV2_FRAME_HEADER_LEN_OFFSET;
-    pub const LEN_SIZE: usize = const_sv2::SV2_FRAME_HEADER_LEN_END;
-    pub const LEN_END: usize = Self::LEN_OFFSET + Self::LEN_SIZE;
-
     pub const SIZE: usize = const_sv2::SV2_FRAME_HEADER_SIZE;
 
-    /// Construct a `Header` from ray bytes
+    /// Construct a `Header` from raw bytes
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < Self::SIZE {
-            return Err(Error::UnexpectedHeaderLength(
-                (Self::SIZE - bytes.len()) as isize,
-            ));
+            return Err(Error::UnexpectedHeaderLength(bytes.len() as isize));
         };
-
         let extension_type = u16::from_le_bytes([bytes[0], bytes[1]]);
         let msg_type = bytes[2];
-        let msg_length = u32::from_le_bytes([bytes[3], bytes[4], bytes[5], 0]);
-
+        let msg_length: U24 = u32::from_le_bytes([bytes[3], bytes[4], bytes[5], 0]).try_into()?;
         Ok(Self {
             extension_type,
             msg_type,
-            // Converting and u32 with the most significant byte set to 0 to and U24 never panic
-            msg_length: msg_length.try_into().unwrap(),
+            msg_length,
         })
     }
 
     /// Get the payload length
     #[allow(clippy::len_without_is_empty)]
     #[inline]
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         let inner: u32 = self.msg_length.into();
         inner as usize
     }
 
     /// Construct a `Header` from payload length, type and extension type.
     #[inline]
-    pub fn from_len(len: u32, message_type: u8, extension_type: u16) -> Option<Header> {
+    pub(crate) fn from_len(msg_length: u32, msg_type: u8, extension_type: u16) -> Option<Header> {
         Some(Self {
             extension_type,
-            msg_type: message_type,
-            msg_length: len.try_into().ok()?,
+            msg_type,
+            msg_length: msg_length.try_into().ok()?,
         })
     }
 
@@ -83,9 +80,11 @@ impl Header {
     }
 
     /// Check if `Header` represents a channel message
+    ///
+    /// A header can represent a channel message if the MSB(Most Significant Bit) is set.
     pub fn channel_msg(&self) -> bool {
-        let mask = 0b0000_0000_0000_0001;
-        self.extension_type & mask == self.extension_type
+        const CHANNEL_MSG_MASK: u16 = 0b0000_0000_0000_0001;
+        self.extension_type & CHANNEL_MSG_MASK == self.extension_type
     }
 
     /// Calculate the length of the encrypted `Header`
@@ -100,10 +99,33 @@ impl Header {
     }
 }
 
-pub struct NoiseHeader {}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
 
-impl NoiseHeader {
-    pub const SIZE: usize = const_sv2::ENCRYPTED_SV2_FRAME_HEADER_SIZE;
-    pub const LEN_OFFSET: usize = const_sv2::NOISE_FRAME_HEADER_LEN_OFFSET;
-    pub const HEADER_SIZE: usize = const_sv2::NOISE_FRAME_HEADER_SIZE;
+    #[test]
+    fn test_header_from_bytes() {
+        let bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        let header = Header::from_bytes(&bytes).unwrap();
+        assert_eq!(header.extension_type, 0x0201);
+        assert_eq!(header.msg_type, 0x03);
+        assert_eq!(header.msg_length, 0x060504_u32.try_into().unwrap());
+    }
+
+    #[test]
+    fn test_header_from_len() {
+        let header = Header::from_len(0x1234, 0x56, 0x789a).unwrap();
+        assert_eq!(header.extension_type, 0x789a);
+        assert_eq!(header.msg_type, 0x56);
+        assert_eq!(header.msg_length, 0x1234_u32.try_into().unwrap());
+
+        let extension_type = 0;
+        let msg_type = 0x1;
+        let msg_length = 0x1234_u32;
+        let header = Header::from_len(msg_length, msg_type, extension_type).unwrap();
+        assert_eq!(header.extension_type, 0);
+        assert_eq!(header.msg_type, 0x1);
+        assert_eq!(header.msg_length, 0x1234_u32.try_into().unwrap());
+    }
 }

--- a/protocols/v2/roles-logic-sv2/src/parsers.rs
+++ b/protocols/v2/roles-logic-sv2/src/parsers.rs
@@ -13,7 +13,7 @@ use binary_sv2::GetSize;
 
 use binary_sv2::{from_bytes, Deserialize};
 
-use framing_sv2::framing2::{Frame, Sv2Frame};
+use framing_sv2::framing2::Sv2Frame;
 
 use const_sv2::{
     CHANNEL_BIT_ALLOCATE_MINING_JOB_TOKEN, CHANNEL_BIT_ALLOCATE_MINING_JOB_TOKEN_SUCCESS,

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use codec_sv2::{Encoder, Frame, StandardDecoder, StandardSv2Frame};
+use codec_sv2::{Encoder, StandardDecoder, StandardSv2Frame};
 use common_messages_sv2::{
     CSetupConnection, CSetupConnectionError, ChannelEndpointChanged, SetupConnection,
     SetupConnectionError, SetupConnectionSuccess,

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -21,7 +21,7 @@ use roles_logic_sv2::{
 };
 use tracing::{debug, error, info, warn};
 
-use codec_sv2::{Frame, HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 
 use stratum_common::bitcoin::{consensus::Decodable, TxOut};

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -17,7 +17,6 @@ use tokio::task::AbortHandle;
 use tracing::{error, info};
 
 use async_recursion::async_recursion;
-use codec_sv2::Frame;
 use nohash_hasher::BuildNoHashHasher;
 use roles_logic_sv2::{
     handlers::job_declaration::ParseServerJobDeclarationMessages,

--- a/roles/jd-client/src/lib/job_declarator/setup_connection.rs
+++ b/roles/jd-client/src/lib/job_declarator/setup_connection.rs
@@ -1,5 +1,5 @@
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     handlers::common::{ParseUpstreamCommonMessages, SendTo},

--- a/roles/jd-client/src/lib/template_receiver/mod.rs
+++ b/roles/jd-client/src/lib/template_receiver/mod.rs
@@ -1,6 +1,6 @@
 use super::{job_declarator::JobDeclarator, status, PoolChangerTrigger};
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/jd-client/src/lib/template_receiver/setup_connection.rs
+++ b/roles/jd-client/src/lib/template_receiver/setup_connection.rs
@@ -1,5 +1,5 @@
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     handlers::common::{ParseUpstreamCommonMessages, SendTo},

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -11,7 +11,7 @@ use super::super::{
 };
 use async_channel::{Receiver, Sender};
 use binary_sv2::{Seq0255, U256};
-use codec_sv2::{Frame, HandshakeRole, Initiator};
+use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -2,7 +2,7 @@ pub mod message_handler;
 use super::{error::JdsError, mempool::JDsMempool, status, Configuration, EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};
 use binary_sv2::{B0255, U256};
-use codec_sv2::{Frame, HandshakeRole, Responder};
+use codec_sv2::{HandshakeRole, Responder};
 use error_handling::handle_result;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey, SignatureService};
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/mining-proxy/src/lib/downstream_mining.rs
@@ -17,7 +17,7 @@ use roles_logic_sv2::{
 };
 use tracing::info;
 
-use codec_sv2::{Frame, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 
 pub type Message = MiningDeviceMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -6,7 +6,7 @@ use roles_logic_sv2::utils::Id;
 use super::downstream_mining::{Channel, DownstreamMiningNode, StdFrame as DownstreamFrame};
 use async_channel::{Receiver, SendError, Sender};
 use async_recursion::async_recursion;
-use codec_sv2::{Frame, HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
 use network_helpers_sv2::noise_connection_tokio::Connection;
 use nohash_hasher::BuildNoHashHasher;
 use roles_logic_sv2::{

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use async_channel::{Receiver, Sender};
 use binary_sv2::U256;
-use codec_sv2::{Frame, HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
 use error_handling::handle_result;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey, SignatureService};
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/pool/src/lib/mining_pool/setup_connection.rs
@@ -3,7 +3,6 @@ use super::super::{
     mining_pool::{EitherFrame, StdFrame},
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::Frame;
 use roles_logic_sv2::{
     common_messages_sv2::{
         has_requires_std_job, has_version_rolling, has_work_selection, SetupConnection,

--- a/roles/pool/src/lib/template_receiver/mod.rs
+++ b/roles/pool/src/lib/template_receiver/mod.rs
@@ -4,7 +4,7 @@ use super::{
     status,
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Frame, HandshakeRole, Initiator};
+use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection_tokio::Connection;

--- a/roles/pool/src/lib/template_receiver/setup_connection.rs
+++ b/roles/pool/src/lib/template_receiver/setup_connection.rs
@@ -3,7 +3,6 @@ use super::super::{
     mining_pool::{EitherFrame, StdFrame},
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::Frame;
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     errors::Error,

--- a/roles/test-utils/mining-device/src/main.rs
+++ b/roles/test-utils/mining-device/src/main.rs
@@ -110,7 +110,7 @@ async fn main() {
 
 use async_channel::{Receiver, Sender};
 use binary_sv2::u256_from_int;
-use codec_sv2::{Frame, Initiator, StandardEitherFrame, StandardSv2Frame};
+use codec_sv2::{Initiator, StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess},
     common_properties::{IsMiningUpstream, IsUpstream},

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -11,7 +11,7 @@ use crate::{
 use async_channel::{Receiver, Sender};
 use async_std::{net::TcpStream, task};
 use binary_sv2::u256_from_int;
-use codec_sv2::{Frame, HandshakeRole, Initiator};
+use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::Connection;

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use async_channel::{Receiver, Sender};
 use binary_sv2::Serialize;
-use codec_sv2::{Frame, StandardEitherFrame as EitherFrame, Sv2Frame};
+use codec_sv2::{StandardEitherFrame as EitherFrame, Sv2Frame};
 use roles_logic_sv2::parsers::{self, AnyMessage};
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
 

--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -451,7 +451,7 @@ mod test {
         into_static::into_static,
         net::{setup_as_downstream, setup_as_upstream},
     };
-    use codec_sv2::{Frame, Sv2Frame};
+    use codec_sv2::Sv2Frame;
     use roles_logic_sv2::{
         mining_sv2::{
             CloseChannel, NewExtendedMiningJob, OpenExtendedMiningChannel,

--- a/utils/message-generator/src/parser/frames.rs
+++ b/utils/message-generator/src/parser/frames.rs
@@ -1,5 +1,5 @@
 use super::sv2_messages::{message_from_path, ReplaceField};
-use codec_sv2::{buffer_sv2::Slice, Frame as _Frame, Sv2Frame};
+use codec_sv2::{buffer_sv2::Slice, Sv2Frame};
 use roles_logic_sv2::parsers::AnyMessage;
 use serde_json::{Map, Value};
 use std::{collections::HashMap, convert::TryInto};


### PR DESCRIPTION
I am breaking #969 into smaller PRs because its touching too many parts of the code and doing it all in a single PR could result in endless conflicts and make it also hard to review. 

In this part the `header.rs` file is tied up with a few things removed and replaced by constants and adding docs. the second commit removes the `Frame` trait and adjust the code accordingly. 

Partially resolves #903 