### PR TITLE
Fix JDC fallback to solo-mining

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
 ]
@@ -497,7 +497,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "codec_sv2"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1564,7 +1564,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "sv1_api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",

--- a/roles/jd-client/src/lib/template_receiver/mod.rs
+++ b/roles/jd-client/src/lib/template_receiver/mod.rs
@@ -57,9 +57,16 @@ impl TemplateRx {
         test_only_do_not_send_solution_to_tp: bool,
     ) {
         let mut encoded_outputs = vec![];
-        miner_coinbase_outputs
-            .consensus_encode(&mut encoded_outputs)
-            .expect("Invalid coinbase output in config");
+        // jd is set to None in initialize_jd_as_solo_miner (in this case we need to take the first output as done by JDS)
+        if jd.is_none() {
+            miner_coinbase_outputs[0]
+                .consensus_encode(&mut encoded_outputs)
+                .expect("Invalid coinbase output in config");
+        } else {
+            miner_coinbase_outputs
+                .consensus_encode(&mut encoded_outputs)
+                .expect("Invalid coinbase output in config");
+        }
         let stream = tokio::net::TcpStream::connect(address).await.unwrap();
 
         let initiator = match authority_public_key {


### PR DESCRIPTION
If the JDC switches to solo_mining, then it initializes as solo mining (using `initialize_jd_as_solo_miner`).
This function initialize a `DownstreamMiningNode` with `jd` field set to `None`. This is the right behaviour, but makes panic this [unwrap](https://github.com/stratum-mining/stratum/blob/dev/roles/jd-client/src/lib/downstream.rs#L379).
Since we are doing solo mining, it should be care of the downstream to change the coinbase downstream, instead of wrapping a None, the `coinbase_tx_prefix` and `suffix` are ignored. 

Perhaps this is not the best way to do that, feedback needed.

In the commit message is writtend how to test this PR.

This PR  is on top of [PR1001](https://github.com/stratum-mining/stratum/pull/1001).
This PR closes [issue 844](https://github.com/stratum-mining/stratum/issues/844)

How to test this PR:
The testing environment is very similar to the one described on PR1001. The only difference is that here we do not have a "good" pool to fallback into. So apply suggestions on PR1001 with the only difference that the jdc config is 
```toml
[[upstreams]]
authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
pool_address = "127.0.0.1:44254"
jd_address = "127.0.0.1:34264"
pool_signature = "Stratum v2 SRI Pool"
```
(you can avoid running a "good" pool then)

EDIT: the MG test is removed