### PR TITLE
Auto rebase workflow addition

### DIFF
--- a/.github/workflows/auto-rebase.yaml
+++ b/.github/workflows/auto-rebase.yaml
@@ -1,0 +1,82 @@
+name: Auto Rebase
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  rebase-outdated-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.AUTO_REBASE_APP_ID}}
+          private_key: ${{ secrets.AUTO_REBASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0  # Fetch full history to have the entire commit history
+
+      - name: Fetch open pull requests with label
+        run: |
+          gh auth setup-git
+          gh pr list --state open --label "ready-to-be-merged" --json number,headRepositoryOwner,headRefName --jq '.[] | "\(.number) \(.headRepositoryOwner.login) \(.headRefName)"' > pr_details.txt
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Rebase pull requests
+        run: |
+          while read pr_number pr_owner pr_branch; do
+            echo "Processing PR #$pr_number"
+
+            # Add the contributor's fork as a remote
+            git remote add contributor https://github.com/$pr_owner/$(gh repo view --json name -q '.name').git
+
+            # Fetch the contributor's branches
+            git fetch contributor
+
+            # Create a unique branch name for this PR
+            unique_branch_name="contributor-branch-$pr_number"
+
+            # Checkout the branch from the contributor's fork
+            git checkout -b $unique_branch_name contributor/$pr_branch
+
+            # Set the committer name and email to match the PR author
+            PR_AUTHOR_NAME=$(gh pr view $pr_number --json author --jq '.author.login')
+            PR_AUTHOR_EMAIL="${PR_AUTHOR_NAME}@users.noreply.github.com"
+
+            git config user.name "$PR_AUTHOR_NAME"
+            git config user.email "$PR_AUTHOR_EMAIL"
+
+            # Rebase the branch on top of the main branch
+            git fetch origin main
+            if ! git rebase origin/main; then
+              echo "Conflict detected. Aborting rebase and continuing."
+              git rebase --abort
+
+              # Post a comment on the PR to notify the author about the conflict
+              gh pr comment $pr_number --body "Hey @$PR_AUTHOR_NAME, your PR cannot be rebased due to conflicts. Could you resolve them, please?"
+
+              continue
+            fi
+
+            # Push the rebased branch back to the contributor's fork
+            git push --force-with-lease contributor $unique_branch_name:$pr_branch
+
+            # Remove the remote
+            git remote remove contributor
+
+            # Ensure we are not on the branch to be deleted
+            git checkout main
+
+            # Delete the local unique branch
+            git branch -D $unique_branch_name
+
+          done < pr_details.txt
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Goal
The goal of this PR is to better manage the situation in which every time we merge a PR against `main`, all the others become outdated, and we need to ask PR authors to rebase them. 
- This creates a bottleneck when we have more PRs ready to be merged all together, but instead we need to wait for authors to rebase and force-push. 
- We could update them by using the "Update branch" button, but that's not ideal since the authors's commits will be committed by the maintainer who updates the PR, leading to track the authors commits as "co-authored" by mainainer as well. 
- We could also update the PRs by merging `main` into PR's branch, but that's not ideal since we would add a merge commit only for this, which will be tracked in the git history forever.

### Solution
This PR adds a new workflow file which is executed every time we push something to main (so after we merge a PR).
- It looks for all opened PRs which are labeled as `ready-to-be-merged`, and automatically rebase them, without leading to the "co-authoring" issue described before.
- If a PR cannot be rebased due to some conflicts, a comment will be generated by the github action bot to tell the author of the PR to manually solve it.  
- If there's no conflict, the PR will be rebased and the relative CI will be automatically triggered again to test the most updated state of the PR

### Examples
To better understand what this PR looks like, I recommend to take a look at my fork, specifically at:
- PR [#24](https://github.com/GitGab19/stratum/pull/24) - which is the one correctly rebased
- PR [#18](https://github.com/GitGab19/stratum/pull/18#issuecomment-2320634751) - which is the one with conflicts, for which a comment has been generated by the github action