### PR TITLE
change macos-14 to macos-13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-14
+          - macos-13
           - ubuntu-latest
         include:
-          - os: macos-14
+          - os: macos-13
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl


### PR DESCRIPTION
Recent changes to `macos-14` still use the latest macOS 14 runner. This PR aims to switch the macOS runner to version 13 to resolve the 'permission denied' error on macOS.