### PR TITLE
doc: Document Seq064K

### DIFF
--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -95,6 +95,15 @@ impl<'a, T: GetSize> GetSize for Seq0255<'a, T> {
     }
 }
 
+/// Fixed size data sequence up to a length of 65535
+///
+/// Byte Length Calculation:
+/// - For fixed-size T: 2 + LENGTH * size_of::<T>()
+/// - For variable-length T: 2 + seq.map(|x| x.length()).sum()
+/// Decsription: 2-byte length L, unsigned little-endian integer 16-bits, followed by a sequence of L elements of type T. Allowed range of length is 0 to 65535.
+///
+/// Used for listing channel ids, tx short hashes, tx hashes, list indexes, and full transaction data.
+///
 /// The liftime is here only for type compatibility with serde-sv2
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Seq064K<'a, T>(pub(crate) Vec<T>, PhantomData<&'a T>);

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
@@ -9,6 +9,7 @@ use crate::{
 use alloc::vec::Vec;
 use serde::{ser, ser::SerializeTuple, Deserialize, Deserializer, Serialize};
 
+/// See `binary_sv2::Seq064k`
 #[derive(Debug, Clone)]
 pub struct Seq064K<'s, T: Clone + Serialize + TryFromBSlice<'s>> {
     seq: Option<Seq<'s, T>>,


### PR DESCRIPTION
Takes specific of bytes, types and sizes from the specification. Lists some use cases for this struct.

Work toward: #1011