### PR TITLE
Add support for data types defined by sv2 extensions

### DIFF
--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "binary_codec_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "buffer_sv2",
  "quickcheck",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "binary_sv2"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "binary_codec_sv2",
  "derive_codec_sv2",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "derive_codec_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "binary_codec_sv2",
 ]

--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_sv2"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2 data format"

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_codec_sv2"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2 data format"

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
@@ -25,14 +25,14 @@ use std::io::{Error as E, ErrorKind};
 mod codec;
 mod datatypes;
 pub use datatypes::{
-    PubKey, Seq0255, Seq064K, ShortTxId, Signature, Str0255, Sv2Option, U32AsRef, B016M, B0255,
-    B032, B064K, U24, U256,
+    PubKey, Seq0255, Seq064K, ShortTxId, Signature, Str0255, Sv2DataType, Sv2Option, U32AsRef,
+    B016M, B0255, B032, B064K, U24, U256,
 };
 
 pub use crate::codec::{
-    decodable::Decodable,
+    decodable::{Decodable, GetMarker},
     encodable::{Encodable, EncodableField},
-    GetSize, SizeHint,
+    Fixed, GetSize, SizeHint,
 };
 
 #[allow(clippy::wrong_self_convention)]

--- a/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_codec_sv2"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Derive macro for Sv2 binary format serializer and deserializer"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -373,14 +373,14 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "binary_codec_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "buffer_sv2",
 ]
 
 [[package]]
 name = "binary_sv2"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "binary_codec_sv2",
  "derive_codec_sv2",


### PR DESCRIPTION
In no-serde-sv2 an sv2 sequence is generic over T. If we want this sequence to be Deserialize we need T to be Fixed and GerMarker. This 2 traits were private since all the sv2 types are already defined in no-serde-sv2. But if we want to use sv2 types defined in an sv2 extensions we need to make these traits public.

The Encodable dervive macro in derive_codec implement GetSize for the passed struct. But GetSize is also a blanket implementation for every type that implement Fixed. So if we implement Fixed for our new sv2 type and then we derive Encodable (commonly renamed Serialize) we get an error. This commit add an attribute to Encodable called already_sized if the struct that we want derive Encodable is market as already_sized the macro will not implement GetSize for it.

This commit also bump minor version of derive_codec and no-serde-sv2 consequentially also of binary-sv2 since it reexport the above libs.


**This PR is the minimum needed in order to use binary-sv2 with externally defined sv2 types. An improvement would be to automatically derive Fixed and GetMarker. This can be done in a successive PR to keep thing simple**