### PR TITLE
remove redundant `Drop` implementation from ITF `TemplateProvider`

### DIFF
--- a/roles/tests-integration/tests/common/mod.rs
+++ b/roles/tests-integration/tests/common/mod.rs
@@ -145,10 +145,6 @@ impl TemplateProvider {
         TemplateProvider { bitcoind }
     }
 
-    fn stop(&self) {
-        let _ = self.bitcoind.client.stop().unwrap();
-    }
-
     fn generate_blocks(&self, n: u64) {
         let mining_address = self
             .bitcoind
@@ -161,12 +157,6 @@ impl TemplateProvider {
             .client
             .generate_to_address(n, &mining_address)
             .unwrap();
-    }
-}
-
-impl Drop for TemplateProvider {
-    fn drop(&mut self) {
-        self.stop();
     }
 }
 


### PR DESCRIPTION
replace https://github.com/stratum-mining/stratum/pull/1290

close https://github.com/stratum-mining/stratum/issues/1288

---

`BitcoinD` already [implements the `Drop` trait](https://docs.rs/bitcoind/latest/bitcoind/struct.BitcoinD.html#impl-Drop-for-BitcoinD)

then we have a second `Drop` implementation for `TemplateProvider`:
https://github.com/stratum-mining/stratum/blob/5bcd54d6eee28a55fcc20c2aaaa707e659cf2136/roles/tests-integration/tests/common/mod.rs#L167-L171

this is not only redundant, but likely the root cause of our problems here, since it calls RPC `stop` 2x:
- the first one kills the process
- the second one fails, since the process is already dead