### PR TITLE
Handle `cargo build` warnings

### DIFF
--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/codec/mod.rs
@@ -112,6 +112,7 @@ pub trait Fixed {
 }
 
 // Not used and will be removed during refactoring
+#[allow(dead_code)]
 pub trait Variable {
     const HEADER_SIZE: usize;
     //const ELEMENT_SIZE: usize;

--- a/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
+++ b/protocols/v2/binary-sv2/no-serde-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
@@ -40,6 +40,7 @@ use alloc::vec::Vec;
 mod inner;
 mod seq_inner;
 
+#[allow(dead_code)]
 trait IntoOwned {
     fn into_owned(self) -> Self;
 }

--- a/protocols/v2/binary-sv2/serde-sv2/src/de.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/de.rs
@@ -453,6 +453,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 }
 
+#[allow(dead_code)]
 struct Seq<'de, 'a> {
     de: &'a mut Deserializer<'de>,
     len: usize,

--- a/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/mod.rs
+++ b/protocols/v2/binary-sv2/serde-sv2/src/primitives/byte_arrays/mod.rs
@@ -5,6 +5,7 @@ pub mod b064k;
 pub mod bytes;
 
 pub trait IntoStatic {
+    #[allow(dead_code)]
     fn into_static(self) -> Self;
 }
 

--- a/protocols/v2/noise-sv2/src/cipher_state.rs
+++ b/protocols/v2/noise-sv2/src/cipher_state.rs
@@ -95,6 +95,7 @@ where
         res
     }
 
+    #[allow(dead_code)]
     fn into_aesg(mut self) -> Option<Cipher<Aes256Gcm>> {
         #[allow(clippy::clone_on_copy)]
         let k = self.get_k().clone()?;
@@ -102,6 +103,7 @@ where
         Some(Cipher::from_cipher(c))
     }
 
