### PR TITLE
Propose an implementation of `noise_sv2` with optional `no_std`

### DIFF
--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -12,13 +12,24 @@ homepage = "https://stratumprotocol.org"
 keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
-secp256k1 = { version = "0.28.2", default-features = false, features =["hashes", "alloc","rand","rand-std"] }
-rand = {version = "0.8.5", default-features = false, features = ["std","std_rng"] }
+secp256k1 = { version = "0.28.2", default-features = false, features = ["hashes", "alloc", "rand"] }
+rand = {version = "0.8.5", default-features = false }
 aes-gcm = "0.10.2"
 chacha20poly1305 = "0.10.1"
-rand_chacha = "0.3.1"
+rand_chacha = { version = "0.3.1", default-features = false }
 const_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/const-sv2"}
+
+[features]
+default = ["std"]
+std = ["rand/std", "rand/std_rng", "rand_chacha/std", "secp256k1/rand-std"]
 
 [dev-dependencies]
 quickcheck = "1.0.3"
 quickcheck_macros = "1"
+rand = {version = "0.8.5", default-features = false, features = ["std", "std_rng"] }
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "abort"

--- a/protocols/v2/noise-sv2/README.md
+++ b/protocols/v2/noise-sv2/README.md
@@ -22,6 +22,12 @@ To include this crate in your project, run:
 cargo add noise_sv2
 ```
 
+This crate can be built with the following feature flags:
+
+- `std`: Enable usage of rust `std` library, enabled by default.
+
+In order to use this crate in a `#![no_std]` environment, use the `--no-default-features` to remove the `std` feature.
+
 ### Examples
 
 This crate provides example on establishing a secure line:

--- a/protocols/v2/noise-sv2/src/cipher_state.rs
+++ b/protocols/v2/noise-sv2/src/cipher_state.rs
@@ -33,7 +33,7 @@
 // within the Noise protocol, ensuring secure data handling, key management, and nonce tracking
 // throughout the communication session.
 
-use std::ptr;
+use core::ptr;
 
 use crate::aed_cipher::AeadCipher;
 use aes_gcm::Aes256Gcm;

--- a/protocols/v2/noise-sv2/src/error.rs
+++ b/protocols/v2/noise-sv2/src/error.rs
@@ -2,6 +2,8 @@
 //
 // Defines error types and utilities for handling errors in the `noise_sv2` module.
 
+use alloc::vec::Vec;
+
 use aes_gcm::Error as AesGcm;
 
 /// Noise protocol error handling.

--- a/protocols/v2/noise-sv2/src/initiator.rs
+++ b/protocols/v2/noise-sv2/src/initiator.rs
@@ -34,7 +34,11 @@
 // The [`Drop`] trait is implemented to automatically trigger secure erasure when the [`Initiator`]
 // instance goes out of scope, preventing potential misuse or leakage of cryptographic material.
 
-use std::{convert::TryInto, ptr};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
+use core::{convert::TryInto, ptr};
 
 use crate::{
     cipher_state::{Cipher, CipherState, GenericCipher},
@@ -93,8 +97,8 @@ pub struct Initiator {
     c2: Option<GenericCipher>,
 }
 
-impl std::fmt::Debug for Initiator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Initiator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Initiator").finish()
     }
 }
