### PR TITLE
`test_diff_management`: adjust `total_run_time` to  60s

### DIFF
--- a/roles/translator/src/lib/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/lib/downstream_sv1/diff_management.rs
@@ -320,7 +320,7 @@ mod test {
     #[test]
     fn test_diff_management() {
         let expected_shares_per_minute = 1000.0;
-        let total_run_time = std::time::Duration::from_secs(30);
+        let total_run_time = std::time::Duration::from_secs(60);
         let initial_nominal_hashrate = measure_hashrate(5);
         let target = match roles_logic_sv2::utils::hash_rate_to_target(
             initial_nominal_hashrate,


### PR DESCRIPTION
we made some adjustments to `test_diff_management` via #995 , which unfortunately did not fully fix #988 

both @Fi3 and I did some investigation on this:
- https://github.com/stratum-mining/stratum/pull/995#issuecomment-2209602801
- https://github.com/stratum-mining/stratum/issues/988#issuecomment-2250316209

in summary, bigger values for `total_run_time` seems to always improve things, so this PR adjusts it to 60s in hope it will fix this once and for all

if we have to re-open #988 again after this is merged, then we should consider #1074 , which completely disables `test_diff_management` until a more sustainable fix is found