### PR TITLE
add `Aggregate MG Test Results` job to MG CI 

### DIFF
--- a/.github/workflows/mg.yaml
+++ b/.github/workflows/mg.yaml
@@ -158,3 +158,28 @@ jobs:
         uses: actions/checkout@v4
       - name: Run translation-proxy-old-share
         run: sh ./test/message-generator/test/translation-proxy-old-share/translation-proxy-old-share.sh
+
+  mg-aggregate-results:
+    name: "Aggregate MG Test Results"
+    runs-on: ubuntu-latest
+    needs:
+      - bad-pool-config-test
+      - interop-jd-translator
+      - interop-proxy-with-multi-ups
+      - interop-proxy-with-multi-ups-extended
+      - jds-do-not-fail-on-wrong-tsdatasucc
+      - jds-do-not-panic-if-jdc-close-connection
+      - jds-do-not-stackoverflow-when-no-token
+      - pool-sri-test-1-standard
+      - pool-sri-test-close-channel
+      - pool-sri-test-extended_0
+      - pool-sri-test-extended_1
+      - pool-sri-test-reject-auth
+      - standard-coverage
+      - sv1-test
+      - translation-proxy-broke-pool
+      - translation-proxy
+      - translation-proxy-old-share
+    steps:
+      - name: Aggregate MG Test Results
+        run: echo "All MG tests completed successfully"


### PR DESCRIPTION
Github only allows branch protection rules based on specific CI jobs. So we are adding a new job that just takes all the other MG test jobs as a prerequisite, so we can use this as an umbrella rule for branch protection.

when some MG test fails:
![image](https://github.com/user-attachments/assets/e1ba19d1-236c-49e6-99ca-5b880d1bf4c8)

when all MG tests pass:
![image](https://github.com/user-attachments/assets/f792f922-b335-475b-baf4-dad60682cf93)
