### PR TITLE
ignore `test_diff_management`

### DIFF
--- a/roles/translator/src/lib/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/lib/downstream_sv1/diff_management.rs
@@ -317,6 +317,7 @@ mod test {
 
     use crate::downstream_sv1::Downstream;
 
+    #[ignore] // as described in issue #988
     #[test]
     fn test_diff_management() {
         let expected_shares_per_minute = 1000.0;


### PR DESCRIPTION
after some failed attempts on #995, this PR disables the `test_diff_management` unit test as a temporary fix to #988

we should not close #988 until a more sustainable fix is found for the long term

we should also be extra careful when modifying `roles/translator/src/lib/downstream_sv1/diff_management.rs`