@@ -164,14 +168,31 @@ impl Initiator {
     /// If the responder public key is provided, the initiator uses this key to authenticate the
     /// responder during the handshake. The initial initiator state is instantiated with the
     /// ephemeral key pair and handshake hash.
+    #[cfg(feature = "std")]
     pub fn new(pk: Option<XOnlyPublicKey>) -> Box<Self> {
+        Self::new_with_rng(pk, &mut rand::thread_rng())
+    }
+
+    /// Creates a new [`Initiator`] instance with an optional responder public key and a custom
+    /// random number generator.
+    ///
+    /// See [`Self::new`] for more details.
+    ///
+    /// The custom random number generator is used to generate the ephemeral key pair. It should be
+    /// provided in order to not implicitely rely on `std` and allow `no_std` environments to
+    /// provide a hardware random number generator for example.
+    #[inline]
+    pub fn new_with_rng<R: rand::Rng + ?Sized>(
+        pk: Option<XOnlyPublicKey>,
+        rng: &mut R,
+    ) -> Box<Self> {
         let mut self_ = Self {
             handshake_cipher: None,
             k: None,
             n: 0,
             ck: [0; 32],
             h: [0; 32],
-            e: Self::generate_key(),
+            e: Self::generate_key_with_rng(rng),
             responder_authority_pk: pk,
             c1: None,
             c2: None,
@@ -187,10 +208,27 @@ impl Initiator {
     /// valid [`XOnlyPublicKey`], an [`Error::InvalidRawPublicKey`] error is returned.
     ///
     /// Typically used when the initiator is aware of the responder's public key in advance.
+    #[cfg(feature = "std")]
     pub fn from_raw_k(key: [u8; 32]) -> Result<Box<Self>, Error> {
+        Self::from_raw_k_with_rng(key, &mut rand::thread_rng())
+    }
+
+    /// Creates a new [`Initiator`] instance using a raw 32-byte public key and a custom random
+    /// number generator.
+    ///
+    /// See [`Self::from_raw_k`] for more details.
+    ///
+    /// The custom random number generator should be provided in order to not implicitely rely on
+    /// `std` and allow `no_std` environments to provide a hardware random number generator for
+    /// example.
+    #[inline]
+    pub fn from_raw_k_with_rng<R: rand::Rng + ?Sized>(
+        key: [u8; 32],
+        rng: &mut R,
+    ) -> Result<Box<Self>, Error> {
         let pk =
             secp256k1::XOnlyPublicKey::from_slice(&key).map_err(|_| Error::InvalidRawPublicKey)?;
-        Ok(Self::new(Some(pk)))
+        Ok(Self::new_with_rng(Some(pk), rng))
     }
 
     /// Creates a new [`Initiator`] without requiring the responder's authority public key.
@@ -198,8 +236,22 @@ impl Initiator {
     /// for use when both the initiator and responder are within the same network. In this case,
     /// the initiator does not validate the responder's static key from a certificate. However,
     /// the connection remains encrypted.
+    #[cfg(feature = "std")]
     pub fn without_pk() -> Result<Box<Self>, Error> {
-        Ok(Self::new(None))
+        Self::without_pk_with_rng(&mut rand::thread_rng())
+    }
+
+    /// Creates a new [`Initiator`] instance without a responder's public key and using a custom
+    /// random number generator.
+    ///
+    /// See [`Self::without_pk`] for more details.
+    ///
+    /// The custom random number generator should be provided in order to not implicitely rely on
+    /// `std` and allow `no_std` environments to provide a hardware random number generator for
+    /// example.
+    #[inline]
+    pub fn without_pk_with_rng<R: rand::Rng + ?Sized>(rng: &mut R) -> Result<Box<Self>, Error> {
+        Ok(Self::new_with_rng(None, rng))
     }
 
     /// Executes the initial step of the Noise NX protocol handshake.
@@ -241,9 +293,29 @@ impl Initiator {
     /// for secure communication. If the provided `message` has an incorrect length, it returns an
     /// [`Error::InvalidMessageLength`]. If decryption or signature verification fails, it returns
     /// an [`Error::InvalidCertificate`].
+    #[cfg(feature = "std")]
     pub fn step_2(
         &mut self,
         message: [u8; INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE],
+    ) -> Result<NoiseCodec, Error> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
+        self.step_2_with_now(message, now)
+    }
+
+    /// Processes the second step of the Noise NX protocol handshake for the initiator given the
+    /// current system time.
+    ///
+    /// See [`Self::step_2`] for more details.
+    ///
+    /// The current system time should be provided to avoid relying on `std` and allow `no_std`
+    /// environments to use another source of time.
+    pub fn step_2_with_now(
+        &mut self,
+        message: [u8; INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE],
+        now: u32,
     ) -> Result<NoiseCodec, Error> {
         // 2. interprets first 64 bytes as ElligatorSwift encoding of x-coordinate of public key
         // from this is derived the 32-bytes remote ephemeral public key `re.public_key`
@@ -308,7 +380,7 @@ impl Initiator {
             .0
             .serialize();
         let rs_pk_xonly = XOnlyPublicKey::from_slice(&rs_pub_key).unwrap();
-        if signature_message.verify(&rs_pk_xonly, &self.responder_authority_pk) {
+        if signature_message.verify_with_now(&rs_pk_xonly, &self.responder_authority_pk, now) {
             let (temp_k1, temp_k2) = Self::hkdf_2(self.get_ck(), &[]);
             let c1 = ChaCha20Poly1305::new(&temp_k1.into());
             let c2 = ChaCha20Poly1305::new(&temp_k2.into());

--- a/protocols/v2/noise-sv2/src/lib.rs
+++ b/protocols/v2/noise-sv2/src/lib.rs
@@ -32,6 +32,11 @@
 //! used to authenticate messages and validate the identities of the Sv2 roles, ensuring that
 //! critical messages like job templates and share submissions originate from legitimate sources.
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
 use aes_gcm::aead::Buffer;
 pub use aes_gcm::aead::Error as AeadError;
 use cipher_state::GenericCipher;
@@ -66,8 +71,8 @@ pub struct NoiseCodec {
     decryptor: GenericCipher,
 }
 
-impl std::fmt::Debug for NoiseCodec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NoiseCodec {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("NoiseCodec").finish()
     }
 }

--- a/protocols/v2/noise-sv2/src/signature_message.rs
+++ b/protocols/v2/noise-sv2/src/signature_message.rs
@@ -21,8 +21,9 @@
 // public key and optional authority key, while ensuring the message falls within the specified
 // validity period.
 
+use core::convert::TryInto;
+
 use secp256k1::{hashes::sha256, schnorr::Signature, Keypair, Message, Secp256k1, XOnlyPublicKey};
-use std::{convert::TryInto, time::SystemTime};
 
 /// `SignatureNoiseMessage` represents a signed message used in the Noise NX protocol
 /// for authentication during the handshake process. It encapsulates the necessary
@@ -70,12 +71,30 @@ impl SignatureNoiseMessage {
     //
     // If an authority public key is not provided, the function assumes that the signature
     // is already valid without further verification.
+    #[cfg(feature = "std")]
     pub fn verify(self, pk: &XOnlyPublicKey, authority_pk: &Option<XOnlyPublicKey>) -> bool {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
+        self.verify_with_now(pk, authority_pk, now)
+    }
+
+    /// Verifies the validity and authenticity of the `SignatureNoiseMessage` at a given timestamp.
+    ///
+    /// See [`Self::verify`] for more details.
+    ///
+    /// The current system time should be provided to avoid relying on `std` and allow `no_std`
+    /// environments to use another source of time.
+
+    #[inline]
+    pub fn verify_with_now(
+        self,
+        pk: &XOnlyPublicKey,
+        authority_pk: &Option<XOnlyPublicKey>,
+        now: u32,
+    ) -> bool {
         if let Some(authority_pk) = authority_pk {
-            let now = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as u32;
             if self.valid_from <= now && self.not_valid_after >= now {
                 let secp = Secp256k1::verification_only();
                 let (m, s) = self.split();
@@ -100,11 +119,30 @@ impl SignatureNoiseMessage {
     // Creates a Schnorr signature for the message, combining the version, validity period, and
     // the static public key of the server (`static_pk`). The resulting signature is then written
     // into the provided message buffer (`msg`).
+    #[cfg(feature = "std")]
     pub fn sign(msg: &mut [u8; 74], static_pk: &XOnlyPublicKey, kp: &Keypair) {
+        Self::sign_with_rng(msg, static_pk, kp, &mut rand::thread_rng());
+    }
+
+    /// Signs a [`SignatureNoiseMessage`] using the provided keypair (`kp`) and a custom random
+    /// number generator.
+    ///
+    /// See [`Self::sign`] for more details.
+    ///
+    /// The random number generator is used in the signature generation. It should be provided in
+    /// order to not implicitely rely on `std` and allow `no_std` environments to provide a
+    /// hardware random number generator for example.
+    #[inline]
+    pub fn sign_with_rng<R: rand::Rng + rand::CryptoRng>(
+        msg: &mut [u8; 74],
+        static_pk: &XOnlyPublicKey,
+        kp: &Keypair,
+        rng: &mut R,
+    ) {
         let secp = Secp256k1::signing_only();
         let m = [&msg[0..10], &static_pk.serialize()].concat();
         let m = Message::from_hashed_data::<sha256::Hash>(&m);
-        let signature = secp.sign_schnorr(&m, kp);
+        let signature = secp.sign_schnorr_with_rng(&m, kp, rng);
         for (i, b) in signature.as_ref().iter().enumerate() {
             msg[10 + i] = *b;
         }

--- a/protocols/v2/noise-sv2/src/test.rs
+++ b/protocols/v2/noise-sv2/src/test.rs
@@ -1,6 +1,7 @@
 use crate::{handshake::HandshakeOp, initiator::Initiator, responder::Responder};
 
 #[test]
+#[cfg(feature = "std")]
 fn test_1() {
     let key_pair = Responder::generate_key();
 
@@ -9,6 +10,33 @@ fn test_1() {
     let first_message = initiator.step_0().unwrap();
     let (second_message, mut codec_responder) = responder.step_1(first_message).unwrap();
     let mut codec_initiator = initiator.step_2(second_message).unwrap();
+    let mut message = "ciao".as_bytes().to_vec();
+    codec_initiator.encrypt(&mut message).unwrap();
+    assert!(message != "ciao".as_bytes().to_vec());
+    codec_responder.decrypt(&mut message).unwrap();
+
+    assert!(message == "ciao".as_bytes().to_vec());
+}
+#[test]
+fn test_1_with_rng() {
+    let key_pair = Responder::generate_key_with_rng(&mut rand::thread_rng());
+
+    let mut initiator: Box<Initiator> =
+        Initiator::new_with_rng(Some(key_pair.public_key().into()), &mut rand::thread_rng());
+    let mut responder = Responder::new_with_rng(key_pair, 31449600, &mut rand::thread_rng());
+    let first_message = initiator.step_0().unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+    let (second_message, mut codec_responder) = responder
+        .step_1_with_now_rng(first_message, now, &mut rand::thread_rng())
+        .unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+    let mut codec_initiator = initiator.step_2_with_now(second_message, now).unwrap();
     let mut message = "ciao".as_bytes().to_vec();
     codec_initiator.encrypt(&mut message).unwrap();
     assert!(message != "ciao".as_bytes().to_vec());


### PR DESCRIPTION
Following @rrybarczyk [comment](https://github.com/stratum-mining/stratum/issues/1130#issuecomment-2422975674) on #1130.

Some equivalent conversion have been done (does not change any functionality, just using the `no_std` equivalents) :
- std::ptr -> core::ptr
- std::boxed::Box -> alloc::boxed::Box
- std::vec::Vec -> alloc::vec::Vec
- std::string::{String, ToString} -> alloc::string::{String, ToString}
- std::convert::TryInto -> core::convert::TryInto
- std::fmt::{Debug, Formatter, Result} -> core::fmt::{Debug, Formatter, Result}
- std::time::Duration -> core::time::Duration

To have a `no-std` version, the `--no-default-features` must be used.

Current public API (`std` dependant) is unchanged.
Additional public API for `no_std` compliance is available using the `*_with_rng` and `*_with_now` suffix, and the corresponding arguments. This delegate the choice of the Ramdom Number Generator and the current System Time to the caller, instead of assuming using the ones from `std`.
- `Initiator::new_with_rng()`, `Initiator::from_raw_k_with_rng()`, `Initiator::without_pk_with_rng()`, `Responder::new_with_rng()`, `Responder::from_authority_kp_with_rng()` and `Responder::generate_key_with_rng()` take an additional argument: `rng` implementing rand::Rng + ?Sized
- `SignatureNoiseMessage::sign_with_rng()` take an additional argument: `rng` implementing rand::Rng + rand::CryptoRng
- `Initiator::step_2_with_now()`  and `SignatureNoiseMessage::verify_with_now()` take an additional argument: `now` for the current system time epoch
- `Responder::step_1()_with_now_rng` take two additional arguments: `rng` implementing rand::Rng + rand::CryptoRng and `now` for the current system time epoch
