### PR TITLE
WaitUntil feature on MG

### DIFF
--- a/test/message-generator/test/translation-proxy/translation-proxy.json
+++ b/test/message-generator/test/translation-proxy/translation-proxy.json
@@ -147,10 +147,11 @@
             "results": [
                 {
                     "type": "match_message_type",
-                    "value": "0x1b"
+                    "value": "0x1b",
+                    "condition": {"WaitUntil": {"WaitUntilConfig": {"timeout": 120, "allowed_messages": ["0x1b", "0x16"] } } }
                 }
             ],
-            "actiondoc": "Sends NewExtendedMiningJob and SetNewPrevHash and waits that a SubmitsShareExtended is submitted" 
+            "actiondoc": "Sends NewExtendedMiningJob and SetNewPrevHash and waits until a SubmitsShareExtended is submitted. Allowed messages: SubmitSharesExtended, UpdateChannel" 
         }
     ],
     "setup_commands": [

--- a/utils/message-generator/README.md
+++ b/utils/message-generator/README.md
@@ -255,6 +255,26 @@ message will be the abbreviated with `setup_connection_success_template_distribu
     ]
 }
 ```
+For the result `MatchMessageType` there is the optional feature `WaitUntil`. The sintax is like this
+```json
+ "results": [
+     {
+         "type": "match_message_type",
+         "value": "0x1b",
+         "condition": {"WaitUntil": {"WaitUntilConfig": {"timeout": 120, "allowed_messages": ["0x1b", "0x16"] } } }
+     }
+ ],
+```
+This action will have the following behaviour:
+1. Checks all the messages that arrive.
+   The `allowed_messages` describe the message types that are allowed, i.e. `0x1b` and `0x16`.
+   If arrives one message that has a different type, the test will fail. This is needed for making
+   the MG a finite state machine.
+2. THe test will listen all the allowed messages until the target message is received. In the
+   previous case, the target message has type `0x1b`.
+3. A timeout that indicates when the test is considered to be failed. This is used in the case that
+   the MG received only messages of allowed type, but hasn't received the target message for a long
+   time, making the MG test stuck.
 
 If the test version is "1", each object is composed by:
 1. `messages_ids`: an array of strings, that are ids of sv1_messages previously defined.


### PR DESCRIPTION
fix to issue [1059](https://github.com/stratum-mining/stratum/issues/1059).
To see a description of the changes apported to this PR, look at the commit message and the README changes.
The feature introduced is backward compatible, as it is introduced optionally.

How to test it:

easy way. look at `translation-proxy.json` MG test. YOu can see that it is launched TProxy. Go the config used and change it in order that the `channel_nominal_hashrate` is few magnitude order higher than the `min_individual_miner_hashrate`. This forces the channel to be updated (possibly more than once) and an `UpdateChannel`. Then you should see `RECEIVED 22, WAITING MESSAGE TYPE 27` several times (i.e. `UpdateChannel`) and finally `MATCHED WAITED  MESSAGE TYPE 27`, namely `SubmitSharesExtended`, resulting in success of the MG test. Reducing the `miner_num_submits_before_update` to 1 may help testing. The hashrates depend on your hardware, on my PC this worked
```toml
min_individual_miner_hashrate=1000000.0
channel_nominal_hashrate = 50000000000.0

```

hard way. test PR [1001](https://github.com/stratum-mining/stratum/pull/1001): checkit out and rebase it on top of the current PR.  Then test it following instructions in the two top commits. Finally change this [MG-test](https://github.com/lorbax/stratum/blob/translator-restart-if-disconnected-from-upstream/test/message-generator/test/change-upstream/change-upstream.json) with the following
```json
{
    "version": "2",
    "doc": [
        "This test does",
        "Acts like a pool that refuses share with JobDeclatarion",
        "Waits for SetupConnection",
        "Sends a SetupConnection.Success and waits that a SetCustomMiningJob is received",
        "Sends a SetCustomMiningJob.Success and waits that UpdateChannel is received",
        "Waits that SubmitShare is received",
        "Responds with SubmitShare.Error"
    ],
    "frame_builders": [
        {
            "type": "automatic",
            "message_id": "test/message-generator/messages/mining_messages.json::open_extended_mining_channel_success"
        },
        {
            "type": "automatic",
            "message_id": "test/message-generator/messages/common_messages.json::setup_connection_success_tproxy"
        },
        {
            "type": "automatic",
            "message_id": "test/message-generator/messages/mining_messages.json::set_custom_mining_job_success"
        },
        {
            "type": "automatic",
            "message_id": "test/message-generator/messages/mining_messages.json::submit_shares_error"
        }
    ],
    "actions": [
       {
            "message_ids": [],
            "role": "server",
            "results": [
                {
                    "type": "match_message_type",
                    "value": "0x00"
                }
            ],
            "actiondoc": "This action checks that a Setupconnection message is received"
        },
        {
            "message_ids": ["setup_connection_success_tproxy"],
            "role": "server",
            "results": [
                {
                    "type": "match_message_type",
                    "value": "0x13"
                }
            ],
          "actiondoc": "This action sends SetupConnection.Success and check that a OpenExtendedfMiningChannel is received"
        },
        {
            "message_ids": ["open_extended_mining_channel_success"],
            "role": "server",
            "results": [
                {
                    "type": "get_message_field",
                    "value": [
                        "MiningProtocol",
                        "SetCustomMiningJob",
                        [
                            [
                                "request_id",
                                "custom_job_req_id"
                            ]
                        ]
                    ]
                }
            ],
          "actiondoc": "This action sends open_extended_mining_channel_success, and a wait for a SetCustomMiningJoband get the req id"
        },
        {
            "message_ids": [],
            "role": "server",
            "results": [
                {
                    "type": "match_message_type",
                    "value": "0x1b",
                    "condition": {"WaitUntil": {"WaitUntilConfig": {"timeout": 120, "allowed_messages": ["0x1b", "0x16", "0x22"] } } }
                }
            ],
            "actiondoc": "This action check submit_shares is received, allowed messages: update channel, submit shares, set custom miningjob"
        },
        {
            "message_ids": ["submit_shares_error"],
            "role": "server",
            "results": [],
            "actiondoc": "This action sends a submit_shares_error"
        }
    ],
    "setup_commands": [
    ],
    "execution_commands": [
    ],
    "cleanup_commands": [
        {
            "command": "sleep",
            "args": ["100000000000"],
            "conditions": "None"
        }
    ],
    "role": "server",
    "upstream": {
        "ip": "127.0.0.1",
        "port": 44254,
        "pub_key": "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72",
        "secret_key": "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
    }
}
```