### PR TITLE
Integration tests avoid tmp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cobertura.xml
 /roles/*/*-config.toml
 /examples/*/Cargo.lock
 /scripts/sv2.h
+/roles/tests-integration/template-provider

--- a/roles/tests-integration/README.md
+++ b/roles/tests-integration/README.md
@@ -22,5 +22,9 @@ $ git clone git@github.com:stratum-mining/stratum.git
 $ cargo test --manifest-path=roles/Cargo.toml --verbose --test '*' -- --nocapture
 ```
 
+Note: during the execution of the tests, a new directory called `template-provider` is created.
+This directory holds the executable for Template Provider node, as well as the different data 
+directories created for each execution.
+
 ## License
 MIT OR Apache-2.0

--- a/roles/tests-integration/lib/template_provider.rs
+++ b/roles/tests-integration/lib/template_provider.rs
@@ -67,10 +67,11 @@ pub struct TemplateProvider {
 
 impl TemplateProvider {
     pub fn start(port: u16, sv2_interval: u32) -> Self {
-        let temp_dir = PathBuf::from("/tmp/.template-provider");
+        let current_dir: PathBuf = std::env::current_dir().expect("failed to read current dir");
+        let tp_dir = current_dir.join("template-provider");
         let mut conf = Conf::default();
         let staticdir = format!(".bitcoin-{}", port);
-        conf.staticdir = Some(temp_dir.join(staticdir));
+        conf.staticdir = Some(tp_dir.join(staticdir));
         let port_arg = format!("-sv2port={}", port);
         let sv2_interval_arg = format!("-sv2interval={}", sv2_interval);
         conf.args.extend(vec![
@@ -88,7 +89,7 @@ impl TemplateProvider {
         let os = env::consts::OS;
         let arch = env::consts::ARCH;
         let download_filename = get_bitcoind_filename(os, arch);
-        let bitcoin_exe_home = temp_dir
+        let bitcoin_exe_home = tp_dir
             .join(format!("bitcoin-sv2-tp-{}", VERSION_TP))
             .join("bin");
 
@@ -112,7 +113,7 @@ impl TemplateProvider {
                 create_dir_all(parent).unwrap();
             }
 
-            unpack_tarball(&tarball_bytes, &temp_dir);
+            unpack_tarball(&tarball_bytes, &tp_dir);
 
             if os == "macos" {
                 let bitcoind_binary = bitcoin_exe_home.join("bitcoind");


### PR DESCRIPTION
closes #1278, alternative to #1342

unfortunately #1293 didn't fix #1278

this PR changes the directory where TP is downloaded into, replacing `/tmp` (which was giving permission errors in an undeterministic way) to a new `template-provider` directory crated at the Integration Test execution (which shouldn't ever have permission issues)

this new directory is listed on a new `.gitignore` so that we don't commit binary executables to the SRI repo, which would be bad practice