### PR TITLE
JDC parse incoming mining messages from upstream after SetupConnection

### DIFF
--- a/roles/jd-client/src/lib/mod.rs
+++ b/roles/jd-client/src/lib/mod.rs
@@ -261,12 +261,6 @@ impl JobDeclaratorClient {
             }
         };
 
-        // Start receiving messages from the SV2 Upstream role
-        if let Err(e) = upstream_sv2::Upstream::parse_incoming(upstream.clone()) {
-            error!("failed to create sv2 parser: {}", e);
-            panic!()
-        }
-
         match upstream_sv2::Upstream::setup_connection(
             upstream.clone(),
             proxy_config.min_supported_version,
@@ -279,6 +273,12 @@ impl JobDeclaratorClient {
                 error!("Failed to connect to Upstream EXITING! : {}", e);
                 panic!()
             }
+        }
+
+        // Start receiving messages from the SV2 Upstream role
+        if let Err(e) = upstream_sv2::Upstream::parse_incoming(upstream.clone()) {
+            error!("failed to create sv2 parser: {}", e);
+            panic!()
         }
 
         // Format `Downstream` connection address


### PR DESCRIPTION
fix #1079 

this PR simply reorders the sequence between `upstream_sv2::Upstream::parse_incoming` and `upstream_sv2::Upstream::setup_connection` inside `JobDeclaratorClient::initialize_jd` 

`Upstream::parse_incoming` only calls `handle_message_mining`, which is not able to handle a `SetupConnection.Success` (because it belongs to the "Common Messages" category, not "Mining Messages")