### PR TITLE
`codec_sv2` with optional `no_std`

### DIFF
--- a/examples/ping-pong-with-noise/Cargo.toml
+++ b/examples/ping-pong-with-noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ping_pong_with_noise"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 publish = false
@@ -14,7 +14,7 @@ async-channel = "1.5.1"
 async-std="1.8.0"
 bytes = "1.0.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
-codec_sv2 = { version = "^1.0.0", path = "../../protocols/v2/codec-sv2", features=["noise_sv2"] }
+codec_sv2 = { version = "^2.0.0", path = "../../protocols/v2/codec-sv2", features=["noise_sv2"] }
 network_helpers_sv2 = { version = "^2.0.0", path = "../../roles/roles-utils/network-helpers", features=["async_std"] }
 key-utils = { version = "^1.0.0", path = "../../utils/key-utils" }
 

--- a/examples/ping-pong-with-noise/Cargo.toml
+++ b/examples/ping-pong-with-noise/Cargo.toml
@@ -17,6 +17,11 @@ binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-
 codec_sv2 = { version = "^2.0.0", path = "../../protocols/v2/codec-sv2", features=["noise_sv2"] }
 network_helpers_sv2 = { version = "^2.0.0", path = "../../roles/roles-utils/network-helpers", features=["async_std"] }
 key-utils = { version = "^1.0.0", path = "../../utils/key-utils" }
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "abort"
 
 [features]
 with_serde = ["binary_sv2/with_serde", "serde", "codec_sv2/with_serde", "network_helpers_sv2/with_serde"]

--- a/examples/template-provider-test/Cargo.toml
+++ b/examples/template-provider-test/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "template-provider-test"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codec_sv2 = { version = "1.0", path = "../../protocols/v2/codec-sv2", features=["noise_sv2"] }
+codec_sv2 = { version = "2.0", path = "../../protocols/v2/codec-sv2", features=["noise_sv2"] }
 roles_logic_sv2 = { version = "^0.1.0", path = "../../protocols/v2/roles-logic-sv2" }
 network_helpers_sv2 = { version = "^0.1.0", path = "../../roles/roles-utils/network-helpers", features=["async_std"] }
 async-channel = "1.5.1"

--- a/protocols/fuzz-tests/Cargo.toml
+++ b/protocols/fuzz-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz-tests"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Automatically generated"]
 publish = false
@@ -18,7 +18,7 @@ libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
 arbitrary = { version = "1", features = ["derive"] }
 rand = "0.8.3"
 binary_codec_sv2 = { version = "1.0.0", path = "../v2/binary-sv2/no-serde-sv2/codec"}
-codec_sv2 = { version = "1.0.0", path = "../v2/codec-sv2", features = ["noise_sv2"]}
+codec_sv2 = { version = "2.0.0", path = "../v2/codec-sv2", features = ["noise_sv2"]}
 roles_logic_sv2 = { version = "1.0.0", path = "../v2/roles-logic-sv2"}
 affinity = "0.1.1"
 threadpool = "1.8.1"

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codec_sv2"
-version = "1.3.1"
+version = "2.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -14,19 +14,21 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 serde = { version = "1.0.89", default-features = false, optional = true }
 framing_sv2 = { version = "^3.0.0", path = "../../../protocols/v2/framing-sv2" }
