### PR TITLE
use `cargo semver-checks` v0.37 and bump crate versions as a follow-up to #1276

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust 1.75.0
+      - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.75.0
+          toolchain: stable
           override: true
 
       - name: Cache Cargo registry
@@ -42,7 +42,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake
 
       - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --version 0.33.0 --locked
+        run: cargo install cargo-semver-checks --version 0.37.0 --locked
 
       - name: Run semver checks for common
         working-directory: common

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = { version = "1.0.64", default-features = false, features = ["alloc"
 iai="0.1"
 mining_sv2 = { path = "../protocols/v2/subprotocols/mining", version = "^1.0.0" }
 roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2", version = "^1.0.0" }
-framing_sv2 = { version = "2.0.0", path = "../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "3.0.0", path = "../protocols/v2/framing-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 num-bigint = "0.4.3"
 num-traits = "0.2.15"

--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_sv2"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_sv2 = {version = "^1.0.0", path = "../serde-sv2", optional = true}
+serde_sv2 = {version = "^2.0.0", path = "../serde-sv2", optional = true}
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true }
 binary_codec_sv2 = {version = "^1.0.0", path = "../no-serde-sv2/codec", optional = true}
 derive_codec_sv2 = {version = "^1.0.0", path = "../no-serde-sv2/derive_codec", optional = true}

--- a/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_sv2"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional = true }
-framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/framing-sv2" }
 noise_sv2 = { version = "1.0", path = "../../../protocols/v2/noise-sv2", optional=true}
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 const_sv2 = { version = "3.0.0", path = "../../../protocols/v2/const-sv2"}

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codec_sv2"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -16,7 +16,7 @@ serde = { version = "1.0.89", default-features = false, optional = true }
 framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
 noise_sv2 = { version = "1.0", path = "../../../protocols/v2/noise-sv2", optional=true}
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
-const_sv2 = { version = "2.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "3.0.0", path = "../../../protocols/v2/const-sv2"}
 buffer_sv2 = { version = "1.0.0", path = "../../../utils/buffer"}
 tracing = { version = "0.1"}
 

--- a/protocols/v2/const-sv2/Cargo.toml
+++ b/protocols/v2/const-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_sv2"
-version = "2.1.0"
+version = "3.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framing_sv2"
-version = "2.0.1"
+version = "3.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framing_sv2"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional = true }
-const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/const-sv2"}
 binary_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../../utils/buffer", optional=true }
 

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noise_sv2"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -17,7 +17,7 @@ rand = {version = "0.8.5", default-features = false, features = ["std","std_rng"
 aes-gcm = "0.10.2"
 chacha20poly1305 = "0.10.1"
 rand_chacha = "0.3.1"
-const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/const-sv2"}
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roles_logic_sv2"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -21,7 +21,7 @@ common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messag
 mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^1.0.0" }
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }
 job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^1.0.0" }
-const_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/const-sv2"}
 framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
 tracing = { version = "0.1"}
 chacha20poly1305 = { version = "0.10.1"}

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -22,7 +22,7 @@ mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^1
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }
 job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^1.0.0" }
 const_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/const-sv2"}
-framing_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/framing-sv2" }
 tracing = { version = "0.1"}
 chacha20poly1305 = { version = "0.10.1"}
 nohash-hasher = "0.2.0"

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common_messages_sv2"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -16,7 +16,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional = true }
 binary_sv2 = { version = "^1.0.0", path = "../../binary-sv2/binary-sv2" }
-const_sv2 = { version = "^2.0.0", path = "../../const-sv2" }
+const_sv2 = { version = "^3.0.0", path = "../../const-sv2" }
 quickcheck = { version = "1.0.3", optional = true }
 quickcheck_macros = { version = "1", optional = true }
 serde_repr = { version= "0.1.10", optional = true }

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job_declaration_sv2"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../binary-sv2/binary-sv2" }
-const_sv2 = {version = "^2.0.0", path = "../../const-sv2"}
+const_sv2 = {version = "^3.0.0", path = "../../const-sv2"}
 
 [features]
 no_std = []

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_sv2"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -17,7 +17,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../binary-sv2/binary-sv2" }
-const_sv2 = {version = "^2.0.0", path = "../../const-sv2"}
+const_sv2 = {version = "^3.0.0", path = "../../const-sv2"}
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "template_distribution_sv2"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -16,7 +16,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = { version = "^1.0.1", path = "../../binary-sv2/binary-sv2" }
-const_sv2 = { version = "^2.0.0", path = "../../const-sv2"}
+const_sv2 = { version = "^3.0.0", path = "../../const-sv2"}
 quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
 

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sv2_ffi"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^1.0.0" }
-const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^2.0.0" }
+const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^3.0.0" }
 binary_sv2 = { path = "../../../protocols/v2/binary-sv2/binary-sv2", version = "^1.0.0" }
 common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^2.0.0" }
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -716,7 +716,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "common_messages_sv2"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -966,7 +966,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "framing_sv2"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1374,7 +1374,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jd_client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "job_declaration_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "mining_sv2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-channel 1.9.0",
  "async-compat",

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "binary_sv2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binary_codec_sv2",
  "derive_codec_sv2",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "serde_sv2"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "buffer_sv2",
  "serde",

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -697,7 +697,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codec_sv2"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "const_sv2"
-version = "2.1.0"
+version = "3.0.0"
 
 [[package]]
 name = "convert_case"
