### PR TITLE
fix `network_helpers_sv2` import on `mining_pool` mod

### DIFF
--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -402,7 +402,7 @@ impl Pool {
             debug!("New connection from {}", address);
 
             let (receiver, sender): (Receiver<EitherFrame>, Sender<EitherFrame>) =
-                network_helpers::plain_connection_tokio::PlainConnection::new(stream).await;
+                network_helpers_sv2::plain_connection_tokio::PlainConnection::new(stream).await;
 
             handle_result!(
                 status_tx,


### PR DESCRIPTION
this is breaking compilation of SRI pool with `test_only_allow_unencrypted` compilation