### PR TITLE
Fix timestamp bug - `min_ntime` becomes always the one sent by TP

### DIFF
--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roles_logic_sv2"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "Common handlers for use within SV2 roles"

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -211,10 +211,11 @@ fn new_extended_job(
         extranonce_len,
     );
 
-    let min_ntime = match new_template.future_template {
-        true => binary_sv2::Sv2Option::new(None),
-        false => binary_sv2::Sv2Option::new(ntime),
-    };
+    let min_ntime = binary_sv2::Sv2Option::new(if new_template.future_template {
+        None
+    } else {
+        ntime
+    });
 
     let new_extended_mining_job: NewExtendedMiningJob<'static> = NewExtendedMiningJob {
         channel_id: 0,

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "roles_logic_sv2"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "binary_sv2",
  "chacha20poly1305",

--- a/roles/tests-integration/tests/common/mod.rs
+++ b/roles/tests-integration/tests/common/mod.rs
@@ -81,20 +81,21 @@ pub struct TemplateProvider {
 }
 
 impl TemplateProvider {
-    pub fn start(port: u16) -> Self {
+    pub fn start(port: u16, sv2_interval: u32) -> Self {
         let temp_dir = PathBuf::from("/tmp/.template-provider");
         let mut conf = Conf::default();
         let staticdir = format!(".bitcoin-{}", port);
         conf.staticdir = Some(temp_dir.join(staticdir));
-        let port = format!("-sv2port={}", port);
+        let port_arg = format!("-sv2port={}", port);
+        let sv2_interval_arg = format!("-sv2interval={}", sv2_interval);
         conf.args.extend(vec![
             "-txindex=1",
             "-sv2",
-            &port,
+            &port_arg,
             "-debug=rpc",
             "-debug=sv2",
-            "-sv2interval=20",
-            "-sv2feedelta=1000",
+            &sv2_interval_arg,
+            "-sv2feedelta=0",
             "-loglevel=sv2:trace",
             "-logtimemicros=1",
         ]);
@@ -284,8 +285,9 @@ pub async fn start_pool(
     pool
 }
 
-pub async fn start_template_provider(tp_port: u16) -> TemplateProvider {
-    let template_provider = TemplateProvider::start(tp_port);
+pub async fn start_template_provider(tp_port: u16, sv2_interval: Option<u32>) -> TemplateProvider {
+    let sv2_interval = sv2_interval.unwrap_or(20);
+    let template_provider = TemplateProvider::start(tp_port, sv2_interval);
     template_provider.generate_blocks(16);
     template_provider
 }

--- a/roles/tests-integration/tests/translator_integration.rs
+++ b/roles/tests-integration/tests/translator_integration.rs
@@ -21,7 +21,7 @@ async fn translation_proxy() {
         None,
     )
     .await;
-    let _tp = common::start_template_provider(tp_addr.port()).await;
+    let _tp = common::start_template_provider(tp_addr.port(), None).await;
     let _pool = common::start_pool(Some(pool_addr), Some(tp_addr)).await;
     let tproxy_addr = common::start_sv2_translator(pool_translator_sniffer_addr).await;
     let _mining_device = common::start_mining_device_sv1(tproxy_addr).await;


### PR DESCRIPTION
This PR introduces a new `last_ntime` field into `JobsCreators` struct to save the last `nTime` value sent by TP. 

In this way, the correct value is always used when creating new jobs (future and not), instead of using the current system time.

Closes #1324 