### PR TITLE
`subprotocol` crates `no_std` support

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [dependencies]
@@ -10,7 +10,7 @@ async-channel = "1.4.0"
 v1 = { path="../protocols/v1", package="sv1_api", version = "^1.0.0" }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 iai="0.1"
-mining_sv2 = { path = "../protocols/v2/subprotocols/mining", version = "^1.0.0" }
+mining_sv2 = { path = "../protocols/v2/subprotocols/mining", version = "^2.0.0" }
 roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2", version = "^1.0.0" }
 framing_sv2 = { version = "3.0.0", path = "../protocols/v2/framing-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -17,10 +17,10 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 stratum-common = { version="1.0.0", path = "../../../common", features=["bitcoin"]}
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true}
 binary_sv2 = {version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2", default-features = true }
-common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^2.0.0" }
-mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^1.0.0" }
-template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }
-job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^1.0.0" }
+common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^3.0.0" }
+mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^2.0.0" }
+template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^2.0.0" }
+job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^2.0.0" }
 const_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/const-sv2"}
 framing_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/framing-sv2" }
 tracing = { version = "0.1"}

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common_messages_sv2"
-version = "2.0.1"
+version = "3.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -22,7 +22,6 @@ quickcheck_macros = { version = "1", optional = true }
 serde_repr = { version= "0.1.10", optional = true }
 
 [features]
-no_std = []
 with_serde = ["binary_sv2/with_serde", "serde", "serde_repr"]
 prop_test = ["quickcheck"]
 

