### PR TITLE
add `ActionResult::SustainConnection` to MG

### DIFF
--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -191,6 +191,7 @@ enum ActionResult {
     MatchMessageLen(usize),
     MatchExtensionType(u16),
     CloseConnection,
+    SustainConnection,
     None,
 }
 
@@ -225,6 +226,7 @@ impl std::fmt::Display for ActionResult {
                 write!(f, "MatchExtensionType: {}", extension_type)
             }
             ActionResult::CloseConnection => write!(f, "Close connection"),
+            ActionResult::SustainConnection => write!(f, "Sustain connection"),
             ActionResult::GetMessageField {
                 subprotocol,
                 fields,

--- a/utils/message-generator/src/parser/actions.rs
+++ b/utils/message-generator/src/parser/actions.rs
@@ -91,6 +91,7 @@ impl Sv2ActionParser {
                     "close_connection" => {
                         action_results.push(ActionResult::CloseConnection);
                     }
+                    "sustain_connection" => action_results.push(ActionResult::SustainConnection),
                     "none" => {
                         action_results.push(ActionResult::None);
                     }


### PR DESCRIPTION
close #1023 and unblock #1025 

this allows for MG to verify that a connection was not closed

it also refactors some parts of `Executor::execute` by moving some logic to the arms of `match result`, which improves code readability