### PR TITLE
enforce `no_std` for all? protocol/v2 crates

### DIFF
--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -18,7 +18,7 @@ serde_sv2 = {version = "^1.0.0", path = "../serde-sv2", optional = true}
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true }
 binary_codec_sv2 = {version = "^1.0.0", path = "../no-serde-sv2/codec", optional = true}
 derive_codec_sv2 = {version = "^1.0.0", path = "../no-serde-sv2/derive_codec", optional = true}
-tracing = {version = "0.1"}
+tracing = { version = "0.1", default-features = false }
 
 [features]
 default = ["core"]

--- a/protocols/v2/binary-sv2/binary-sv2/README.md
+++ b/protocols/v2/binary-sv2/binary-sv2/README.md
@@ -1,0 +1,3 @@
+# binary_sv2
+
+`binary_sv2` is a Rust `no_std` crate

--- a/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
@@ -39,11 +39,10 @@ pub fn u256_from_int<V: Into<u64>>(value: V) -> U256<'static> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::vec::Vec;
 
     mod test_struct {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -74,8 +73,6 @@ mod test {
 
     mod test_f32 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -106,8 +103,6 @@ mod test {
 
     mod test_b0255 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -153,8 +148,6 @@ mod test {
 
     mod test_u256 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -183,8 +176,6 @@ mod test {
 
     mod test_signature {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -213,8 +204,6 @@ mod test {
 
     mod test_b016m {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -263,8 +252,6 @@ mod test {
 
     mod test_b064k {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -296,8 +283,6 @@ mod test {
 
     mod test_seq0255_u256 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -338,8 +323,6 @@ mod test {
 
     mod test_0255_bool {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -366,8 +349,6 @@ mod test {
 
     mod test_seq0255_u16 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -394,8 +375,6 @@ mod test {
 
     mod test_seq_0255_u24 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -428,8 +407,6 @@ mod test {
 
     mod test_seqo255_u32 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -456,8 +433,6 @@ mod test {
 
     mod test_seq0255_signature {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -493,8 +468,6 @@ mod test {
 
     mod test_seq_064_u256 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -535,8 +508,6 @@ mod test {
 
     mod test_064_bool {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -571,8 +542,6 @@ mod test {
 
     mod test_se1o64k_u16 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -599,8 +568,6 @@ mod test {
 
     mod test_seq064k_u24 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -633,8 +600,6 @@ mod test {
 
     mod test_seq064k_u32 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -660,8 +625,6 @@ mod test {
     }
     mod test_seq064k_signature {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -696,8 +659,6 @@ mod test {
     }
     mod test_seq064k_b016m {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -732,7 +693,6 @@ mod test {
     }
     mod test_seq_0255_in_struct {
         use super::*;
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -759,8 +719,6 @@ mod test {
     }
     mod test_sv2_option_u256 {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -796,8 +754,6 @@ mod test {
     }
     mod test_sv2_option_none {
         use super::*;
-        #[cfg(not(feature = "with_serde"))]
-        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {

--- a/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
@@ -1,5 +1,10 @@
 // TODO unify errors from serde_sv2 and no-serde-sv2
-//
+
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
 use core::convert::TryInto;
 
 #[cfg(feature = "with_serde")]
@@ -37,6 +42,8 @@ mod test {
 
     mod test_struct {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -67,6 +74,8 @@ mod test {
 
     mod test_f32 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -97,6 +106,8 @@ mod test {
 
     mod test_b0255 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -142,6 +153,8 @@ mod test {
 
     mod test_u256 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -170,6 +183,8 @@ mod test {
 
     mod test_signature {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -198,6 +213,8 @@ mod test {
 
     mod test_b016m {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -246,6 +263,8 @@ mod test {
 
     mod test_b064k {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -277,6 +296,8 @@ mod test {
 
     mod test_seq0255_u256 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -317,6 +338,8 @@ mod test {
 
     mod test_0255_bool {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -343,6 +366,8 @@ mod test {
 
     mod test_seq0255_u16 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -369,6 +394,8 @@ mod test {
 
     mod test_seq_0255_u24 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -401,6 +428,8 @@ mod test {
 
     mod test_seqo255_u32 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -427,6 +456,8 @@ mod test {
 
     mod test_seq0255_signature {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -462,6 +493,8 @@ mod test {
 
     mod test_seq_064_u256 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -502,6 +535,8 @@ mod test {
 
     mod test_064_bool {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -536,6 +571,8 @@ mod test {
 
     mod test_se1o64k_u16 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -562,6 +599,8 @@ mod test {
 
     mod test_seq064k_u24 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -594,6 +633,8 @@ mod test {
 
     mod test_seq064k_u32 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -619,6 +660,8 @@ mod test {
     }
     mod test_seq064k_signature {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -653,6 +696,8 @@ mod test {
     }
     mod test_seq064k_b016m {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -687,6 +732,7 @@ mod test {
     }
     mod test_seq_0255_in_struct {
         use super::*;
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {
@@ -713,6 +759,8 @@ mod test {
     }
     mod test_sv2_option_u256 {
         use super::*;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
         use core::convert::TryInto;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -748,7 +796,8 @@ mod test {
     }
     mod test_sv2_option_none {
         use super::*;
-        use core::convert::TryInto;
+        #[cfg(not(feature = "with_serde"))]
+        use alloc::vec::Vec;
 
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Test<'decoder> {

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/README.md
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/README.md
@@ -1,0 +1,3 @@
+# binary_codec_sv2
+
+`binary_codec_sv2` is a Rust `no_std` crate

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/decodable.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/decodable.rs
@@ -6,7 +6,7 @@ use crate::{
     Error,
 };
 use alloc::vec::Vec;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 #[cfg(not(feature = "no_std"))]
 use std::io::{Cursor, Read};
 

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/mod.rs
@@ -11,6 +11,8 @@ mod impls;
 #[cfg(feature = "with_buffer_pool")]
 use buffer_sv2::Slice;
 
+use alloc::vec::Vec;
+
 /// Return the encoded byte size or a `Decodable`
 pub trait SizeHint {
     fn size_hint(data: &[u8], offset: usize) -> Result<usize, Error>;

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/copy_data_types.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/copy_data_types.rs
@@ -1,5 +1,7 @@
 //! Copy data types
 use crate::{codec::Fixed, datatypes::Sv2DataType, Error};
+
+use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 
 #[cfg(not(feature = "no_std"))]

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/mod.rs
@@ -12,10 +12,10 @@ pub use non_copy_data_types::{
     B0255, B032, B064K, U256,
 };
 
+use alloc::vec::Vec;
+use core::convert::TryInto;
 #[cfg(not(feature = "no_std"))]
 use std::io::{Error as E, Read, Write};
-
-use std::convert::TryInto;
 
 pub trait Sv2DataType<'a>: Sized + SizeHint + GetSize + TryInto<FieldMarker> {
     fn from_bytes_(data: &'a mut [u8]) -> Result<Self, Error> {

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
@@ -4,9 +4,9 @@ use crate::{
     datatypes::Sv2DataType,
     Error,
 };
-use core::convert::TryFrom;
-use std::convert::TryInto;
 
+use alloc::vec::Vec;
+use core::convert::{TryFrom, TryInto};
 #[cfg(not(feature = "no_std"))]
 use std::io::{Error as E, Read, Write};
 

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "prop_test")]
 use quickcheck::{Arbitrary, Gen};
 
+use alloc::string::String;
+#[cfg(feature = "prop_test")]
+use alloc::vec::Vec;
+
 mod inner;
 mod seq_inner;
 
@@ -28,7 +32,6 @@ impl<'decoder> From<[u8; 32]> for U256<'decoder> {
     }
 }
 
-#[cfg(not(feature = "with_serde"))]
 #[cfg(feature = "prop_test")]
 impl<'a> U256<'a> {
     pub fn from_gen(g: &mut Gen) -> Self {
@@ -40,7 +43,6 @@ impl<'a> U256<'a> {
     }
 }
 
-#[cfg(not(feature = "with_serde"))]
 #[cfg(feature = "prop_test")]
 impl<'a> B016M<'a> {
     pub fn from_gen(g: &mut Gen) -> Self {

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -280,7 +280,7 @@ impl_into_encodable_field_for_seq!(B064K<'a>);
 impl_into_encodable_field_for_seq!(B016M<'a>);
 
 #[cfg(feature = "prop_test")]
-impl<'a, T> std::convert::TryFrom<Seq0255<'a, T>> for Vec<T> {
+impl<'a, T> core::convert::TryFrom<Seq0255<'a, T>> for Vec<T> {
     type Error = &'static str;
     fn try_from(v: Seq0255<'a, T>) -> Result<Self, Self::Error> {
         if v.0.len() > 255 {
@@ -292,7 +292,7 @@ impl<'a, T> std::convert::TryFrom<Seq0255<'a, T>> for Vec<T> {
 }
 
 #[cfg(feature = "prop_test")]
-impl<'a, T> std::convert::TryFrom<Seq064K<'a, T>> for Vec<T> {
+impl<'a, T> core::convert::TryFrom<Seq064K<'a, T>> for Vec<T> {
     type Error = &'static str;
     fn try_from(v: Seq064K<'a, T>) -> Result<Self, Self::Error> {
         if v.0.len() > 64 {

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
@@ -19,6 +19,9 @@
 //! Seq0255  <-> SEQ0_255[T]
 //! Seq064K  <-> SEQ0_64K[T]
 //! ```
+
+#![cfg_attr(feature = "no_std", no_std)]
+
 #[cfg(not(feature = "no_std"))]
 use std::io::{Error as E, ErrorKind};
 
@@ -34,6 +37,8 @@ pub use crate::codec::{
     encodable::{Encodable, EncodableField},
     Fixed, GetSize, SizeHint,
 };
+
+use alloc::vec::Vec;
 
 #[allow(clippy::wrong_self_convention)]
 pub fn to_bytes<T: Encodable + GetSize>(src: T) -> Result<Vec<u8>, Error> {
@@ -281,7 +286,7 @@ impl From<&[u8]> for CVec {
         // the std lib)
         let len = buffer.len();
         let ptr = buffer.as_mut_ptr();
-        std::mem::forget(buffer);
+        core::mem::forget(buffer);
 
         CVec {
             data: ptr,
@@ -296,7 +301,7 @@ impl From<&[u8]> for CVec {
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn cvec_from_buffer(data: *const u8, len: usize) -> CVec {
-    let input = std::slice::from_raw_parts(data, len);
+    let input = core::slice::from_raw_parts(data, len);
 
     let mut buffer: Vec<u8> = vec![0; len];
     buffer.copy_from_slice(input);
@@ -305,7 +310,7 @@ pub unsafe extern "C" fn cvec_from_buffer(data: *const u8, len: usize) -> CVec {
     // cause UB, but it may be unsound due to unclear (to me, at least) guarantees of the std lib)
     let len = buffer.len();
     let ptr = buffer.as_mut_ptr();
-    std::mem::forget(buffer);
+    core::mem::forget(buffer);
 
     CVec {
         data: ptr,
@@ -360,7 +365,7 @@ impl<'a, const A: bool, const B: usize, const C: usize, const D: usize>
                 let len = inner.len();
                 let cap = inner.capacity();
                 let ptr = inner.as_mut_ptr();
-                std::mem::forget(inner);
+                core::mem::forget(inner);
 
                 (ptr, len, cap)
             }
@@ -371,7 +376,7 @@ impl<'a, const A: bool, const B: usize, const C: usize, const D: usize>
                 let len = inner.len();
                 let cap = inner.capacity();
                 let ptr = inner.as_mut_ptr();
-                std::mem::forget(inner);
+                core::mem::forget(inner);
 
                 (ptr, len, cap)
             }
@@ -393,7 +398,7 @@ pub unsafe extern "C" fn init_cvec2() -> CVec2 {
     // cause UB, but it may be unsound due to unclear (to me, at least) guarantees of the std lib)
     let len = buffer.len();
     let ptr = buffer.as_mut_ptr();
-    std::mem::forget(buffer);
+    core::mem::forget(buffer);
 
     CVec2 {
         data: ptr,
@@ -412,7 +417,7 @@ pub unsafe extern "C" fn cvec2_push(cvec2: &mut CVec2, cvec: CVec) {
 
     let len = buffer.len();
     let ptr = buffer.as_mut_ptr();
-    std::mem::forget(buffer);
+    core::mem::forget(buffer);
 
     cvec2.data = ptr;
     cvec2.len = len;
@@ -428,7 +433,7 @@ impl<'a, T: Into<CVec>> From<Seq0255<'a, T>> for CVec2 {
         let len = v.len();
         let capacity = v.capacity();
         let data = v.as_mut_ptr();
-        std::mem::forget(v);
+        core::mem::forget(v);
         Self {
             data,
             len,
@@ -445,7 +450,7 @@ impl<'a, T: Into<CVec>> From<Seq064K<'a, T>> for CVec2 {
         let len = v.len();
         let capacity = v.capacity();
         let data = v.as_mut_ptr();
-        std::mem::forget(v);
+        core::mem::forget(v);
         Self {
             data,
             len,

--- a/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/README.md
+++ b/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/README.md
@@ -1,0 +1,3 @@
+# derive_codec_sv2
+
+`derive_codec_sv2` is a Rust `no_std` crate

--- a/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/src/lib.rs
@@ -1,4 +1,13 @@
+#![no_std]
+
+extern crate alloc;
 extern crate proc_macro;
+
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::iter::FromIterator;
 use proc_macro::{Group, TokenStream, TokenTree};
 

--- a/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
@@ -18,8 +18,5 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 buffer_sv2 = {version = "^1.0.0",  path = "../../../../utils/buffer"}
 
-[features]
-no_std = []
-
 [package.metadata.docs.rs]
 all-features = true

--- a/protocols/v2/binary-sv2/serde-sv2/README.md
+++ b/protocols/v2/binary-sv2/serde-sv2/README.md
@@ -1,0 +1,3 @@
+# serde_sv2
+
+`serde_sv2` is a Rust `no_std` crate

--- a/protocols/v2/binary-sv2/serde-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/lib.rs
@@ -75,7 +75,7 @@
 //! [rkyv1]: https://docs.rs/rkyv/0.4.3/rkyv
 //! [rkyv2]: https://davidkoloski.me/blog/rkyv-is-faster-than/
 
-#![cfg_attr(feature = "no_std", no_std)]
+#![no_std]
 
 #[macro_use]
 extern crate alloc;

--- a/protocols/v2/const-sv2/Cargo.toml
+++ b/protocols/v2/const-sv2/Cargo.toml
@@ -13,8 +13,5 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-no_std = []
-
 [package.metadata.docs.rs]
 all-features = true

--- a/protocols/v2/const-sv2/README.md
+++ b/protocols/v2/const-sv2/README.md
@@ -5,7 +5,7 @@
 [![rustc+](https://img.shields.io/badge/rustc-1.75.0%2B-lightgrey.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
 [![license](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/stratum-mining/stratum/blob/main/LICENSE.md)
 
-`const_sv2` is a Rust crate that provides essential constants for the Sv2 (Stratum V2) protocol. These constants are crucial for message framing, encryption, and protocol-specific identifiers across various Sv2 components, including Mining, Job Declaration, and Template Distribution protocols.
+`const_sv2` is a Rust `no_std` crate that provides essential constants for the Sv2 (Stratum V2) protocol. These constants are crucial for message framing, encryption, and protocol-specific identifiers across various Sv2 components, including Mining, Job Declaration, and Template Distribution protocols.
 
 ## Key Capabilities
 

--- a/protocols/v2/const-sv2/src/lib.rs
+++ b/protocols/v2/const-sv2/src/lib.rs
@@ -36,7 +36,7 @@
 //! `channel_id`. In this case, the first 4 bytes of the payload represent the
 //! `channel_id` the message is destined for.
 
-#![cfg_attr(feature = "no_std", no_std)]
+#![no_std]
 
 /// Identifier for the extension_type field in the SV2 frame, indicating no
 /// extensions.

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -20,8 +20,7 @@ binary_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/bina
 buffer_sv2 = { version = "^1.0.0", path = "../../../utils/buffer", optional=true }
 
 [features]
-no_std = []
-with_serde = ["binary_sv2/with_serde", "serde", "buffer_sv2/with_serde"]
+with_serde = ["binary_sv2/with_serde", "serde", "buffer_sv2?/with_serde"]
 with_buffer_pool = ["binary_sv2/with_buffer_pool", "buffer_sv2"]
 
 [package.metadata.docs.rs]

--- a/protocols/v2/framing-sv2/README.md
+++ b/protocols/v2/framing-sv2/README.md
@@ -1,0 +1,3 @@
+# framing_sv2
+
+`framing_sv2` is a Rust `no_std` crate

--- a/protocols/v2/framing-sv2/src/lib.rs
+++ b/protocols/v2/framing-sv2/src/lib.rs
@@ -23,7 +23,8 @@
 //! The `with_serde` feature flag is only used for the Message Generator, and deprecated for any
 //! other kind of usage. It will likely be fully deprecated in the future.
 
-#![cfg_attr(feature = "no_std", no_std)]
+#![no_std]
+
 extern crate alloc;
 
 /// SV2 framing types

--- a/utils/buffer/src/buffer_pool/mod.rs
+++ b/utils/buffer/src/buffer_pool/mod.rs
@@ -606,7 +606,7 @@ impl<T: Buffer> Buffer for BufferPool<T> {
                     "{} {} {}",
                     self.inner_memory.raw_offset, self.inner_memory.raw_len, self.inner_memory.len
                 );
-                let mut res = self.inner_memory.get_data_owned(shared_state, mode);
+                let res = self.inner_memory.get_data_owned(shared_state, mode);
                 self.pool_back
                     .set_len_from_inner_memory(self.inner_memory.len);
                 println!(
@@ -684,7 +684,7 @@ impl<T: Buffer> Buffer for BufferPool<T> {
 impl<T: Buffer> Drop for BufferPool<T> {
     fn drop(&mut self) {
         while self.shared_state.load(Ordering::Relaxed) != 0 {
-            std::hint::spin_loop();
+            core::hint::spin_loop();
         }
     }
 }

--- a/utils/buffer/src/lib.rs
+++ b/utils/buffer/src/lib.rs
@@ -1,4 +1,4 @@
-//#![cfg_attr(not(feature = "debug"), no_std)]
+#![cfg_attr(not(feature = "debug"), no_std)]
 //#![feature(backtrace)]
 
 mod buffer;


### PR DESCRIPTION
Most of protocol/v2 crates are almost `no_std`, as listed [here](https://github.com/stratum-mining/stratum/issues/1130#issuecomment-2438642786).

Having a lib crate that can be `no_std` or `std` by the selection of a feature :
```rust
#![cfg_attr(not(feature = "std"), no_std)]
```
or the current implementation :
```rust
#![cfg_attr(feature = "no_std", no_std)]
```
is only usefull if :
- the crate could use some `std` related dependency (for instance `std::vec::Vec`)
- but we want the crate's user to be able to not have a dependancy on `std` so we disable the functionalities using `std`

In some case we can replace the `std` dep by its `alloc` equivalent if exists (`alloc::vec::Vec`) and we can keep the functionality in `no_std` environement.

Finally, a `std` binary can use some `no_std` dependencies, but an `no_std` binary cannot use any `std` deps. So making the low level crates all `no_std` will make them copamtible for every kind of binary (app).

We should use the `std` feature only if some functionality requires `std` and not have any `no_std` equivalent.

As far as I tried all protocol/v2/ crates (libs) can be 100% `no_std` a,d does not need the `std` (or `no_std`) feature to optionally add `std` dep.

This PR is targeting to get rid of `std` dep without loosing any functionality or efficiency.

Note: I will make 1 commit per crate to explain what and how I am doing it.
Note2: being `no_alloc` is another level of complexity for deep embedded system, which is not at all this PR concern.
