### PR TITLE
`tp_authority_public_key` update in pool & jdc configs

### DIFF
--- a/roles/jd-client/config-examples/jdc-config-hosted-example.toml
+++ b/roles/jd-client/config-examples/jdc-config-hosted-example.toml
@@ -28,7 +28,7 @@ retry = 10
 # tp_address = "127.0.0.1:8442"
 # Hosted testnet TP 
 tp_address = "75.119.150.111:8442"
-tp_authority_public_key = "9azQdassggC7L3YMVcZyRJmK7qrFDj5MZNHb4LkaUrJRUhct92W"
+tp_authority_public_key = "9bwHCYnjhbHm4AS3pWg9MtAH83mzWohoJJJDELYBqZhDNqszDLc"
 
 # Solo Mining config
 # List of coinbase outputs used to build the coinbase tx in case of Solo Mining (as last-resort solution of the pools fallback system)

--- a/roles/pool/config-examples/pool-config-hosted-tp-example.toml
+++ b/roles/pool/config-examples/pool-config-hosted-tp-example.toml
@@ -25,4 +25,4 @@ pool_signature = "Stratum v2 SRI Pool"
 #tp_address = "127.0.0.1:8442"
 # Hosted testnet TP 
 tp_address = "75.119.150.111:8442"
-tp_authority_public_key = "9azQdassggC7L3YMVcZyRJmK7qrFDj5MZNHb4LkaUrJRUhct92W"
+tp_authority_public_key = "9bwHCYnjhbHm4AS3pWg9MtAH83mzWohoJJJDELYBqZhDNqszDLc"


### PR DESCRIPTION
During latest changes on our hosted infrastructure, we had to spin up a new TP for `testnet4`, so a new `sv2_authority_key` has been generated there.

This PR updates Pool and JDC to use the newest public key on their relative config examples.