### PR TITLE
use 1.75.0 toolchain on sv2-header-check.yaml

### DIFF
--- a/.github/workflows/sv2-header-check.yaml
+++ b/.github/workflows/sv2-header-check.yaml
@@ -24,7 +24,7 @@ jobs:
 
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.75.0
           override: true
       - name: Check sv2 header file is up to date with commit
         run: |


### PR DESCRIPTION
follow up to https://github.com/stratum-mining/stratum/pull/1170

`cbindgen` v0.21.0 cannot be built with Rust v1.75.0