### PR TITLE
bump protocols versioning

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = { version = "1.0.64", default-features = false, features = ["alloc"
 iai="0.1"
 mining_sv2 = { path = "../protocols/v2/subprotocols/mining", version = "^1.0.0" }
 roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2", version = "^1.0.0" }
-framing_sv2 = { version = "1.1.0", path = "../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "2.0.0", path = "../protocols/v2/framing-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 num-bigint = "0.4.3"
 num-traits = "0.2.15"

--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "framing_sv2"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",

--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "const_sv2"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "secp256k1 0.28.2",
 ]

--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "codec_sv2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codec_sv2"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2 data format"

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/stratum-mining/stratum"
 
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional = true }
-framing_sv2 = { version = "1.1.0", path = "../../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
 noise_sv2 = { version = "1.0", path = "../../../protocols/v2/noise-sv2", optional=true}
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 const_sv2 = { version = "1.0.0", path = "../../../protocols/v2/const-sv2"}

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.89", default-features = false, optional = true }
 framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
 noise_sv2 = { version = "1.0", path = "../../../protocols/v2/noise-sv2", optional=true}
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
-const_sv2 = { version = "1.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "2.0.0", path = "../../../protocols/v2/const-sv2"}
 buffer_sv2 = { version = "1.0.0", path = "../../../utils/buffer"}
 tracing = { version = "0.1"}
 

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(feature = "no_std", no_std)]
 
+pub use framing_sv2::framing::Frame;
+
 extern crate alloc;
 
 #[cfg(feature = "noise_sv2")]

--- a/protocols/v2/const-sv2/Cargo.toml
+++ b/protocols/v2/const-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_sv2"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2  constatnts"

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framing_sv2"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2 frames"

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/stratum-mining/stratum"
 
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional = true }
-const_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
 binary_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../../utils/buffer", optional=true }
 

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -13,7 +13,7 @@ rand = {version = "0.8.5", default-features = false, features = ["std","std_rng"
 aes-gcm = "0.10.2"
 chacha20poly1305 = "0.10.1"
 rand_chacha = "0.3.1"
-const_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -17,7 +17,7 @@ mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^1
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }
 job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^1.0.0" }
 const_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/const-sv2"}
-framing_sv2 = { version = "^1.1.0", path = "../../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
 tracing = { version = "0.1"}
 chacha20poly1305 = { version = "0.10.1"}
 nohash-hasher = "0.2.0"

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -16,7 +16,7 @@ common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messag
 mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^1.0.0" }
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }
 job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^1.0.0" }
-const_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
 framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
 tracing = { version = "0.1"}
 chacha20poly1305 = { version = "0.10.1"}

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/stratum-mining/stratum"
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/binary-sv2" }
-const_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
+const_sv2 = {version = "^2.0.0", path = "../../../../protocols/v2/const-sv2"}
 quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
 serde_repr = {version= "0.1.10", optional=true}

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/stratum-mining/stratum"
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/binary-sv2" }
-const_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
+const_sv2 = {version = "^2.0.0", path = "../../../../protocols/v2/const-sv2"}
 
 [features]
 no_std = []

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/stratum-mining/stratum"
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/binary-sv2" }
-const_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
+const_sv2 = {version = "^2.0.0", path = "../../../../protocols/v2/const-sv2"}
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/stratum-mining/stratum"
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = { version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/binary-sv2" }
-const_sv2 = { version = "^1.0.0", path = "../../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "^2.0.0", path = "../../../../protocols/v2/const-sv2"}
 quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
 

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^1.0.0" }
-const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^1.0.0" }
+const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^2.0.0" }
 binary_sv2 = { path = "../../../protocols/v2/binary-sv2/binary-sv2", version = "^1.0.0" }
 common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^1.0.0" }
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -54,12 +54,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
-name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
@@ -317,6 +311,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +442,9 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -594,7 +602,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "codec_sv2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -629,10 +637,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_sv2"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "secp256k1 0.28.2",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -649,6 +706,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -694,6 +757,15 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -995,23 +1067,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
-dependencies = [
- "ahash 0.3.8",
- "autocfg",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -1208,6 +1276,7 @@ dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "codec_sv2",
+ "config",
  "error_handling",
  "framing_sv2",
  "futures",
@@ -1218,7 +1287,6 @@ dependencies = [
  "serde",
  "stratum-common",
  "tokio",
- "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1231,6 +1299,7 @@ dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "codec_sv2",
+ "config",
  "const_sv2",
  "error_handling",
  "hashbrown 0.11.2",
@@ -1246,7 +1315,6 @@ dependencies = [
  "serde_json",
  "stratum-common",
  "tokio",
- "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1266,6 +1334,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -1297,6 +1376,12 @@ name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1336,6 +1421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mining-device"
 version = "0.1.1"
 dependencies = [
@@ -1367,6 +1458,7 @@ dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "codec_sv2",
+ "config",
  "const_sv2",
  "futures",
  "key-utils",
@@ -1377,7 +1469,6 @@ dependencies = [
  "serde",
  "stratum-common",
  "tokio",
- "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1441,6 +1532,16 @@ dependencies = [
  "rand",
  "rand_chacha",
  "secp256k1 0.28.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1513,6 +1614,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1656,57 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pest"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1653,6 +1815,7 @@ dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "codec_sv2",
+ "config",
  "const_sv2",
  "error_handling",
  "hex",
@@ -1665,7 +1828,6 @@ dependencies = [
  "serde",
  "stratum-common",
  "tokio",
- "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1797,6 +1959,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.5.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rpc_sv2"
 version = "1.0.0"
 dependencies = [
@@ -1808,6 +1982,16 @@ dependencies = [
  "serde",
  "serde_json",
  "stratum-common",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1926,8 +2110,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "buffer_sv2",
  "serde",
@@ -2090,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "template_distribution_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -2106,6 +2299,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2326,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2160,11 +2382,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.6"
-source = "git+https://github.com/diondokter/toml-rs?rev=c4161aa#c4161aa70202b3992dbec79b76e7a8659713b604"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "hashbrown 0.7.2",
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2264,6 +2511,7 @@ dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "codec_sv2",
+ "config",
  "error_handling",
  "framing_sv2",
  "futures",
@@ -2279,7 +2527,6 @@ dependencies = [
  "sv1_api",
  "tokio",
  "tokio-util",
- "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2297,10 +2544,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "universal-hash"
@@ -2602,6 +2861,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "framing_sv2"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "sv1_api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",

--- a/roles/jd-client/Cargo.toml
+++ b/roles/jd-client/Cargo.toml
@@ -17,7 +17,7 @@ async-recursion = "0.3.2"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-framing_sv2 = { version = "^1.1.0", path = "../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^2.0.0", path = "../../protocols/v2/framing-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["with_tokio", "with_buffer_pool"] }
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }

--- a/roles/jd-server/Cargo.toml
+++ b/roles/jd-server/Cargo.toml
@@ -15,7 +15,7 @@ async-channel = "1.5.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
-const_sv2 = { version = "^1.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "^2.0.0", path = "../../protocols/v2/const-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"

--- a/roles/mining-proxy/Cargo.toml
+++ b/roles/mining-proxy/Cargo.toml
@@ -18,7 +18,7 @@ async-recursion = "0.3.2"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-const_sv2 = { version = "^1.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "^2.0.0", path = "../../protocols/v2/const-sv2" }
 futures = "0.3.19"
 network_helpers_sv2 = {version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio","with_buffer_pool"] }
 once_cell = "1.12.0"

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -16,7 +16,7 @@ async-channel = "1.5.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
-const_sv2 = { version = "^1.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "^2.0.0", path = "../../protocols/v2/const-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features =["with_tokio","with_buffer_pool"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -15,7 +15,7 @@ async-channel = { version = "1.8.0", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 binary_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2", optional = true }
 codec_sv2 = { version = "1.0.1", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"], optional = true }
-const_sv2 = {version = "1.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = {version = "2.0.0", path = "../../../protocols/v2/const-sv2"}
 serde = { version = "1.0.89", features = ["derive"], default-features = false, optional = true }
 tracing = { version = "0.1" }
 futures = "0.3.28"

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 stratum-common = { version = "1.0.0", path = "../../../common" }
 codec_sv2 = { version = "^1.0.1", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"] }
 roles_logic_sv2 = { version = "1.0.0", path = "../../../protocols/v2/roles-logic-sv2" }
-const_sv2 = { version = "1.0.0", path = "../../../protocols/v2/const-sv2" }
+const_sv2 = { version = "2.0.0", path = "../../../protocols/v2/const-sv2" }
 async-channel = "1.5.1"
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../../roles-utils/network-helpers", features=["tokio"] }

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -18,7 +18,7 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-framing_sv2 = { version = "^1.1.0", path = "../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^2.0.0", path = "../../protocols/v2/framing-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["async_std", "with_buffer_pool"] }
 once_cell = "1.12.0"
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }

--- a/utils/message-generator/Cargo.toml
+++ b/utils/message-generator/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 async-channel = "1.8.0"
 binary_sv2 = { version = "1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2", features = ["with_serde"] }
 codec_sv2 = { version = "1.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2","with_buffer_pool","with_serde"] }
-const_sv2 = { version = "1.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "2.0.0", path = "../../protocols/v2/const-sv2" }
 load_file = "1.0.1"
 network_helpers_sv2 = { version = "2.0.0", path = "../../roles/roles-utils/network-helpers", features = ["with_tokio","with_serde"] }
 roles_logic_sv2 = { version = "1.0.0", path = "../../protocols/v2/roles-logic-sv2", features = ["with_serde"] }


### PR DESCRIPTION
after merging https://github.com/stratum-mining/stratum/pull/976 we didn't properly manage versioning of `framing_sv2` + `codec_sv2` crates

this PR fixes this

hopefully this will not happen again once https://github.com/stratum-mining/stratum/pull/985 is finally merged, as it will enforce semver on both `dev` and `main` branches