### PR TITLE
Have JDS ping local mempool less frequently

### DIFF
--- a/roles/jd-server/config-examples/jds-config-local-example.toml
+++ b/roles/jd-server/config-examples/jds-config-local-example.toml
@@ -28,4 +28,4 @@ core_rpc_pass =  "password"
 # Time interval used for JDS mempool update 
 [mempool_update_interval]
 unit = "secs"
-value = 0.1
+value = 1


### PR DESCRIPTION
Otherwise Bitcoin Core `-debug=rpc` logging becomes too noisy.

It's probably also too high for production on mainnet, "distracting" the node from its other work, but that's something that benchmarking might find.