### PR TITLE
Add Rust Docs CI

### DIFF
--- a/.github/workflows/rust-docs.yaml
+++ b/.github/workflows/rust-docs.yaml
@@ -1,0 +1,35 @@
+name: Validate Rust Docs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Find and Document All Crates
+        run: |
+          # Fail on any error
+          set -e
+          
+          # Find all Cargo.toml files (crates) and run `cargo doc` for each
+          find . -name "Cargo.toml" | while read -r crate; do
+            crate_dir=$(dirname "$crate")
+            echo "Generating documentation for $crate_dir..."
+            (
+              cd "$crate_dir" || exit 1
+              cargo doc --all-features --no-deps
+            )
+          done

--- a/benches/benches/src/sv1/criterion_sv1_benchmark.rs
+++ b/benches/benches/src/sv1/criterion_sv1_benchmark.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! This code uses `criterion` crate to benchmark the performance sv1.
 //! It measures connection time, send subscription latency and share submission time.
 

--- a/benches/benches/src/sv1/iai_sv1_benchmark.rs
+++ b/benches/benches/src/sv1/iai_sv1_benchmark.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! The code uses iai library to measure the system requirements of sv1 client.
 
 use iai::{black_box, main};

--- a/benches/benches/src/sv1/lib/client.rs
+++ b/benches/benches/src/sv1/lib/client.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! The defines a sv1 `Client` struct that handles message exchange with the server.
 //! It includes methods for initializing the client, parsing messages, and sending various types of
 //! messages. It also provides a trait implementation for handling server messages and managing

