### PR TITLE
`release-libs.yaml` use `1.75.0` toolchain

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: 1.75.0
             override: true
       - name: Login
         run: cargo login ${{ secrets.CRATES_IO_DEPLOY_KEY }}


### PR DESCRIPTION
follow up to https://github.com/stratum-mining/stratum/pull/1329

it turns out that `cargo` v1.83.0 (which is the current `stable` toolchain) outputs the following string when `cargo publish` is trying to publish a crate that has already been published:

```
$ cargo +stable publish
    Updating crates.io index
error: crate stratum-common@1.0.0 already exists on crates.io index
```

but the script checks for a different string, which is the output of `cargo` v1.75.0 (MSRV):
```
$ cargo +1.75.0 publish
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): crate version `1.0.0` is already uploaded
```

one could argue:
> why not adapt `scripts/release-libs.sh` to look for the `already exists on crates.io index` string?

that would be suboptimal, because in the future a new `stable` could use yet another different string, which would break the workflow again (making us forever chase a moving target)

so it's better to simply always run the workflow under MSRV and always have a predictable outcome