### PR TITLE
Enable `all-feature` flag for rust-docs

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/stratum-mining/stratum"
 [dependencies]
 bitcoin = {version="0.29.1",optional=true}
 secp256k1 = { version = "0.28.2", default-features = false, features =["alloc","rand","rand-std"] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v1/Cargo.toml
+++ b/protocols/v1/Cargo.toml
@@ -27,3 +27,6 @@ binary_sv2 = { version = "^1.0.0", path = "../v2/binary-sv2/binary-sv2"}
 [dev-dependencies]
 quickcheck = "1"
 quickcheck_macros = "1"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -26,3 +26,6 @@ core = ["binary_codec_sv2", "derive_codec_sv2"]
 with_serde = ["serde_sv2", "serde"]
 prop_test = ["binary_codec_sv2/prop_test", "derive_codec_sv2"]
 with_buffer_pool = ["binary_codec_sv2/with_buffer_pool", "derive_codec_sv2"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
@@ -22,3 +22,6 @@ no_std = []
 default = ["no_std"]
 prop_test = ["quickcheck"]
 with_buffer_pool = ["buffer_sv2"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/Cargo.toml
@@ -18,3 +18,6 @@ binary_codec_sv2 = {version = "^1.0.0", path="../codec"}
 
 [lib]
 proc-macro = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
@@ -20,3 +20,6 @@ buffer_sv2 = {version = "^1.0.0",  path = "../../../../utils/buffer"}
 
 [features]
 no_std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -20,9 +20,10 @@ const_sv2 = { version = "2.0.0", path = "../../../protocols/v2/const-sv2"}
 buffer_sv2 = { version = "1.0.0", path = "../../../utils/buffer"}
 tracing = { version = "0.1"}
 
-
-
 [features]
 with_serde = ["binary_sv2/with_serde", "serde", "framing_sv2/with_serde", "buffer_sv2/with_serde"]
 with_buffer_pool = ["framing_sv2/with_buffer_pool"]
 no_std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/const-sv2/Cargo.toml
+++ b/protocols/v2/const-sv2/Cargo.toml
@@ -21,3 +21,6 @@ secp256k1 = { version = "0.28.2", default-features = false, features =["hashes",
 
 [features]
 no_std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional = true }
 const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
@@ -24,3 +23,6 @@ buffer_sv2 = { version = "^1.0.0", path = "../../../utils/buffer", optional=true
 no_std = []
 with_serde = ["binary_sv2/with_serde", "serde", "buffer_sv2/with_serde"]
 with_buffer_pool = ["binary_sv2/with_buffer_pool", "buffer_sv2"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -22,3 +22,6 @@ const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
 [dev-dependencies]
 quickcheck = "1.0.3"
 quickcheck_macros = "1"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -44,3 +44,6 @@ with_serde = [ "serde",
 prop_test = ["template_distribution_sv2/prop_test"]
 # Code coverage tools may conflict with the nopanic logic, so we can disable it when needed
 disable_nopanic = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -25,3 +25,6 @@ serde_repr = {version= "0.1.10", optional=true}
 no_std = []
 with_serde = ["binary_sv2/with_serde", "serde", "serde_repr"]
 prop_test = ["quickcheck"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -20,3 +20,6 @@ const_sv2 = {version = "^2.0.0", path = "../../../../protocols/v2/const-sv2"}
 [features]
 no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -26,3 +26,6 @@ quickcheck_macros = "1"
 [features]
 no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -24,3 +24,6 @@ quickcheck_macros = { version = "1", optional=true }
 no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]
 prop_test = ["quickcheck"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -29,3 +29,5 @@ quickcheck_macros = "1"
 with_serde = []
 prop_test = ["binary_sv2/prop_test", "common_messages_sv2/prop_test", "template_distribution_sv2/prop_test"]
 
+[package.metadata.docs.rs]
+all-features = true

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -31,3 +31,6 @@ async_std = ["async-std", "async-channel", "binary_sv2", "codec_sv2"]
 with_tokio = ["tokio", "async-channel", "binary_sv2", "codec_sv2"]
 with_serde = ["binary_sv2/with_serde", "serde", "codec_sv2/with_serde"]
 with_buffer_pool = ["codec_sv2/with_buffer_pool"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -23,3 +23,6 @@ base64 = "0.21.5"
 hyper = { version = "1.1.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/utils/bip32-key-derivation/Cargo.toml
+++ b/utils/bip32-key-derivation/Cargo.toml
@@ -25,3 +25,6 @@ slip132 = "0.10"
 
 [dev-dependencies]
 toml = { version = "0.5.6", git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/utils/buffer/Cargo.toml
+++ b/utils/buffer/Cargo.toml
@@ -33,3 +33,6 @@ harness = false
 debug = []
 fuzz = []
 with_serde = ["serde"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/utils/error-handling/Cargo.toml
+++ b/utils/error-handling/Cargo.toml
@@ -10,3 +10,6 @@ homepage = "https://stratumprotocol.org"
 repository = "https://github.com/stratum-mining/stratum"
 license = "MIT + Apache-2.0"
 keywords = ["stratum", "mining", "bitcoin", "protocol"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/utils/key-utils/Cargo.toml
+++ b/utils/key-utils/Cargo.toml
@@ -29,3 +29,6 @@ serde = { version = "1.0.89", features = ["derive","alloc"], default-features = 
 
 [dev-dependencies]
 toml = { version = "0.5.6", git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
This PR enables the  `all-feature` flag for `rust-docs` in every published crate.
Close #1210 