### PR TITLE
add CI for Rust Docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,111 @@
+# Enforces Rust Docs sanity (protocols crates only)
+# If `cargo doc --all-features` fails for one crate, the entire workflow fails
+
+name: Rust Docs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  cargo-doc-all-features:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Rust Docs crate common
+        run: |
+          cd common
+          cargo doc
+
+      - name: Rust Docs crate buffer_sv2
+        run: |
+          cd utils/buffer
+          cargo doc
+
+      - name: Rust Docs crate no_serde_sv2_derive_codec
+        run: |
+          cd protocols/v2/binary-sv2/no-serde-sv2/derive_codec
+          cargo doc
+
+      - name: Rust Docs crate no_serde_sv2_codec
+        run: |
+          cd protocols/v2/binary-sv2/no-serde-sv2/codec
+          cargo doc --features with_buffer_pool
+
+      - name: Rust Docs crate serde_sv2
+        run: |
+          cd protocols/v2/binary-sv2/serde-sv2
+          cargo doc
+
+      - name: Rust Docs crate binary_sv2
+        run: |
+          cd protocols/v2/binary-sv2/binary-sv2
+          cargo doc --features core,with_buffer_pool
+
+      - name: Rust Docs crate const_sv2
+        run: |
+          cd protocols/v2/const-sv2
+          cargo doc
+
+      - name: Rust Docs crate framing_sv2
+        run: |
+          cd protocols/v2/framing-sv2
+          cargo doc --features with_buffer_pool
+
+      - name: Rust Docs crate noise_sv2
+        run: |
+          cd protocols/v2/noise-sv2
+          cargo doc --features std
+
+      - name: Rust Docs crate codec_sv2
+        run: |
+          cd protocols/v2/codec-sv2
+          cargo doc --features with_buffer_pool,noise_sv2
+
+      - name: Rust Docs crate common_messages
+        run: |
+          cd protocols/v2/subprotocols/common-messages
+          cargo doc
+
+      - name: Rust Docs crate job_declaration
+        run: |
+          cd protocols/v2/subprotocols/job-declaration
+          cargo doc --all-features
+
+      - name: Rust Docs crate mining
+        run: |
+          cd protocols/v2/subprotocols/mining
+          cargo doc --all-features
+
+      - name: Rust Docs crate template_distribution
+        run: |
+          cd protocols/v2/subprotocols/template-distribution
+          cargo doc
+
+      - name: Rust Docs crate sv2_ffi
+        run: |
+          cd protocols/v2/sv2-ffi
+          cargo doc
+
+      - name: Rust Docs crate roles_logic_sv2
+
+        run: |
+          cd protocols/v2/roles-logic-sv2
+          cargo doc
+
+      - name: Rust Docs crate sv1_api
+        run: |
+          cd protocols/v1
+          cargo doc


### PR DESCRIPTION
close #1311 

adds a new CI that enforces Rust Docs are not broken