### PR TITLE
bypass `cargo semver-checks --all-features` for roles_logic_sv2

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run semver checks for protocols/v2/roles-logic-sv2
         working-directory: protocols/v2/roles-logic-sv2
-        run: cargo semver-checks
+        run: cargo semver-checks --default-features
 
       - name: Run semver checks for protocols/v1
         working-directory: protocols/v1


### PR DESCRIPTION
the `framing_sv2/with_serde` flag [was added](https://github.com/stratum-mining/stratum/commit/100a331a3bcda0721835ac4f5ca17c8554df79ef) to `roles_logic_sv2` aiming to unblock the SemVer CI introduced via https://github.com/stratum-mining/stratum/pull/985

unfortunately the `with_serde` feature flag is broken for `framing_sv2`, and that is having undesired consequences on downstream crates that use `roles_logic_sv2` as dependencies

this PR allows us to can keep our SemVer CI unblocked by this problem, so that via https://github.com/stratum-mining/stratum/pull/1101 we can make sure that `roles_logic_sv2` does not include `framing_sv2/with_serde`