### PR TITLE
patch `roles_logic_sv2` `with_serde` flag

### DIFF
--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -606,7 +606,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "roles_logic_sv2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binary_sv2",
  "chacha20poly1305",

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roles_logic_sv2"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2018"
 description = "Common handlers for use within SV2 roles"
 license = "MIT OR Apache-2.0"
@@ -35,8 +35,7 @@ with_serde = [ "serde",
 "common_messages_sv2/with_serde",
 "template_distribution_sv2/with_serde",
 "job_declaration_sv2/with_serde",
-"mining_sv2/with_serde",
-"framing_sv2/with_serde"]
+"mining_sv2/with_serde"]
 prop_test = ["template_distribution_sv2/prop_test"]
 # Code coverage tools may conflict with the nopanic logic, so we can disable it when needed
 disable_nopanic = []


### PR DESCRIPTION
this `framing_sv2/with_serde` flag was added to `roles_logic_sv2` aiming to unblock the SemVer CI introduced via https://github.com/stratum-mining/stratum/pull/985

unfortunately the `with_serde` feature flag is broken for `framing_sv2`, and that is having undesired consequences on downstream crates that use `roles_logic_sv2` as dependencies

via https://github.com/stratum-mining/stratum/pull/1100 we can keep our SemVer CI unblocked by this problem, but we also need to make sure `roles_logic_sv2` does not include `framing_sv2/with_serde`

this PR is patching `roles_logic_sv2` to achieve this goal