### PR TITLE
Handle test TemplateProvider drop error

### DIFF
--- a/roles/tests-integration/tests/common/mod.rs
+++ b/roles/tests-integration/tests/common/mod.rs
@@ -146,7 +146,7 @@ impl TemplateProvider {
     }
 
     fn stop(&self) {
-        let _ = self.bitcoind.client.stop().unwrap();
+        self.bitcoind.stop().expect("Failed to stop bitcoind");
     }
 
     fn generate_blocks(&self, n: u64) {


### PR DESCRIPTION
Resolves #1288 

As the current error we are seeing is `ConnectionRefused`, it might be that bitcoind is already down. Lets fail gracefully and keep an eye on this if it keeps poping