@@ -966,7 +966,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "framing_sv2"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-channel 1.9.0",
  "binary_sv2",
@@ -1545,7 +1545,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mining_device"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "mining_proxy_sv2"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-std",
@@ -1671,7 +1671,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noise_sv2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 1.1.1",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "roles_logic_sv2"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "binary_sv2",
  "chacha20poly1305",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "template_distribution_sv2"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "binary_sv2",
  "const_sv2",

--- a/roles/jd-client/Cargo.toml
+++ b/roles/jd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_client"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Job Declarator Client (JDC) role"
@@ -22,7 +22,7 @@ async-recursion = "0.3.2"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-framing_sv2 = { version = "^2.0.0", path = "../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^3.0.0", path = "../../protocols/v2/framing-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["with_tokio", "with_buffer_pool"] }
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }

--- a/roles/jd-server/Cargo.toml
+++ b/roles/jd-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_server"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "Job Declarator Server (JDS) role"
@@ -22,7 +22,7 @@ async-channel = "1.5.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
-const_sv2 = { version = "^2.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "^3.0.0", path = "../../protocols/v2/const-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"

--- a/roles/mining-proxy/Cargo.toml
+++ b/roles/mining-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_proxy_sv2"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "SV2 mining proxy role"
@@ -23,7 +23,7 @@ async-recursion = "0.3.2"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-const_sv2 = { version = "^2.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "^3.0.0", path = "../../protocols/v2/const-sv2" }
 futures = "0.3.19"
 network_helpers_sv2 = {version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio","with_buffer_pool"] }
 once_cell = "1.12.0"

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pool_sv2"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "SV2 pool role"
@@ -22,7 +22,7 @@ async-channel = "1.5.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
-const_sv2 = { version = "^2.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "^3.0.0", path = "../../protocols/v2/const-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features =["with_tokio","with_buffer_pool"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network_helpers_sv2"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "Networking utils for SV2 roles"
@@ -20,7 +20,7 @@ async-channel = { version = "1.8.0", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 binary_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2", optional = true }
 codec_sv2 = { version = "1.0.1", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"], optional = true }
-const_sv2 = {version = "2.0.0", path = "../../../protocols/v2/const-sv2"}
+const_sv2 = {version = "3.0.0", path = "../../../protocols/v2/const-sv2"}
 serde = { version = "1.0.89", features = ["derive"], default-features = false, optional = true }
 tracing = { version = "0.1" }
 futures = "0.3.28"

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_device"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 publish = false
@@ -23,7 +23,7 @@ path = "src/lib/mod.rs"
 stratum-common = { version = "1.0.0", path = "../../../common" }
 codec_sv2 = { version = "^1.0.1", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"] }
 roles_logic_sv2 = { version = "1.0.0", path = "../../../protocols/v2/roles-logic-sv2" }
-const_sv2 = { version = "2.0.0", path = "../../../protocols/v2/const-sv2" }
+const_sv2 = { version = "3.0.0", path = "../../../protocols/v2/const-sv2" }
 async-channel = "1.5.1"
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../../roles-utils/network-helpers", features=["tokio"] }

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "translator_sv2"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Server used to bridge SV1 miners to SV2 pools"
@@ -27,7 +27,7 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
 codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-framing_sv2 = { version = "^2.0.0", path = "../../protocols/v2/framing-sv2" }
+framing_sv2 = { version = "^3.0.0", path = "../../protocols/v2/framing-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["async_std", "with_buffer_pool"] }
 once_cell = "1.12.0"
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }

--- a/utils/message-generator/Cargo.toml
+++ b/utils/message-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message_generator_sv2"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "message generator"
@@ -17,7 +17,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 async-channel = "1.8.0"
 binary_sv2 = { version = "1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2", features = ["with_serde"] }
 codec_sv2 = { version = "1.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2","with_buffer_pool","with_serde"] }
-const_sv2 = { version = "2.0.0", path = "../../protocols/v2/const-sv2" }
+const_sv2 = { version = "3.0.0", path = "../../protocols/v2/const-sv2" }
 load_file = "1.0.1"
 network_helpers_sv2 = { version = "2.0.0", path = "../../roles/roles-utils/network-helpers", features = ["with_tokio","with_serde"] }
 roles_logic_sv2 = { version = "1.0.0", path = "../../protocols/v2/roles-logic-sv2", features = ["with_serde"] }


### PR DESCRIPTION
follow up to #1276 according to this comment: https://github.com/stratum-mining/stratum/issues/1275#issuecomment-2532472582

---

# rationale

we are planning to remove more cargo build features in the future, and therefore it's desirable to enforce semver around this via CI

as a consequence, we need to use `cargo semver-check` v0.37 (or greater, but always locked)

this creates incompatibilities with MSRV, therefore we need to run `cargo semver-check` on `stable`

finally, switching `cargo semver-check` to v0.37 forced us to bump many crate versions

---

PR changes:
- use `cargo semver-check` v0.37
- use `stable` toolchain instead of MSRV 1.75
- bump MAJOR for crates that dropped `no_std` features on #1276 
- bump PATCH for crates that had dependencies on the crates that were bumped because of #1276