### PR TITLE
Redefining lastDeclareJob 

### DIFF
--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -32,8 +32,8 @@ pub type EitherFrame = StandardEitherFrame<Message>;
 
 /// 1 to 1 connection with a downstream node that implement the mining (sub)protocol can be either
 /// a mining device or a downstream proxy.
-/// A downstream can only be linked with an upstream at a time. Support multi upstrems for
-/// downstream do no make much sense.
+/// A downstream can only be linked with an upstream at a time. Support multi upstreams for
+/// downstream do not make much sense.
 #[derive(Debug)]
 pub struct DownstreamMiningNode {
     receiver: Receiver<EitherFrame>,
@@ -181,7 +181,7 @@ impl DownstreamMiningNode {
         }
     }
 
-    /// Send SetupConnectionSuccess to donwstream and start processing new messages coming from
+    /// Send SetupConnectionSuccess to downstream and start processing new messages coming from
     /// downstream
     pub async fn start(
         self_mutex: &Arc<Mutex<Self>>,
@@ -225,7 +225,7 @@ impl DownstreamMiningNode {
     // mining channel success
     fn set_channel_factory(self_mutex: Arc<Mutex<Self>>) {
         if !self_mutex.safe_lock(|s| s.status.is_solo_miner()).unwrap() {
-            // Safe unwrap already checked if it contains an upstream withe `is_solo_miner`
+            // Safe unwrap already checked if it contains an upstream with `is_solo_miner`
             let upstream = self_mutex
                 .safe_lock(|s| s.status.get_upstream().unwrap())
                 .unwrap();

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -146,6 +146,10 @@ impl JobDeclarator {
             .unwrap()
     }
 
+    /// We maintain a window of 2 jobs. If more than 2 blocks are found,
+    /// the ordering will depend on the request ID. Only the 2 most recent request
+    /// IDs will be kept in memory, while the rest will be discarded.
+    /// More information can be found here: https://github.com/stratum-mining/stratum/pull/904#discussion_r1609469048
     fn update_last_declare_job_sent(
         self_mutex: &Arc<Mutex<Self>>,
         request_id: u32,

--- a/roles/jd-client/src/lib/mod.rs
+++ b/roles/jd-client/src/lib/mod.rs
@@ -15,7 +15,7 @@ use std::{sync::atomic::AtomicBool, time::Duration};
 /// In the meantime if the context that is running the template receiver receives a SetNewPrevHash
 /// it wait until the value of this global is true before doing anything.
 ///
-/// Acuire and Release memory ordering is used.
+/// Acquire and Release memory ordering is used.
 ///
 /// Memory Ordering Explanation:
 /// We use Acquire-Release ordering instead of SeqCst or Relaxed for the following reasons:

--- a/roles/jd-client/src/main.rs
+++ b/roles/jd-client/src/main.rs
@@ -46,12 +46,12 @@ fn process_cli_args<'a>() -> ProxyResult<'a, ProxyConfig> {
 /// TODO on setupconnection with bitcoind (TP) JDC must signal that want a tx short hash list with
 /// the templates
 ///
-/// TODO JDC must handle TxShortHahhList message
+/// TODO JDC must handle TxShortHashList message
 ///
 /// This will start:
 /// 1. An Upstream, this will connect with the mining Pool
 /// 2. A listner that will wait for a mining downstream with ExtendedChannel capabilities (tproxy,
-///    minin-proxy)
+///    mining-proxy)
 /// 3. A JobDeclarator, this will connect with the job-declarator-server
 /// 4. A TemplateRx, this will connect with bitcoind
 ///
@@ -78,15 +78,15 @@ fn process_cli_args<'a>() -> ProxyResult<'a, ProxyConfig> {
 /// Then we receive CommitMiningJobSuccess and we use the new token to send SetCustomMiningJob to
 /// the pool.
 /// When we receive SetCustomMiningJobSuccess we set in Upstream job_id equal to the one received
-/// in SetCustomMiningJobSuccess so that we sill send shares upstream with the right job_id.
+/// in SetCustomMiningJobSuccess so that we still send shares upstream with the right job_id.
 ///
 /// The above procedure, let us send NewExtendedMiningJob downstream right after a NewTemplate has
 /// been received this will reduce the time that pass from a NewTemplate and the mining-device
 /// starting to mine on the new job.
 ///
 /// In the case a future NewTemplate the SetCustomMiningJob is sent only if the canditate become
-/// the actual NewTemplate so that we do not send a lot of usless future Job to the pool. That
-/// means that SetCustomMiningJob is sent only when a NewTemplate becom "active"
+/// the actual NewTemplate so that we do not send a lot of useless future Job to the pool. That
+/// means that SetCustomMiningJob is sent only when a NewTemplate become "active"
 ///
 /// The JobDeclarator always have 2 avaiable token, that means that whenever a token is used to
 /// commit a job with upstream we require a new one. Having always a token when needed means that
@@ -217,7 +217,7 @@ async fn initialize_jd_as_solo_miner(
     };
     let miner_tx_out = lib::proxy_config::get_coinbase_output(&proxy_config).unwrap();
 
-    // When Downstream receive a share that meets bitcoin target it transformit in a
+    // When Downstream receive a share that meets bitcoin target it transform it in a
     // SubmitSolution and send it to the TemplateReceiver
     let (send_solution, recv_solution) = bounded(10);
 
@@ -290,7 +290,7 @@ async fn initialize_jd(
         port,
     );
 
-    // When Downstream receive a share that meets bitcoin target it transformit in a
+    // When Downstream receive a share that meets bitcoin target it transform it in a
     // SubmitSolution and send it to the TemplateReceiver
     let (send_solution, recv_solution) = bounded(10);
 


### PR DESCRIPTION
The PR is opened to address the suggested changes by @Fi3 on PR #904. The comments are as follows:

- [Better management of LastDeclareJobs - no more wrong fallback-system activations #904 (comment)](https://github.com/stratum-mining/stratum/pull/904#discussion_r1609437598): Panic in safe lock state not advisable.
- [Better management of LastDeclareJobs - no more wrong fallback-system activations #904 (comment)](https://github.com/stratum-mining/stratum/pull/904#discussion_r1609469048): We are now using an array of size 2, as there should not be more than 2 Request id with corresponding jobs at any given point. If an anomaly arises, the process will error out.