### PR TITLE
remove `readme` field from `Cargo.toml` of crates that dont have a `README.md`

### DIFF
--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -3,7 +3,6 @@ name = "roles_logic_sv2"
 version = "1.2.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
-readme = "README.md"
 description = "Common handlers for use within SV2 roles"
 documentation = "https://docs.rs/roles_logic_sv2"
 license = "MIT OR Apache-2.0"

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -3,7 +3,6 @@ name = "sv2_ffi"
 version = "1.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
-readme = "README.md"
 description = "SV2 FFI"
 documentation = "https://github.com/stratum-mining/stratum"
 license = "MIT OR Apache-2.0"

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "Networking utils for SV2 roles"
 documentation = "https://docs.rs/network_helpers_sv2"
-readme = "README.md"
 homepage = "https://stratumprotocol.org"
 repository = "https://github.com/stratum-mining/stratum"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
close #1326