### PR TITLE
Update binary-sv2/no-serde-sv2 excport EncodablePrimitive

### DIFF
--- a/protocols/Cargo.lock
+++ b/protocols/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "binary_codec_sv2"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "buffer_sv2",
  "quickcheck",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "binary_sv2"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "binary_codec_sv2",
  "derive_codec_sv2",

--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_sv2"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2 data format"

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_codec_sv2"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["fi3 <email@email.org>"]
 edition = "2018"
 description = "Sv2 data format"

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
@@ -58,7 +58,7 @@ pub mod decodable {
 }
 
 pub mod encodable {
-    pub use crate::codec::encodable::{Encodable, EncodableField};
+    pub use crate::codec::encodable::{Encodable, EncodableField, EncodablePrimitive};
 }
 
 #[macro_use]


### PR DESCRIPTION
In order to implement Encodable (aka Serialize) for sv2 type defined by extensions EncodablePrimitive is needed.