### PR TITLE
simplify `[package.metadata.docs.rs]` on `protocols` crates

### DIFF
--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -28,4 +28,4 @@ prop_test = ["binary_codec_sv2/prop_test", "derive_codec_sv2"]
 with_buffer_pool = ["binary_codec_sv2/with_buffer_pool", "derive_codec_sv2"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["core", "with_buffer_pool"]

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/Cargo.toml
@@ -24,4 +24,4 @@ prop_test = ["quickcheck"]
 with_buffer_pool = ["buffer_sv2"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["with_buffer_pool"]

--- a/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/no-serde-sv2/derive_codec/Cargo.toml
@@ -18,6 +18,3 @@ binary_codec_sv2 = {version = "^1.0.0", path="../codec"}
 
 [lib]
 proc-macro = true
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/serde-sv2/Cargo.toml
@@ -17,6 +17,3 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 buffer_sv2 = {version = "^1.0.0",  path = "../../../../utils/buffer"}
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -29,4 +29,4 @@ with_buffer_pool = ["framing_sv2/with_buffer_pool"]
 no_std = []
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["with_buffer_pool", "noise_sv2"]

--- a/protocols/v2/const-sv2/Cargo.toml
+++ b/protocols/v2/const-sv2/Cargo.toml
@@ -12,6 +12,3 @@ homepage = "https://stratumprotocol.org"
 keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -29,4 +29,4 @@ with_serde = ["binary_sv2/with_serde", "serde", "buffer_sv2?/with_serde"]
 with_buffer_pool = ["binary_sv2/with_buffer_pool", "buffer_sv2"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["with_buffer_pool"]

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -22,6 +22,3 @@ const_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/const-sv2"}
 [dev-dependencies]
 quickcheck = "1.0.3"
 quickcheck_macros = "1"
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -43,6 +43,3 @@ with_serde = [ "serde",
 prop_test = ["template_distribution_sv2/prop_test"]
 # Code coverage tools may conflict with the nopanic logic, so we can disable it when needed
 disable_nopanic = []
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -24,6 +24,3 @@ serde_repr = { version= "0.1.10", optional = true }
 [features]
 with_serde = ["binary_sv2/with_serde", "serde", "serde_repr"]
 prop_test = ["quickcheck"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -19,6 +19,3 @@ const_sv2 = {version = "^3.0.0", path = "../../const-sv2"}
 
 [features]
 with_serde = ["binary_sv2/with_serde", "serde"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -25,6 +25,3 @@ quickcheck_macros = "1"
 
 [features]
 with_serde = ["binary_sv2/with_serde", "serde"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -23,6 +23,3 @@ quickcheck_macros = { version = "1", optional=true }
 [features]
 with_serde = ["binary_sv2/with_serde", "serde"]
 prop_test = ["quickcheck"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -27,6 +27,3 @@ quickcheck_macros = "1"
 [features]
 with_serde = []
 prop_test = ["binary_sv2/prop_test", "common_messages_sv2/prop_test", "template_distribution_sv2/prop_test"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/utils/buffer/Cargo.toml
+++ b/utils/buffer/Cargo.toml
@@ -33,6 +33,3 @@ harness = false
 debug = []
 fuzz = []
 with_serde = ["serde"]
-
-[package.metadata.docs.rs]
-all-features = true


### PR DESCRIPTION
currently we are making sure all published `protocols` crates cover all of the crates features on Rust Docs

we enforce that by having the following on `Cargo.toml` of each crate:
```toml
[package.metadata.docs.rs]
all-features = true
```

this strategy was suggested on #1210 and implemented via #1211

during some discussions in #1311 @jbesraa pointed out that this strategy is a bit overengineered

I agree `all-features` is more generalistic than necessary, and it is causing trouble (e.g.: trying to build `cargo b --all-features` on `template_distribution_sv2` breaks due to `with_serde` and `prop_test` being built together)

also, features like `no_std` and `with_serde` are being deprecated, so there's no point in wasting engineering effort on them

---

this PR is simplifying the `[package.metadata.docs.rs]` parameters

now, for each crate, we only enable publishing Rust Docs with features that are relevant for API usage, namely:

- `binary_sv2`: `features = ["core", "with_buffer_pool"]`
- `binary_codec_sv2`: `features = ["with_buffer_pool"]`
- `codec_sv2`: `features = ["with_buffer_pool", "noise_sv2"]`
- `framing_sv2`: `features = ["with_buffer_pool"]`

the following crates have no features that are relevant for API usage, and therefore we don't enforce anything on their `Cargo.toml`:
- `derive_codec_sv2`
- `serde_sv2`
- `const_sv2`
- `noise_sv2`
- `roles_logic_sv2`
- `common_messages_sv2`
- `job_declaration_sv2`
- `mining_sv2`
- `template_distribution_sv2`
- `sv2_ffi`
- `buffer_sv2`