### PR TITLE
bump `buffer_sv2` patch

### DIFF
--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "serde",

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "criterion",

--- a/utils/buffer/Cargo.toml
+++ b/utils/buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffer_sv2"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "buffer"


### PR DESCRIPTION
we need to bump `buffer_sv2` PATCH version for two modifications introduced during milestone v1.2.0:
- #1230
- #1232

this PR bumps `buffer_sv2` PATCH from 1.1.0 to 1.1.1