--- a/benches/benches/src/sv2/criterion_sv2_benchmark.rs
+++ b/benches/benches/src/sv2/criterion_sv2_benchmark.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use criterion::{black_box, Criterion};
 use roles_logic_sv2::{

--- a/benches/benches/src/sv2/iai_sv2_benchmark.rs
+++ b/benches/benches/src/sv2/iai_sv2_benchmark.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use iai::{black_box, main};
 use roles_logic_sv2::{

--- a/benches/benches/src/sv2/lib/client.rs
+++ b/benches/benches/src/sv2/lib/client.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use bitcoin::{
     blockdata::block::BlockHeader, hash_types::BlockHash, hashes::Hash, util::uint::Uint256,
 };

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! # Stratum Common Crate
 //!
 //! `stratum_common` is a utility crate designed to centralize

--- a/examples/interop-cpp/src/main.rs
+++ b/examples/interop-cpp/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 fn main() -> Result<(), std::io::Error> {
     use main_::main;
     main()

--- a/examples/interop-cpp/template-provider/example-of-guix-build/quickcheck/src/lib.rs
+++ b/examples/interop-cpp/template-provider/example-of-guix-build/quickcheck/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(test)]
 mod tests {
     #[test]

--- a/examples/interop-cpp/template-provider/example-of-guix-build/quickcheck_macros/src/lib.rs
+++ b/examples/interop-cpp/template-provider/example-of-guix-build/quickcheck_macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(test)]
 mod tests {
     #[test]

--- a/examples/ping-pong-with-noise/src/main.rs
+++ b/examples/ping-pong-with-noise/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 mod messages;
 mod node;
 use async_std::{

--- a/examples/ping-pong-with-noise/src/messages.rs
+++ b/examples/ping-pong-with-noise/src/messages.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::{binary_codec_sv2, decodable::DecodableField, decodable::FieldMarker};
 use binary_sv2::{Deserialize, GetSize, Seq064K, Serialize, Str0255, U24, U256};

--- a/examples/ping-pong-with-noise/src/node.rs
+++ b/examples/ping-pong-with-noise/src/node.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::messages::{Message, Ping, Pong};
 use binary_sv2::{from_bytes, GetSize, U256};
 use rand::Rng;

--- a/examples/ping-pong-without-noise/src/main.rs
+++ b/examples/ping-pong-without-noise/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 mod messages;
 mod node;
 use async_std::{

--- a/examples/ping-pong-without-noise/src/messages.rs
+++ b/examples/ping-pong-without-noise/src/messages.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use binary_sv2::{binary_codec_sv2, decodable::DecodableField, decodable::FieldMarker};
 use binary_sv2::{Deserialize, GetSize, Seq064K, Serialize, Str0255, U24, U256};

--- a/examples/ping-pong-without-noise/src/node.rs
+++ b/examples/ping-pong-without-noise/src/node.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::messages::{Message, Ping, Pong};
 use binary_sv2::{from_bytes, U256};
 use rand::Rng;

--- a/examples/sv1-client-and-server/src/main.rs
+++ b/examples/sv1-client-and-server/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_std::net::{TcpListener, TcpStream};
 use std::convert::{TryFrom, TryInto};
 

--- a/examples/template-provider-test/src/main.rs
+++ b/examples/template-provider-test/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{Receiver, Sender};
 use async_std::net::TcpStream;
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame, Sv2Frame};

--- a/protocols/fuzz-tests/src/main.rs
+++ b/protocols/fuzz-tests/src/main.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![deny(missing_docs)]
 use libfuzzer_sys::fuzz_target;
 use binary_codec_sv2::{Seq064K,U256,B0255,Seq0255};
 use binary_codec_sv2::from_bytes;

--- a/protocols/v1/src/error.rs
+++ b/protocols/v1/src/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     methods::{Method, MethodError},
     utils::HexU32Be,

--- a/protocols/v1/src/json_rpc.rs
+++ b/protocols/v1/src/json_rpc.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! https://www.jsonrpc.org/specification#response_object
 use serde::{Deserialize, Serialize};
 

--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::result_unit_err)]
+#![deny(missing_docs)]
 //! Startum V1 application protocol:
 //!
 //! json-rpc has two types of messages: **request** and **response**.

--- a/protocols/v1/src/methods/client_to_server.rs
+++ b/protocols/v1/src/methods/client_to_server.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use bitcoin_hashes::hex::ToHex;
 use serde_json::{
     Value,

--- a/protocols/v1/src/methods/mod.rs
+++ b/protocols/v1/src/methods/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::error::Error;
 use bitcoin_hashes::Error as BTCHashError;
 use hex::FromHexError;

--- a/protocols/v1/src/methods/server_to_client.rs
+++ b/protocols/v1/src/methods/server_to_client.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use serde_json::{
     Value,
     Value::{Array as JArrary, Bool as JBool, Number as JNumber, String as JString},

--- a/protocols/v1/src/utils.rs
+++ b/protocols/v1/src/utils.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::error::{self, Error};
 use binary_sv2::{B032, U256};
 use bitcoin_hashes::hex::{FromHex, ToHex};

--- a/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/binary-sv2/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // TODO unify errors from serde_sv2 and no-serde-sv2
 
 #![no_std]

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/decodable.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/decodable.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     codec::{GetSize, SizeHint},
     datatypes::{

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/encodable.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/encodable.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     codec::GetSize,
     datatypes::{

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/impls.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/impls.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     codec::{
         decodable::{

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // At lower level I generally prefer to work with slices as more efficient than Read/Write streams
 // eg: Read for & [u8] is implemented with memcpy but here is more than enough to just get a
 // pointer to the original data

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/copy_data_types.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/copy_data_types.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Copy data types
 use crate::{codec::Fixed, datatypes::Sv2DataType, Error};
 

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     codec::{GetSize, SizeHint},
     Error,

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::IntoOwned;
 use crate::{
     codec::{GetSize, SizeHint},

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(feature = "prop_test")]
 use quickcheck::{Arbitrary, Gen};
 

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     codec::{
         decodable::{Decodable, DecodableField, FieldMarker, GetMarker, PrimitiveMarker},

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! ```txt
 //! SERDE    <-> Sv2
 //! bool     <-> BOOL

--- a/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 
 extern crate alloc;
 extern crate proc_macro;

--- a/protocols/v2/binary-sv2/serde-sv2/src/de.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/de.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Serde deserializer for [stratum v2][Sv2] implemented following [serde tutorial][tutorial]
 //!
 //! [Sv2]: https://docs.google.com/document/d/1FadCWj-57dvhxsnFM_7X806qyvhR0u3i85607bGHxvg/edit

--- a/protocols/v2/binary-sv2/serde-sv2/src/error.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use alloc::string::String;
 use core::fmt::{self, Display};
 

--- a/protocols/v2/binary-sv2/serde-sv2/src/lib.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Serde serializer/deserializer for [stratum v2][Sv2] implemented following [serde
 //! tutorial][tutorial]
 //!

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b016m.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b016m.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{error::Error, primitives::GetSize};
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b0255.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b0255.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{error::Error, primitives::GetSize};
 use alloc::{string::ToString, vec::Vec};
 use core::convert::{TryFrom, TryInto};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b032.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b032.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{error::Error, primitives::GetSize};
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/b064k.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{error::Error, primitives::GetSize};
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/bytes.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/bytes.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::primitives::GetSize;
 use alloc::vec::Vec;
 use serde::{de::Visitor, ser, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/mod.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod b016m;
 pub mod b0255;
 pub mod b032;

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/mod.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use alloc::{string::String, vec::Vec};
 mod byte_arrays;
 pub mod sequences;

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/mod.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{ShortTxId, Signature, B016M, B0255, B064K, U24, U256};
 use crate::Error;
 use core::convert::TryInto;

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/option.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/option.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{
     super::{Signature, U24, U256},
     Seq, SeqMaxLen, SeqVisitor, TryFromBSlice,

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq0255.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq0255.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{
     super::{Signature, U24, U256},
     Seq, SeqMaxLen, SeqVisitor, TryFromBSlice,

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/sequences/seq064k.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{
     super::{Signature, B016M, B064K, U24, U256},
     Seq, SeqMaxLen, SeqVisitor, TryFromBSlice,

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/short_tx_id.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/short_tx_id.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{error::Error, primitives::FixedSize};
 use alloc::{boxed::Box, vec::Vec};
 use core::convert::TryFrom;

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/signature.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/signature.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{error::Error, primitives::FixedSize};
 use alloc::boxed::Box;
 use core::convert::TryFrom;

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/u24.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/u24.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::primitives::FixedSize;
 use core::convert::TryFrom;
 use serde::{de::Visitor, ser, Deserialize, Deserializer, Serialize};

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/u256.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/u256.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{error::Error, primitives::FixedSize};
 use alloc::{boxed::Box, vec::Vec};
 use core::convert::TryFrom;

--- a/protocols/v2/binary-sv2/serde-sv2/src/ser.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/ser.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Serde serializer for [stratum v2][Sv2] implemented following [serde tutorial][tutorial]
 //!
 //! Right now trying to serialize a value that is an invalid Sv2 type will result in a panic so

--- a/protocols/v2/codec-sv2/examples/encrypted.rs
+++ b/protocols/v2/codec-sv2/examples/encrypted.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Using Sv2 Codec with Noise Encryption
 //
 // This example demonstrates how to use the `codec-sv2` crate to encode and decode Sv2 frames

--- a/protocols/v2/codec-sv2/examples/unencrypted.rs
+++ b/protocols/v2/codec-sv2/examples/unencrypted.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Using Sv2 Codec Without Encryption
 //
 // This example demonstrates how to use the `codec-sv2` crate to encode and decode Sv2 frames

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Decoder
 //
 // Provides utilities for decoding messages held by Sv2 frames, with or without Noise protocol

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Encoder
 //
 // Provides utilities for encoding messages into Sv2 frames, with or without Noise protocol

--- a/protocols/v2/codec-sv2/src/error.rs
+++ b/protocols/v2/codec-sv2/src/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! # Error Handling and Result Types
 //!
 //! This module defines error types and utilities for handling errors in the `codec_sv2` module.

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! # Stratum V2 Codec Library
 //!
 //! `codec_sv2` provides the message encoding and decoding functionality for the Stratum V2 (Sv2)

--- a/protocols/v2/const-sv2/src/lib.rs
+++ b/protocols/v2/const-sv2/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! This crate provides all constants used in the SV2 protocol.
 //! These constants are essential for message framing, encryption, and
 //! protocol-specific identifiers across various SV2 components, including

--- a/protocols/v2/framing-sv2/src/error.rs
+++ b/protocols/v2/framing-sv2/src/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // use crate::framing2::EitherFrame;
 use core::fmt;
 

--- a/protocols/v2/framing-sv2/src/framing.rs
+++ b/protocols/v2/framing-sv2/src/framing.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{header::Header, Error};
 use alloc::vec::Vec;
 use binary_sv2::{to_writer, GetSize, Serialize};

--- a/protocols/v2/framing-sv2/src/header.rs
+++ b/protocols/v2/framing-sv2/src/header.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::Error;
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;

--- a/protocols/v2/framing-sv2/src/lib.rs
+++ b/protocols/v2/framing-sv2/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! The SV2 protocol is binary, with fixed message framing.
 //! Each message begins with the extension type, message type, and message length (six bytes in
 //! total), followed by a variable length message.

--- a/protocols/v2/noise-sv2/examples/handshake.rs
+++ b/protocols/v2/noise-sv2/examples/handshake.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Noise Protocol Handshake
 //
 // This example demonstrates how to use the `noise-sv2` crate to establish a Noise handshake

--- a/protocols/v2/noise-sv2/src/aed_cipher.rs
+++ b/protocols/v2/noise-sv2/src/aed_cipher.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # AEAD Cipher
 //
 // Abstracts the encryption and decryption operations for authenticated encryption with associated

--- a/protocols/v2/noise-sv2/src/cipher_state.rs
+++ b/protocols/v2/noise-sv2/src/cipher_state.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Cipher State Management
 //
 // Defines the [`CipherState`] trait and the [`GenericCipher`] enum, which manage the state of

--- a/protocols/v2/noise-sv2/src/error.rs
+++ b/protocols/v2/noise-sv2/src/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Error Handling
 //
 // Defines error types and utilities for handling errors in the `noise_sv2` module.

--- a/protocols/v2/noise-sv2/src/handshake.rs
+++ b/protocols/v2/noise-sv2/src/handshake.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Noise Handshake Operations
 //
 // The [`HandshakeOp`] trait defines the cryptographic operations and utilities required to perform

--- a/protocols/v2/noise-sv2/src/initiator.rs
+++ b/protocols/v2/noise-sv2/src/initiator.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Initiator Role
 //
 // Manages the [`Initiator`] role in the Noise protocol handshake for communication between Sv2

--- a/protocols/v2/noise-sv2/src/lib.rs
+++ b/protocols/v2/noise-sv2/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! # Noise-SV2: Noise Protocol Implementation for Stratum V2
 //!
 //! `noise_sv2` ensures secure communication between Sv2 roles by handling encryption, decryption,

--- a/protocols/v2/noise-sv2/src/responder.rs
+++ b/protocols/v2/noise-sv2/src/responder.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Responder Role
 //
 // Manages the [`Responder`] role in the Noise protocol handshake for secure communication between

--- a/protocols/v2/noise-sv2/src/signature_message.rs
+++ b/protocols/v2/noise-sv2/src/signature_message.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // # Signature-Based Message Handling
 //
 // Defines the [`SignatureNoiseMessage`] struct, which represents a signed message used in the

--- a/protocols/v2/noise-sv2/src/test.rs
+++ b/protocols/v2/noise-sv2/src/test.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{handshake::HandshakeOp, initiator::Initiator, responder::Responder};
 
 #[test]

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::extended_to_standard_job;
 use crate::{
     common_properties::StandardChannel,

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod channel_factory;
 pub mod proxy_group_channel;
 

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/proxy_group_channel.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/proxy_group_channel.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{common_properties::StandardChannel, parsers::Mining, Error};
 
 use mining_sv2::{

--- a/protocols/v2/roles-logic-sv2/src/common_properties.rs
+++ b/protocols/v2/roles-logic-sv2/src/common_properties.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Traits that implements very basic properties that every implementation should use
 use crate::selectors::{
     DownstreamMiningSelector, DownstreamSelector, NullDownstreamMiningSelector,

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Errors specific to this crate
 
 use crate::{

--- a/protocols/v2/roles-logic-sv2/src/handlers/common.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/common.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::SendTo_;
 use crate::{
     common_properties::CommonDownstreamData,

--- a/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/job_declaration.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{parsers::JobDeclaration, utils::Mutex};
 use std::sync::Arc;
 pub type SendTo = SendTo_<JobDeclaration<'static>, ()>;

--- a/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{common_properties::RequestIdMapper, errors::Error, parsers::Mining};
 use core::convert::TryInto;
 use mining_sv2::{

--- a/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Handlers are divided per (sub)protocol and per Downstream/Upstream.
 //! Each (sup)protocol defines a handler for both the Upstream node and the Downstream node
 //! Handlers are a trait called `Parse[Downstream/Upstream][(sub)protocol]`

--- a/protocols/v2/roles-logic-sv2/src/handlers/template_distribution.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/template_distribution.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::SendTo_;
 use crate::{errors::Error, parsers::TemplateDistribution, utils::Mutex};
 use template_distribution_sv2::{

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! The job creator module provides logic to create extended mining jobs given a template from
 //! a template provider as well as logic to clean up old templates when new blocks are mined
 use crate::{errors, utils::Id, Error};

--- a/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! The Job Dispatcher contains relevant logic to maintain group channels in proxy roles such as:
 //! - converting extended jobs to standard jobs
 //! - handling updates to jobs when new templates and prev hashes arrive, as well as cleaning up old

--- a/protocols/v2/roles-logic-sv2/src/lib.rs
+++ b/protocols/v2/roles-logic-sv2/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Provides all relevant types, traits and functions to implement a valid SV2 role.
 //!
 //! - For channel and job management, see [`channel_logic`], which utilizes [`job_creator`] and

--- a/protocols/v2/roles-logic-sv2/src/parsers.rs
+++ b/protocols/v2/roles-logic-sv2/src/parsers.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! The parsers modules provides logic to convert raw SV2 message data into rust types
 //! as well as logic to handle conversions among SV2 rust types
 

--- a/protocols/v2/roles-logic-sv2/src/routing_logic.rs
+++ b/protocols/v2/roles-logic-sv2/src/routing_logic.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! The routing logic code is used by the handler to determine where a message should be relayed or
 //! responded to
 //!

--- a/protocols/v2/roles-logic-sv2/src/selectors.rs
+++ b/protocols/v2/roles-logic-sv2/src/selectors.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Selectors are used from the routing logic in order to chose to which remote or set of remotes
 //! a message should be ralyied, or to which remote or set of remotes a message should be sent.
 use crate::{

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::{
     convert::{TryFrom, TryInto},
     ops::{Div, Mul},

--- a/protocols/v2/subprotocols/common-messages/src/channel_endpoint_changed.rs
+++ b/protocols/v2/subprotocols/common-messages/src/channel_endpoint_changed.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/common-messages/src/lib.rs
+++ b/protocols/v2/subprotocols/common-messages/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "no_std", no_std)]
+#![deny(missing_docs)]
 
 //! Common messages for [stratum v2][Sv2]
 //! The following protocol messages are common across all of the sv2 (sub)protocols.

--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/job-declaration/src/declare_mining_job.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/declare_mining_job.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/job-declaration/src/identify_transactions.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/identify_transactions.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/job-declaration/src/lib.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "no_std", no_std)]
+#![deny(missing_docs)]
 
 //! # Job Declaration Protocol
 //!

--- a/protocols/v2/subprotocols/job-declaration/src/provide_missing_transactions.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/provide_missing_transactions.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/job-declaration/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/submit_solution.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/close_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/close_channel.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/lib.rs
+++ b/protocols/v2/subprotocols/mining/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "no_std", no_std)]
+#![deny(missing_docs)]
 
 //! # Mining Protocol
 //! ## Channels

--- a/protocols/v2/subprotocols/mining/src/new_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/new_mining_job.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/open_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/open_channel.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use alloc::string::ToString;
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;

--- a/protocols/v2/subprotocols/mining/src/reconnect.rs
+++ b/protocols/v2/subprotocols/mining/src/reconnect.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/set_extranonce_prefix.rs
+++ b/protocols/v2/subprotocols/mining/src/set_extranonce_prefix.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/set_group_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/set_group_channel.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/mining/src/set_new_prev_hash.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/set_target.rs
+++ b/protocols/v2/subprotocols/mining/src/set_target.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/submit_shares.rs
+++ b/protocols/v2/subprotocols/mining/src/submit_shares.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/mining/src/update_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/update_channel.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/template-distribution/src/coinbase_output_data_size.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/coinbase_output_data_size.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/template-distribution/src/lib.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "no_std", no_std)]
+#![deny(missing_docs)]
 
 //! # Template Distribution Protocol
 //! The Template Distribution protocol is used to receive updates of the block template to use in

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(not(feature = "with_serde"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "with_serde"))]

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(not(feature = "with_serde"))]
+#![deny(missing_docs)]
 use std::{
     fmt,
     fmt::{Display, Formatter},

--- a/roles/jd-client/src/args.rs
+++ b/roles/jd-client/src/args.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::path::PathBuf;
 
 #[derive(Debug)]

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{
     job_declarator::JobDeclarator,
     status::{self, State},

--- a/roles/jd-client/src/lib/error.rs
+++ b/roles/jd-client/src/lib/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use ext_config::ConfigError;
 use std::fmt;
 

--- a/roles/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-client/src/lib/job_declarator/message_handler.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::JobDeclarator;
 use roles_logic_sv2::{
     handlers::{job_declaration::ParseServerJobDeclarationMessages, SendTo_},

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod message_handler;
 use async_channel::{Receiver, Sender};
 use binary_sv2::{Seq0255, Seq064K, B016M, B064K, U256};

--- a/roles/jd-client/src/lib/job_declarator/setup_connection.rs
+++ b/roles/jd-client/src/lib/job_declarator/setup_connection.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{Receiver, Sender};
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{

--- a/roles/jd-client/src/lib/mod.rs
+++ b/roles/jd-client/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod downstream;
 pub mod error;
 pub mod job_declarator;

--- a/roles/jd-client/src/lib/proxy_config.rs
+++ b/roles/jd-client/src/lib/proxy_config.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![deny(missing_docs)]
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use roles_logic_sv2::{errors::Error, utils::CoinbaseOutput as CoinbaseOutput_};
 use serde::Deserialize;

--- a/roles/jd-client/src/lib/status.rs
+++ b/roles/jd-client/src/lib/status.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::error::{self, Error};
 
 #[derive(Debug)]

--- a/roles/jd-client/src/lib/template_receiver/message_handler.rs
+++ b/roles/jd-client/src/lib/template_receiver/message_handler.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::TemplateRx;
 use roles_logic_sv2::{
     errors::Error,

--- a/roles/jd-client/src/lib/template_receiver/mod.rs
+++ b/roles/jd-client/src/lib/template_receiver/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{job_declarator::JobDeclarator, status, PoolChangerTrigger};
 use async_channel::{Receiver, Sender};
 use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};

--- a/roles/jd-client/src/lib/template_receiver/setup_connection.rs
+++ b/roles/jd-client/src/lib/template_receiver/setup_connection.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{Receiver, Sender};
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{

--- a/roles/jd-client/src/lib/upstream_sv2/mod.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::parsers::PoolMessages;
 

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::super::downstream::DownstreamMiningNode as Downstream;
 
 use super::super::{

--- a/roles/jd-client/src/main.rs
+++ b/roles/jd-client/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(special_module_name)]
+#![deny(missing_docs)]
 mod args;
 mod lib;
 

--- a/roles/jd-server/src/lib/error.rs
+++ b/roles/jd-server/src/lib/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::{
     convert::From,
     fmt::Debug,

--- a/roles/jd-server/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-server/src/lib/job_declarator/message_handler.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use binary_sv2::ShortTxId;
 use roles_logic_sv2::{
     handlers::{job_declaration::ParseClientJobDeclarationMessages, SendTo_},

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod message_handler;
 use super::{error::JdsError, mempool::JDsMempool, status, Configuration, EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};

--- a/roles/jd-server/src/lib/mempool/error.rs
+++ b/roles/jd-server/src/lib/mempool/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use rpc_sv2::mini_rpc_client::RpcError;
 use std::{convert::From, sync::PoisonError};
 use tracing::{error, warn};

--- a/roles/jd-server/src/lib/mempool/mod.rs
+++ b/roles/jd-server/src/lib/mempool/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod error;
 use super::job_declarator::AddTrasactionsToMempoolInner;
 use crate::mempool::error::JdsMempoolError;

--- a/roles/jd-server/src/lib/mod.rs
+++ b/roles/jd-server/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod error;
 pub mod job_declarator;
 pub mod mempool;

--- a/roles/jd-server/src/lib/status.rs
+++ b/roles/jd-server/src/lib/status.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use roles_logic_sv2::parsers::Mining;
 
 use super::error::JdsError;

--- a/roles/jd-server/src/main.rs
+++ b/roles/jd-server/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(special_module_name)]
+#![deny(missing_docs)]
 pub use crate::lib::{
     mempool::{self},
     status, Configuration,

--- a/roles/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/mining-proxy/src/lib/downstream_mining.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::{convert::TryInto, sync::Arc};
 
 use async_channel::{Receiver, SendError, Sender};

--- a/roles/mining-proxy/src/lib/error.rs
+++ b/roles/mining-proxy/src/lib/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::SendError;
 use codec_sv2::StandardEitherFrame;
 use roles_logic_sv2::parsers::PoolMessages;

--- a/roles/mining-proxy/src/lib/mod.rs
+++ b/roles/mining-proxy/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod downstream_mining;
 pub mod error;
 pub mod upstream_mining;

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![deny(missing_docs)]
 
 use core::convert::TryInto;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};

--- a/roles/mining-proxy/src/main.rs
+++ b/roles/mining-proxy/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Configurable Sv2 it support extended and group channel
 //! Upstream means another proxy or a pool
 //! Downstream means another proxy or a mining device

--- a/roles/pool/src/lib/error.rs
+++ b/roles/pool/src/lib/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::{
     convert::From,
     fmt::Debug,

--- a/roles/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/pool/src/lib/mining_pool/message_handler.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::super::mining_pool::Downstream;
 use roles_logic_sv2::{
     errors::Error,

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{
     error::{PoolError, PoolResult},
     status,

--- a/roles/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/pool/src/lib/mining_pool/setup_connection.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::super::{
     error::{PoolError, PoolResult},
     mining_pool::{EitherFrame, StdFrame},

--- a/roles/pool/src/lib/mod.rs
+++ b/roles/pool/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod error;
 pub mod mining_pool;
 pub mod status;

--- a/roles/pool/src/lib/status.rs
+++ b/roles/pool/src/lib/status.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use roles_logic_sv2::parsers::Mining;
 
 use super::error::PoolError;

--- a/roles/pool/src/lib/template_receiver/message_handler.rs
+++ b/roles/pool/src/lib/template_receiver/message_handler.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::TemplateRx;
 use roles_logic_sv2::{
     errors::Error,

--- a/roles/pool/src/lib/template_receiver/mod.rs
+++ b/roles/pool/src/lib/template_receiver/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{
     error::{PoolError, PoolResult},
     mining_pool::{EitherFrame, StdFrame},

--- a/roles/pool/src/lib/template_receiver/setup_connection.rs
+++ b/roles/pool/src/lib/template_receiver/setup_connection.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::super::{
     error::{PoolError, PoolResult},
     mining_pool::{EitherFrame, StdFrame},

--- a/roles/pool/src/main.rs
+++ b/roles/pool/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(special_module_name)]
+#![deny(missing_docs)]
 
 mod lib;
 use ext_config::{Config, File, FileFormat};

--- a/roles/roles-utils/network-helpers/src/lib.rs
+++ b/roles/roles-utils/network-helpers/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #[cfg(feature = "async_std")]
 mod noise_connection_async_std;
 #[cfg(feature = "async_std")]

--- a/roles/roles-utils/network-helpers/src/noise_connection_async_std.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection_async_std.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{bounded, Receiver, Sender};
 use async_std::{
     net::{TcpListener, TcpStream},

--- a/roles/roles-utils/network-helpers/src/noise_connection_tokio.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection_tokio.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::Error;
 use async_channel::{bounded, Receiver, Sender};
 use binary_sv2::{Deserialize, Serialize};

--- a/roles/roles-utils/network-helpers/src/plain_connection_async_std.rs
+++ b/roles/roles-utils/network-helpers/src/plain_connection_async_std.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{bounded, Receiver, Sender};
 use async_std::{
     net::{TcpListener, TcpStream},

--- a/roles/roles-utils/network-helpers/src/plain_connection_tokio.rs
+++ b/roles/roles-utils/network-helpers/src/plain_connection_tokio.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{bounded, Receiver, Sender};
 use binary_sv2::{Deserialize, Serialize};
 use core::convert::TryInto;

--- a/roles/roles-utils/rpc/src/lib.rs
+++ b/roles/roles-utils/rpc/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod mini_rpc_client;
 use serde::{Deserialize, Serialize};
 

--- a/roles/roles-utils/rpc/src/mini_rpc_client.rs
+++ b/roles/roles-utils/rpc/src/mini_rpc_client.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 // TODO
 //  - manage id in RpcResult messages
 use base64::Engine;

--- a/roles/test-utils/mining-device-sv1/src/client.rs
+++ b/roles/test-utils/mining-device-sv1/src/client.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_std::net::TcpStream;
 use std::{convert::TryInto, net::SocketAddr, ops::Div};
 

--- a/roles/test-utils/mining-device-sv1/src/job.rs
+++ b/roles/test-utils/mining-device-sv1/src/job.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::convert::TryInto;
 use v1::server_to_client;
 

--- a/roles/test-utils/mining-device-sv1/src/lib.rs
+++ b/roles/test-utils/mining-device-sv1/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod client;
 pub mod job;
 pub mod miner;

--- a/roles/test-utils/mining-device-sv1/src/main.rs
+++ b/roles/test-utils/mining-device-sv1/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub(crate) mod client;
 pub(crate) mod job;
 pub(crate) mod miner;

--- a/roles/test-utils/mining-device-sv1/src/miner.rs
+++ b/roles/test-utils/mining-device-sv1/src/miner.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::job::Job;
 use std::convert::TryInto;
 use stratum_common::bitcoin::{

--- a/roles/test-utils/mining-device/src/lib/mod.rs
+++ b/roles/test-utils/mining-device/src/lib/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::option_map_unit_fn)]
+#![deny(missing_docs)]
 use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection_tokio::Connection;
 use roles_logic_sv2::utils::Id;

--- a/roles/test-utils/mining-device/src/main.rs
+++ b/roles/test-utils/mining-device/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(special_module_name)]
+#![deny(missing_docs)]
 #![allow(clippy::option_map_unit_fn)]
 use key_utils::Secp256k1PublicKey;
 

--- a/roles/tests-integration/tests/common/mod.rs
+++ b/roles/tests-integration/tests/common/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 mod sniffer;
 
 use bitcoind::{bitcoincore_rpc::RpcApi, BitcoinD, Conf};

--- a/roles/tests-integration/tests/common/sniffer.rs
+++ b/roles/tests-integration/tests/common/sniffer.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{Receiver, Sender};
 use codec_sv2::{
     framing_sv2::framing::Frame, HandshakeRole, Initiator, Responder, StandardEitherFrame, Sv2Frame,

--- a/roles/tests-integration/tests/pool_integration.rs
+++ b/roles/tests-integration/tests/pool_integration.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 mod common;
 
 use std::convert::TryInto;

--- a/roles/translator/src/args.rs
+++ b/roles/translator/src/args.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::path::PathBuf;
 
 #[derive(Debug)]

--- a/roles/translator/src/lib/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/lib/downstream_sv1/diff_management.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{Downstream, DownstreamMessages, SetDownstreamTarget};
 
 use super::super::error::{Error, ProxyResult};

--- a/roles/translator/src/lib/downstream_sv1/downstream.rs
+++ b/roles/translator/src/lib/downstream_sv1/downstream.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     downstream_sv1,
     error::ProxyResult,

--- a/roles/translator/src/lib/downstream_sv1/mod.rs
+++ b/roles/translator/src/lib/downstream_sv1/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use roles_logic_sv2::mining_sv2::Target;
 use v1::{client_to_server::Submit, utils::HexU32Be};
 pub mod diff_management;

--- a/roles/translator/src/lib/error.rs
+++ b/roles/translator/src/lib/error.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use ext_config::ConfigError;
 use roles_logic_sv2::{
     mining_sv2::{ExtendedExtranonce, NewExtendedMiningJob, SetCustomMiningJob},

--- a/roles/translator/src/lib/mod.rs
+++ b/roles/translator/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{bounded, unbounded};
 use futures::FutureExt;
 use rand::Rng;

--- a/roles/translator/src/lib/proxy/bridge.rs
+++ b/roles/translator/src/lib/proxy/bridge.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use async_channel::{Receiver, Sender};
 use roles_logic_sv2::{
     channel_logic::channel_factory::{ExtendedChannelKind, ProxyExtendedChannelFactory, Share},

--- a/roles/translator/src/lib/proxy/mod.rs
+++ b/roles/translator/src/lib/proxy/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 pub mod bridge;
 pub mod next_mining_notify;
 pub use bridge::Bridge;

--- a/roles/translator/src/lib/proxy/next_mining_notify.rs
+++ b/roles/translator/src/lib/proxy/next_mining_notify.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use roles_logic_sv2::{
     job_creator::extended_job_to_non_segwit,
     mining_sv2::{NewExtendedMiningJob, SetNewPrevHash},

--- a/roles/translator/src/lib/proxy_config.rs
+++ b/roles/translator/src/lib/proxy_config.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use key_utils::Secp256k1PublicKey;
 use serde::Deserialize;
 

--- a/roles/translator/src/lib/status.rs
+++ b/roles/translator/src/lib/status.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::error::{self, Error};
 
 #[derive(Debug)]

--- a/roles/translator/src/lib/upstream_sv2/diff_management.rs
+++ b/roles/translator/src/lib/upstream_sv2/diff_management.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::Upstream;
 
 use super::super::{

--- a/roles/translator/src/lib/upstream_sv2/mod.rs
+++ b/roles/translator/src/lib/upstream_sv2/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::parsers::PoolMessages;
 

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     downstream_sv1::Downstream,
     error::{

--- a/roles/translator/src/lib/upstream_sv2/upstream_connection.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream_connection.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::{super::error::ProxyResult, EitherFrame, StdFrame};
 use async_channel::{Receiver, Sender};
 

--- a/roles/translator/src/lib/utils.rs
+++ b/roles/translator/src/lib/utils.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 /// currently the pool only supports 16 bytes exactly for its channels
 /// to use but that may change
 pub fn proxy_extranonce1_len(

--- a/roles/translator/src/main.rs
+++ b/roles/translator/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(special_module_name)]
+#![deny(missing_docs)]
 mod args;
 mod lib;
 

--- a/test/scale/src/main.rs
+++ b/test/scale/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::thread;
 use tokio::{
     net::{TcpListener, TcpStream},

--- a/utils/bip32-key-derivation/src/lib.rs
+++ b/utils/bip32-key-derivation/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::str::FromStr;
 use stratum_common::bitcoin::{
     secp256k1::Secp256k1,

--- a/utils/bip32-key-derivation/src/main.rs
+++ b/utils/bip32-key-derivation/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use std::env;
 use stratum_common::bitcoin::util::bip32::ExtendedPubKey;
 

--- a/utils/buffer/benches/control_struct.rs
+++ b/utils/buffer/benches/control_struct.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use buffer_sv2::{Buffer, Slice};
 use std::sync::{Arc, Mutex};
 

--- a/utils/buffer/benches/pool_benchmark.rs
+++ b/utils/buffer/benches/pool_benchmark.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use core::sync::atomic::Ordering;
 use criterion::{criterion_group, criterion_main, Criterion};
 

--- a/utils/buffer/benches/pool_iai.rs
+++ b/utils/buffer/benches/pool_iai.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use buffer_sv2::{Buffer, BufferFromSystemMemory as BufferFromMemory, BufferPool as Pool};
 use core::time::Duration;
 use rand::Rng;

--- a/utils/buffer/fuzz/fuzz_targets/faster.rs
+++ b/utils/buffer/fuzz/fuzz_targets/faster.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![deny(missing_docs)]
 use arbitrary::Arbitrary;
 use buffer_sv2::BufferPool as Pool;
 use buffer_sv2::{Buffer, Slice};

--- a/utils/buffer/fuzz/fuzz_targets/slower.rs
+++ b/utils/buffer/fuzz/fuzz_targets/slower.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![deny(missing_docs)]
 use affinity::{get_core_num, set_thread_affinity};
 use arbitrary::Arbitrary;
 use buffer_sv2::BufferPool as Pool;

--- a/utils/buffer/src/buffer.rs
+++ b/utils/buffer/src/buffer.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::Buffer;
 use aes_gcm::aead::Buffer as AeadBuffer;
 use alloc::vec::Vec;

--- a/utils/buffer/src/buffer_pool/mod.rs
+++ b/utils/buffer/src/buffer_pool/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use alloc::{vec, vec::Vec};
 use core::sync::atomic::Ordering;
 

--- a/utils/buffer/src/buffer_pool/pool_back.rs
+++ b/utils/buffer/src/buffer_pool/pool_back.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::buffer_pool::{InnerMemory, PoolFront, PoolMode, POOL_CAPACITY};
 
 #[derive(Debug, Clone)]

--- a/utils/buffer/src/lib.rs
+++ b/utils/buffer/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "debug"), no_std)]
+#![deny(missing_docs)]
 //#![feature(backtrace)]
 
 mod buffer;

--- a/utils/buffer/src/slice.rs
+++ b/utils/buffer/src/slice.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use alloc::{sync::Arc, vec::Vec};
 use core::sync::atomic::{AtomicU8, Ordering};
 #[cfg(feature = "debug")]

--- a/utils/buffer/src/test.rs
+++ b/utils/buffer/src/test.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use alloc::vec::Vec;
 
 use crate::{buffer_pool::BufferPool as Pool, slice::Slice, Buffer};

--- a/utils/error-handling/src/lib.rs
+++ b/utils/error-handling/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::crate_in_macro_def)]
+#![deny(missing_docs)]
 /// # Description
 /// This macro handles errors inserting error handling logic for a given `Result<T,
 /// crate::error::Error<'a>>` it is used by passing in a `Sender<crate::status::Status>` as the

--- a/utils/key-utils/src/lib.rs
+++ b/utils/key-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use bs58::{decode, decode::Error as Bs58DecodeError};
 use core::convert::TryFrom;
 use secp256k1::{

--- a/utils/key-utils/src/main.rs
+++ b/utils/key-utils/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use ::key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use secp256k1::{rand, Keypair, Secp256k1};
 

--- a/utils/message-generator/src/executor.rs
+++ b/utils/message-generator/src/executor.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     external_commands::os_command,
     into_static::into_static,

--- a/utils/message-generator/src/executor_sv1.rs
+++ b/utils/message-generator/src/executor_sv1.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{
     external_commands::os_command, net::setup_as_sv1_downstream, Command, Sv1Action,
     Sv1ActionResult, Test,

--- a/utils/message-generator/src/external_commands.rs
+++ b/utils/message-generator/src/external_commands.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use binary_sv2::{Deserialize, Serialize};
 use std::{process::Stdio, time::Duration};
 use tokio::{

--- a/utils/message-generator/src/into_static.rs
+++ b/utils/message-generator/src/into_static.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use roles_logic_sv2::{
     common_messages_sv2::{
         ChannelEndpointChanged, SetupConnection, SetupConnectionError, SetupConnectionSuccess,

--- a/utils/message-generator/src/main.rs
+++ b/utils/message-generator/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 mod executor;
 mod executor_sv1;
 mod external_commands;

--- a/utils/message-generator/src/net.rs
+++ b/utils/message-generator/src/net.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{os_command, Command};
 use async_channel::{bounded, Receiver, Sender};
 use binary_sv2::{Deserialize, GetSize, Serialize};

--- a/utils/message-generator/src/parser/actions.rs
+++ b/utils/message-generator/src/parser/actions.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use crate::{Action, ActionResult, Role, SaveField, Sv1Action, Sv1ActionResult, Sv2Type};
 use codec_sv2::{buffer_sv2::Slice, StandardEitherFrame, Sv2Frame};
 use roles_logic_sv2::parsers::AnyMessage;

--- a/utils/message-generator/src/parser/frames.rs
+++ b/utils/message-generator/src/parser/frames.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::sv2_messages::{message_from_path, ReplaceField};
 use codec_sv2::{buffer_sv2::Slice, Sv2Frame};
 use roles_logic_sv2::parsers::AnyMessage;

--- a/utils/message-generator/src/parser/mod.rs
+++ b/utils/message-generator/src/parser/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 mod actions;
 mod frames;
 pub mod sv1_messages;

--- a/utils/message-generator/src/parser/sv1_messages.rs
+++ b/utils/message-generator/src/parser/sv1_messages.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use v1::json_rpc::*;

--- a/utils/message-generator/src/parser/sv2_messages.rs
+++ b/utils/message-generator/src/parser/sv2_messages.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use binary_sv2::{Deserialize, Serialize};
 use roles_logic_sv2::{
     common_messages_sv2::{SetupConnectionError, SetupConnectionSuccess},


### PR DESCRIPTION
close #1270

this PR does two things:
- enforce `#![deny(missing_docs)]` on every `*.rs` file that still doesn't have it
- enforce CI does `cargo doc --all-features` on every crate of the repo (via shell recursion)

we should aim to merge this PR by the end of Milestone 1.2.0

this will be the final toothcomb that will give us confidence to move forward from #845 knowing that we didn't let anything go without notice