### PR TITLE
publish libs to `crates.io` on release tags

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -11,9 +11,12 @@
 name: Release Libs
 
 on:
+  # Manually run by going to "Actions/Release" in Github and running the workflow
+  workflow_dispatch:
+  # every time a new release tag is created
   push:
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
 
 jobs:
   libs_publish:


### PR DESCRIPTION
currently, `release-libs.yaml` will publish the libs to `crates.io` every time we merge to `main`, which is the main event for releases

with the new conventions proposed in #1124, we want to avoid that, since not every merge to `main` will be a release

this PR makes `release-libs.yaml` only be able to run:
- once new release tags are added
- via manual trigger