+    #[allow(dead_code)]
     fn into_chacha(mut self) -> Option<Cipher<ChaCha20Poly1305>> {
         #[allow(clippy::clone_on_copy)]
         let k = self.get_k().clone()?;

--- a/protocols/v2/noise-sv2/src/handshake.rs
+++ b/protocols/v2/noise-sv2/src/handshake.rs
@@ -101,6 +101,7 @@ pub trait HandshakeOp<Cipher: AeadCipher>: CipherState<Cipher> {
     // Generates a fresh key pair, consisting of a secret key and a corresponding public key,
     // using the [`Secp256k1`] elliptic curve. If the generated public key does not match the
     // expected parity, a new key pair is generated to ensure consistency.
+    #[allow(dead_code)]
     #[cfg(feature = "std")]
     fn generate_key() -> Keypair {
         Self::generate_key_with_rng(&mut rand::thread_rng())
@@ -173,6 +174,7 @@ pub trait HandshakeOp<Cipher: AeadCipher>: CipherState<Cipher> {
         (out_1, out_2)
     }
 
+    #[allow(dead_code)]
     fn hkdf_3(
         chaining_key: &[u8; 32],
         input_key_material: &[u8],
@@ -236,6 +238,7 @@ pub trait HandshakeOp<Cipher: AeadCipher>: CipherState<Cipher> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     fn ecdh(private: &[u8], public: &[u8]) -> [u8; 32] {
         let private = SecretKey::from_slice(private).expect("Wrong key");
         let x_public = XOnlyPublicKey::from_slice(public).expect("Wrong key");
@@ -284,7 +287,7 @@ mod test {
     use core::convert::TryInto;
     use quickcheck::{Arbitrary, TestResult};
     use quickcheck_macros;
-    use secp256k1::{ecdh::SharedSecret, SecretKey, XOnlyPublicKey};
+    use secp256k1::SecretKey;
 
     struct TestHandShake {
         k: Option<[u8; 32]>,

--- a/protocols/v2/noise-sv2/src/signature_message.rs
+++ b/protocols/v2/noise-sv2/src/signature_message.rs
@@ -71,6 +71,7 @@ impl SignatureNoiseMessage {
     //
     // If an authority public key is not provided, the function assumes that the signature
     // is already valid without further verification.
+    #[allow(dead_code)]
     #[cfg(feature = "std")]
     pub fn verify(self, pk: &XOnlyPublicKey, authority_pk: &Option<XOnlyPublicKey>) -> bool {
         let now = std::time::SystemTime::now()
@@ -119,6 +120,7 @@ impl SignatureNoiseMessage {
     // Creates a Schnorr signature for the message, combining the version, validity period, and
     // the static public key of the server (`static_pk`). The resulting signature is then written
     // into the provided message buffer (`msg`).
+    #[allow(dead_code)]
     #[cfg(feature = "std")]
     pub fn sign(msg: &mut [u8; 74], static_pk: &XOnlyPublicKey, kp: &Keypair) {
         Self::sign_with_rng(msg, static_pk, kp, &mut rand::thread_rng());

--- a/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
@@ -74,6 +74,7 @@ impl<'a> BlockHeader<'a> {
 // helper struct to identify Standard Jobs being managed for downstream
 #[derive(Debug)]
 struct DownstreamJob {
+    #[allow(dead_code)]
     merkle_root: Vec<u8>,
     extended_job_id: u32,
 }

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -797,7 +797,7 @@ pub fn target_from_hash_rate(hash_per_second: f32, share_per_min: f32) -> U256<'
 }
 
 /// TODO: Not used, to be removed.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
+#[allow(clippy::too_many_arguments)]
 pub fn get_target(
     nonce: u32,
     version: u32,

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -388,7 +388,7 @@ pub extern "C" fn new_encoder() -> *mut EncoderWrapper {
 pub extern "C" fn flush_encoder(encoder: *mut EncoderWrapper) {
     let mut encoder = unsafe { Box::from_raw(encoder) };
     encoder.free = true;
-    Box::into_raw(encoder);
+    let _ = Box::into_raw(encoder);
 }
 
 fn encode_(
@@ -431,7 +431,7 @@ pub unsafe extern "C" fn encode(
     if encoder.free {
         let result = encode_(message, &mut encoder);
         encoder.free = false;
-        Box::into_raw(encoder);
+        let _ = Box::into_raw(encoder);
         result.into()
     } else {
         CResult::Err(Sv2Error::EncoderBusy)
@@ -453,7 +453,7 @@ pub extern "C" fn get_writable(decoder: *mut DecoderWrapper) -> CVec {
     let mut decoder = unsafe { Box::from_raw(decoder) };
     let writable = decoder.0.writable();
     let res = CVec::as_shared_buffer(writable);
-    Box::into_raw(decoder);
+    let _ = Box::into_raw(decoder);
     res
 }
 
@@ -472,7 +472,7 @@ pub extern "C" fn next_frame(decoder: *mut DecoderWrapper) -> CResult<CSv2Messag
             let len = payload.len();
             let ptr = payload.as_mut_ptr();
             let payload = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
-            Box::into_raw(decoder);
+            let _ = Box::into_raw(decoder);
             (msg_type, payload)
                 .try_into()
                 .map(|x: Sv2Message| x.into())
@@ -480,7 +480,7 @@ pub extern "C" fn next_frame(decoder: *mut DecoderWrapper) -> CResult<CSv2Messag
                 .into()
         }
         Err(_) => {
-            Box::into_raw(decoder);
+            let _ = Box::into_raw(decoder);
             CResult::Err(Sv2Error::MissingBytes)
         }
     }

--- a/roles/roles-utils/rpc/src/lib.rs
+++ b/roles/roles-utils/rpc/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Hash([u8; 32]);
 
+#[allow(dead_code)]
 #[derive(Clone, Deserialize)]
 pub struct Amount(f64);
 


### PR DESCRIPTION
resolves #1096  and #1048 

None of the dead code is removed and only marked with `dead_code` macro.