### PR TITLE
use rust stable for semver CI

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust 1.75.0
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.75.0
+          toolchain: stable
           override: true
 
       - name: Cache Cargo registry


### PR DESCRIPTION
`cargo semver-checks` had a new release a couple hours ago: https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.34.0

this release changed MSRV of `cargo semver-checks` from `1.75` to `1.77`

currently, `semver-check.yaml` is installing `1.75`:
https://github.com/stratum-mining/stratum/blob/a09084426092a6dfef8862571bc4a0098a05e935/.github/workflows/semver-check.yaml#L21-L25

as a consequence, our entire SemVer CI is failing with:
```
Run cargo semver-checks
error: rustc version is not high enough: >=1.77.0 needed, got 1.75.0

HELP: to use the latest rustc, run `rustup update stable && cargo +stable semver-checks <args>`
```

[example](https://github.com/stratum-mining/stratum/actions/runs/10396114294/job/28789511722?pr=1102)

this PR changes `1.75` to `stable` on `semver-check.yaml`, so that we don't face this issue again in the future
