### PR TITLE
add unix specific execution permission to tp binary executable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-14
           - ubuntu-latest
         include:
-          - os: macos-latest
+          - os: macos-14
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl


### PR DESCRIPTION
closes #1278 
The error Permission denied (os error 13) indicates that your process does not have the necessary permissions to execute the bitcoind binary located at /tmp/.template-provider/bitcoin-sv2-tp-0.1.9/bin/bitcoind
Solution: changing macos runner version worked