-noise_sv2 = { version = "1.0", path = "../../../protocols/v2/noise-sv2", optional=true}
+noise_sv2 = { version = "1.0", path = "../../../protocols/v2/noise-sv2", default-features = false, optional = true }
 binary_sv2 = { version = "1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 const_sv2 = { version = "3.0.0", path = "../../../protocols/v2/const-sv2"}
 buffer_sv2 = { version = "1.0.0", path = "../../../utils/buffer"}
+rand = {version = "0.8.5", default-features = false }
 tracing = { version = "0.1"}
 
 [dev-dependencies]
 key-utils = { version = "^1.0.0", path = "../../../utils/key-utils" }
 
 [features]
+default = ["std"]
+std = ["noise_sv2?/std", "rand/std", "rand/std_rng"]
 with_serde = ["binary_sv2/with_serde", "serde", "framing_sv2/with_serde", "buffer_sv2/with_serde"]
 with_buffer_pool = ["framing_sv2/with_buffer_pool"]
-no_std = []
 
 [package.metadata.docs.rs]
 features = ["with_buffer_pool", "noise_sv2"]

--- a/protocols/v2/codec-sv2/README.md
+++ b/protocols/v2/codec-sv2/README.md
@@ -28,12 +28,15 @@ cargo add codec_sv2
 
 This crate can be built with the following feature flags:
 
+- `std`: Enable usage of rust `std` library, enabled by default.
 - `noise_sv2`: Enables support for Noise protocol encryption and decryption.
 - `with_buffer_pool`: Enables buffer pooling for more efficient memory management.
 - `with_serde`: builds [`binary_sv2`](https://crates.io/crates/binary_sv2) and
   [`buffer_sv2`](https://crates.io/crates/buffer_sv2) crates with `serde`-based encoding and
   decoding. Note that this feature flag is only used for the Message Generator, and deprecated
   for any other kind of usage. It will likely be fully deprecated in the future.
+
+In order to use this crate in a `#![no_std]` environment, use the `--no-default-features` to remove the `std` feature.
 
 ### Examples
 

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sv2_ffi"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "SV2 FFI"
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 crate-type = ["staticlib"]
 
 [dependencies]
-codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^1.0.0" }
+codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0" }
 const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^3.0.0" }
 binary_sv2 = { path = "../../../protocols/v2/binary-sv2/binary-sv2", version = "^1.0.0" }
 common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^3.0.0" }

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "const_sv2",
  "framing_sv2",
  "noise_sv2",
+ "rand",
  "serde",
  "tracing",
 ]

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -697,7 +697,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codec_sv2"
-version = "1.3.1"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1375,7 +1375,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jd_client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "binary_sv2",
@@ -1546,7 +1546,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mining_device"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "mining_proxy_sv2"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "async-channel 1.9.0",
  "async-std",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 1.1.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-compat",

--- a/roles/jd-client/Cargo.toml
+++ b/roles/jd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_client"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Job Declarator Client (JDC) role"
@@ -21,7 +21,7 @@ async-channel = "1.5.1"
 async-recursion = "0.3.2"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
-codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
+codec_sv2 = { version = "^2.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 framing_sv2 = { version = "^3.0.0", path = "../../protocols/v2/framing-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["with_tokio", "with_buffer_pool"] }
 roles_logic_sv2 = { version = "^1.0.0", path = "../../protocols/v2/roles-logic-sv2" }

--- a/roles/jd-server/Cargo.toml
+++ b/roles/jd-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_server"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "Job Declarator Server (JDS) role"
@@ -21,7 +21,7 @@ stratum-common = { version = "1.0.0", path = "../../common" }
 async-channel = "1.5.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
-codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
+codec_sv2 = { version = "^2.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
 const_sv2 = { version = "^3.0.0", path = "../../protocols/v2/const-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }

--- a/roles/mining-proxy/Cargo.toml
+++ b/roles/mining-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_proxy_sv2"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "SV2 mining proxy role"
@@ -22,7 +22,7 @@ async-channel = "1.8.0"
 async-recursion = "0.3.2"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
-codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
+codec_sv2 = { version = "^2.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 const_sv2 = { version = "^3.0.0", path = "../../protocols/v2/const-sv2" }
 futures = "0.3.19"
 network_helpers_sv2 = {version = "2.0.0", path = "../roles-utils/network-helpers", features = ["with_tokio","with_buffer_pool"] }

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pool_sv2"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "SV2 pool role"
@@ -21,7 +21,7 @@ stratum-common = { version = "1.0.0", path = "../../common" }
 async-channel = "1.5.1"
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
-codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
+codec_sv2 = { version = "^2.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
 const_sv2 = { version = "^3.0.0", path = "../../protocols/v2/const-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features =["with_tokio","with_buffer_pool"] }
 noise_sv2 = { version = "1.1.0", path = "../../protocols/v2/noise-sv2" }

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network_helpers_sv2"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "Networking utils for SV2 roles"
@@ -18,7 +18,7 @@ async-std = { version = "1.8.0", optional = true }
 async-channel = { version = "1.8.0", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 binary_sv2 = { version = "^1.0.0", path = "../../../protocols/v2/binary-sv2/binary-sv2", optional = true }
-codec_sv2 = { version = "1.0.1", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"], optional = true }
+codec_sv2 = { version = "2.0.0", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"], optional = true }
 const_sv2 = {version = "3.0.0", path = "../../../protocols/v2/const-sv2"}
 serde = { version = "1.0.89", features = ["derive"], default-features = false, optional = true }
 tracing = { version = "0.1" }

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_device"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 publish = false
@@ -21,7 +21,7 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 stratum-common = { version = "1.0.0", path = "../../../common" }
-codec_sv2 = { version = "^1.0.1", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"] }
+codec_sv2 = { version = "^2.0.0", path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"] }
 roles_logic_sv2 = { version = "1.0.0", path = "../../../protocols/v2/roles-logic-sv2" }
 const_sv2 = { version = "3.0.0", path = "../../../protocols/v2/const-sv2" }
 async-channel = "1.5.1"

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "translator_sv2"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Server used to bridge SV1 miners to SV2 pools"
@@ -26,7 +26,7 @@ async-recursion = "0.3.2"
 async-std = { version = "1.12.0", features = ["attributes"] }
 binary_sv2 = { version = "^1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2" }
 buffer_sv2 = { version = "^1.0.0", path = "../../utils/buffer" }
-codec_sv2 = { version = "^1.0.1", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
+codec_sv2 = { version = "^2.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 framing_sv2 = { version = "^3.0.0", path = "../../protocols/v2/framing-sv2" }
 network_helpers_sv2 = { version = "2.0.0", path = "../roles-utils/network-helpers", features=["async_std", "with_buffer_pool"] }
 once_cell = "1.12.0"

--- a/utils/message-generator/Cargo.toml
+++ b/utils/message-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message_generator_sv2"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "message generator"
@@ -16,7 +16,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 async-channel = "1.8.0"
 binary_sv2 = { version = "1.0.0", path = "../../protocols/v2/binary-sv2/binary-sv2", features = ["with_serde"] }
-codec_sv2 = { version = "1.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2","with_buffer_pool","with_serde"] }
+codec_sv2 = { version = "2.0.0", path = "../../protocols/v2/codec-sv2", features = ["noise_sv2","with_buffer_pool","with_serde"] }
 const_sv2 = { version = "3.0.0", path = "../../protocols/v2/const-sv2" }
 load_file = "1.0.1"
 network_helpers_sv2 = { version = "2.0.0", path = "../../roles/roles-utils/network-helpers", features = ["with_tokio","with_serde"] }


### PR DESCRIPTION
same technique as for `noise_sv2` on which it is depending : adding a `#![no_std]` compliant intermediary API using the `x_with_now_rng()` so use can provide a `no_std` system time and randome number generator is the embedded system have them.