### PR TITLE
Allow backtrace print to stdout in integration tests

### DIFF
--- a/roles/tests-integration/lib/sniffer.rs
+++ b/roles/tests-integration/lib/sniffer.rs
@@ -105,10 +105,6 @@ impl Sniffer {
         check_on_drop: bool,
         intercept_messages: Option<Vec<InterceptMessage>>,
     ) -> Self {
-        // Don't print backtrace on panic
-        std::panic::set_hook(Box::new(|_| {
-            println!();
-        }));
         Self {
             identifier,
             listening_address,


### PR DESCRIPTION
resolves #1381 