### PR TITLE
Fix bencher false alarms on CI

### DIFF
--- a/.github/workflows/run-benchmarks.yaml
+++ b/.github/workflows/run-benchmarks.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   benchmark_sv1_criterion:

--- a/.github/workflows/track-benchmarks.yaml
+++ b/.github/workflows/track-benchmarks.yaml
@@ -56,13 +56,15 @@ jobs:
             let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
             core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
-            core.exportVariable("PR_DEFAULT", prEvent.pull_request.base.repo.default_branch);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
       - uses: bencherdev/bencher@main
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --branch-start-point main \
+          --branch '${{ env.PR_HEAD }}' \
+          --branch-start-point '${{ env.PR_BASE }}' \
+          --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
           --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \
@@ -117,15 +119,17 @@ jobs:
           script: |
             let fs = require('fs');
             let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
+            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
-            core.exportVariable("PR_DEFAULT", prEvent.pull_request.base.repo.default_branch);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
       - uses: bencherdev/bencher@main
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --branch-start-point main \
+          --branch '${{ env.PR_HEAD }}' \
+          --branch-start-point '${{ env.PR_BASE }}' \
+          --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
           --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \
@@ -180,15 +184,17 @@ jobs:
           script: |
             let fs = require('fs');
             let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
+            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
-            core.exportVariable("PR_DEFAULT", prEvent.pull_request.base.repo.default_branch);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
       - uses: bencherdev/bencher@main
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --branch-start-point main \
+          --branch '${{ env.PR_HEAD }}' \
+          --branch-start-point '${{ env.PR_BASE }}' \
+          --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
           --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \
@@ -243,15 +249,17 @@ jobs:
           script: |
             let fs = require('fs');
             let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
+            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
-            core.exportVariable("PR_DEFAULT", prEvent.pull_request.base.repo.default_branch);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
       - uses: bencherdev/bencher@main
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --branch-start-point main \
+          --branch '${{ env.PR_HEAD }}' \
+          --branch-start-point '${{ env.PR_BASE }}' \
+          --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
           --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/track-benchmarks.yaml
+++ b/.github/workflows/track-benchmarks.yaml
@@ -62,9 +62,8 @@ jobs:
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --if-branch '${{ env.PR_HEAD }}' \
-          --else-if-branch '${{ env.PR_BASE }}' \
-          --else-if-branch '${{ env.PR_DEFAULT }}' \
+          --branch-start-point main \
+          --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \
           --token "${{ secrets.BENCHER_API_TOKEN }}" \
@@ -126,9 +125,8 @@ jobs:
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --if-branch '${{ env.PR_HEAD }}' \
-          --else-if-branch '${{ env.PR_BASE }}' \
-          --else-if-branch '${{ env.PR_DEFAULT }}' \
+          --branch-start-point main \
+          --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \
           --token "${{ secrets.BENCHER_API_TOKEN }}" \
@@ -190,9 +188,8 @@ jobs:
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --if-branch '${{ env.PR_HEAD }}' \
-          --else-if-branch '${{ env.PR_BASE }}' \
-          --else-if-branch '${{ env.PR_DEFAULT }}' \
+          --branch-start-point main \
+          --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \
           --token "${{ secrets.BENCHER_API_TOKEN }}" \
@@ -254,9 +251,8 @@ jobs:
       - name: Track Benchmarks with Bencher
         run: |
           bencher run \
-          --if-branch '${{ env.PR_HEAD }}' \
-          --else-if-branch '${{ env.PR_BASE }}' \
-          --else-if-branch '${{ env.PR_DEFAULT }}' \
+          --branch-start-point main \
+          --branch-reset \
           --ci-number '${{ env.PR_NUMBER }}' \
           --github-actions "${{ secrets.GITHUB_TOKEN }}" \
           --token "${{ secrets.BENCHER_API_TOKEN }}" \

--- a/benches/benches/src/sv1/criterion_sv1_benchmark.rs
+++ b/benches/benches/src/sv1/criterion_sv1_benchmark.rs
@@ -220,7 +220,7 @@ fn benchmark_submit_serialize_deserialize_handle(c: &mut Criterion, mut client: 
 
 fn main() {
     let mut criterion = Criterion::default()
-        .sample_size(50)
+        .sample_size(100)
         .measurement_time(std::time::Duration::from_secs(5));
     let client = Client::new(90);
     benchmark_get_subscribe(&mut criterion, client.clone());

--- a/benches/benches/src/sv2/criterion_sv2_benchmark.rs
+++ b/benches/benches/src/sv2/criterion_sv2_benchmark.rs
@@ -197,7 +197,7 @@ fn client_sv2_handle_message_common(c: &mut Criterion) {
 
 fn main() {
     let mut criterion = Criterion::default()
-        .sample_size(50)
+        .sample_size(100)
         .measurement_time(std::time::Duration::from_secs(5));
     client_sv2_setup_connection(&mut criterion);
     client_sv2_setup_connection_serialize(&mut criterion);


### PR DESCRIPTION
This PR updates the way branches are managed by [bencher](bencher.dev), greatly improving the possibility of getting false alarms (about performance regressions) by our CI. 
Close #1051 