--- a/protocols/v2/subprotocols/common-messages/README.md
+++ b/protocols/v2/subprotocols/common-messages/README.md
@@ -6,7 +6,7 @@
 [![license](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/stratum-mining/stratum/blob/main/LICENSE.md)
 [![codecov](https://codecov.io/gh/stratum-mining/stratum/branch/main/graph/badge.svg)](https://app.codecov.io/gh/stratum-mining/stratum/tree/main/protocols%2Fv2%2Fcommon_messages_sv2)
 
-`common_messages_sv2` is a Rust crate that implements a set of messages shared across all Stratum V2 subprotocols.
+`common_messages_sv2` is a Rust `#![no-std]` crate that implements a set of messages shared across all Stratum V2 subprotocols.
 
 For further information, please refer to [Stratum V2 documentation - Common Messages](https://stratumprotocol.org/specification/03-Protocol-Overview/#36-common-protocol-messages).
 
@@ -14,7 +14,6 @@ For further information, please refer to [Stratum V2 documentation - Common Mess
 
 This crate can be built with the following features:
 
- - `std`: Enables support for standard library features.
  - `serde`: Enables support for serialization and deserialization using Serde.
  - `quickcheck`: Enables support for property-based testing using QuickCheck.
 

--- a/protocols/v2/subprotocols/common-messages/src/lib.rs
+++ b/protocols/v2/subprotocols/common-messages/src/lib.rs
@@ -13,7 +13,9 @@
 //!
 //! For further information about the messages, please refer to [Stratum V2
 //! documentation - Common Messages](https://stratumprotocol.org/specification/03-Protocol-Overview/#36-common-protocol-messages).
-#![cfg_attr(feature = "no_std", no_std)]
+
+#![no_std]
+
 extern crate alloc;
 mod channel_endpoint_changed;
 mod setup_connection;

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job_declaration_sv2"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -18,7 +18,6 @@ binary_sv2 = {version = "^1.0.0", path = "../../binary-sv2/binary-sv2" }
 const_sv2 = {version = "^3.0.0", path = "../../const-sv2"}
 
 [features]
-no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]
 
 [package.metadata.docs.rs]

--- a/protocols/v2/subprotocols/job-declaration/README.md
+++ b/protocols/v2/subprotocols/job-declaration/README.md
@@ -6,7 +6,7 @@
 [![license](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/stratum-mining/stratum/blob/main/LICENSE.md)
 [![codecov](https://codecov.io/gh/stratum-mining/stratum/branch/main/graph/badge.svg)](https://app.codecov.io/gh/stratum-mining/stratum/tree/main/protocols%2Fv2%2Fjob_declaration_sv2)
 
-The following crate contains the messages defined in the Job Declaration Protocol of Stratum V2.
+`job_declaration_sv2` is a Rust `#![no-std]` crate that contains the messages defined in the Job Declaration Protocol of Stratum V2.
 This protocol runs between the Job Declarator Server(JDS) and Job Declarator Client(JDC). and can be
 provided as a trusted 3rd party service for mining farms.
 
@@ -15,7 +15,6 @@ For further information about the messages, please refer to [Stratum V2 document
 ## Build Options
 
 This crate can be built with the following features:
-- `std`: Enables support for standard library features.
 - `with_serde`: Enables support for serialization and deserialization using Serde.
 
 **Note that this feature flag is only used for the Message Generator, and deprecated for any other

--- a/protocols/v2/subprotocols/job-declaration/src/lib.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "no_std", no_std)]
-
 //! # Job Declaration Protocol
 //!
 //! `job_declaration_sv2` is a Rust crate that implements a set of messages defined in the Job
@@ -16,6 +14,8 @@
 //!
 //! For further information about the messages, please refer to [Stratum V2 documentation - Job
 //! Declaration](https://stratumprotocol.org/specification/06-Job-Declaration-Protocol/).
+
+#![no_std]
 
 extern crate alloc;
 mod allocate_mining_job_token;

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_sv2"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -24,7 +24,6 @@ quickcheck = "1.0.3"
 quickcheck_macros = "1"
 
 [features]
-no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]
 
 [package.metadata.docs.rs]

--- a/protocols/v2/subprotocols/mining/README.md
+++ b/protocols/v2/subprotocols/mining/README.md
@@ -6,7 +6,7 @@
 [![license](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/stratum-mining/stratum/blob/main/LICENSE.md)
 [![codecov](https://codecov.io/gh/stratum-mining/stratum/branch/main/graph/badge.svg)](https://app.codecov.io/gh/stratum-mining/stratum/tree/main/protocols%2Fv2%2Fmining_sv2)
 
-`mining_sv2` is a Rust crate that implements a set of  messages defined in the Mining protocol of Stratum V2.
+`mining_sv2` is a Rust `#![no_std]` crate that implements a set of  messages defined in the Mining protocol of Stratum V2.
 The Mining protocol enables:
 - distribution of work to mining devices
 - submission of proof of work from mining devices
@@ -17,7 +17,6 @@ For further information about the messages, please refer to [Stratum V2 document
 ## Build Options
 
 This crate can be built with the following features:
-- `no_std`: Disables the standard library.
 - `with_serde`: Enables support for serialization and deserialization using Serde.
 
 **Note that `with_serde` feature flag is only used for the Message Generator, and deprecated for any

--- a/protocols/v2/subprotocols/mining/src/lib.rs
+++ b/protocols/v2/subprotocols/mining/src/lib.rs
@@ -11,7 +11,6 @@
 //! ## Build Options
 //!
 //! This crate can be built with the following features:
-//! - `no_std`: Disables the standard library.
 //! - `with_serde`: Enables support for serialization and deserialization using Serde.
 //!
 //! **Note that `with_serde` feature flag is only used for the Message Generator, and deprecated
@@ -27,7 +26,9 @@
 //!
 //! For further information about the mining protocol, please refer to [Stratum V2 documentation -
 //! Mining Protocol](https://stratumprotocol.org/specification/05-Mining-Protocol/).
-#![cfg_attr(feature = "no_std", no_std)]
+
+#![no_std]
+
 use binary_sv2::{B032, U256};
 use core::{
     cmp::{Ord, PartialOrd},

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "template_distribution_sv2"
-version = "1.0.3"
+version = "2.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"
@@ -21,7 +21,6 @@ quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
 
 [features]
-no_std = []
 with_serde = ["binary_sv2/with_serde", "serde"]
 prop_test = ["quickcheck"]
 

--- a/protocols/v2/subprotocols/template-distribution/README.md
+++ b/protocols/v2/subprotocols/template-distribution/README.md
@@ -6,7 +6,7 @@
 [![license](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/stratum-mining/stratum/blob/main/LICENSE.md)
 [![codecov](https://codecov.io/gh/stratum-mining/stratum/branch/main/graph/badge.svg)](https://app.codecov.io/gh/stratum-mining/stratum/tree/main/protocols%2Fv2%2Ftemplate_distribution_sv2)
 
-`template_distribution_sv2` is a Rust crate that implements a set of messages defined in the
+`template_distribution_sv2` is a Rust `#![no_std]` crate that implements a set of messages defined in the
 Template Distribution Protocol of Stratum V2. The Template Distribution protocol can be used to
 receive updates of the block templates to use in mining.
 
@@ -15,7 +15,6 @@ For further information about the messages, please refer to [Stratum V2 document
 ## Build Options
 
 This crate can be built with the following features:
-- `std`: Enables support for standard library features.
 - `with_serde`: Enables support for serialization and deserialization using Serde.
 - `prop_test`: Enables support for property testing.
 

--- a/protocols/v2/subprotocols/template-distribution/src/lib.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/lib.rs
@@ -16,7 +16,9 @@
 //!
 //! For further information about the messages, please refer to [Stratum V2 documentation - Job
 //! Distribution](https://stratumprotocol.org/specification/07-Template-Distribution-Protocol/).
-#![cfg_attr(feature = "no_std", no_std)]
+
+#![no_std]
+
 extern crate alloc;
 
 #[cfg(feature = "prop_test")]

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -7,8 +7,6 @@ use binary_sv2::Error;
 use binary_sv2::{Deserialize, Seq0255, Serialize, B0255, B064K, U256};
 #[cfg(not(feature = "with_serde"))]
 use core::convert::TryInto;
-#[cfg(all(feature = "with_serde", not(feature = "no_std")))]
-use std::convert::TryInto;
 
 /// Message used by an upstream(Template Provider) to provide a new template for downstream to mine
 /// on.

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["staticlib"]
 codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^1.0.0" }
 const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^3.0.0" }
 binary_sv2 = { path = "../../../protocols/v2/binary-sv2/binary-sv2", version = "^1.0.0" }
-common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^2.0.0" }
-template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^1.0.1" }
+common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^3.0.0" }
+template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^2.0.0" }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -716,7 +716,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "common_messages_sv2"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "job_declaration_sv2"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "mining_sv2"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "template_distribution_sv2"
-version = "1.0.3"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "const_sv2",


### PR DESCRIPTION
`common_messages_sv2` `job_declaration_sv2` `mining_sv2` `template_distribution_sv2`: remove the `no_std` feature and make them `#![no_std]` as they never use `std` anywhere.

- bump their MAJOR version because of feature removal
- bump the dependant crates PATCH version
- updates docs