### PR TITLE
remove `readme` field from `Cargo.toml` of crates that dont have a `README.md`

### DIFF
--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV2 JD Server RPC"
 documentation = "https://docs.rs/rpc_sv2"
-readme = "README.md"
 homepage = "https://stratumprotocol.org"
 repository = "https://github.com/stratum-mining/stratum"
 license = "MIT OR Apache-2.0"

--- a/utils/error-handling/Cargo.toml
+++ b/utils/error-handling/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Macro used to clean and centralize error handling within async processes"
 documentation = "https://docs.rs/error_handling"
-readme = "README.md"
 homepage = "https://stratumprotocol.org"
 repository = "https://github.com/stratum-mining/stratum"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
follow up to #1328

we missed these crates:
- `error_handling`
- `rpc_sv2`