### PR TITLE
Protocols v2 no_std support

### DIFF
--- a/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/binary-sv2/Cargo.toml
@@ -18,7 +18,6 @@ serde_sv2 = { path = "../serde-sv2", optional = true }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true }
 binary_codec_sv2 = { path = "../no-serde-sv2/codec", optional = true }
 derive_codec_sv2 = { path = "../no-serde-sv2/derive_codec", optional = true }
-tracing = { version = "0.1", default-features = false }
 
 [features]
 default = ["core"]

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -19,14 +19,14 @@ binary_sv2 = { path = "../../../protocols/v2/binary-sv2/binary-sv2" }
 const_sv2 = { path = "../../../protocols/v2/const-sv2"}
 buffer_sv2 = { path = "../../../utils/buffer"}
 rand = { version = "0.8.5", default-features = false }
-tracing = { version = "0.1"}
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 key-utils = { path = "../../../utils/key-utils" }
 
 [features]
 default = ["std"]
-std = ["noise_sv2?/std", "rand/std", "rand/std_rng"]
+std = ["noise_sv2?/std", "rand/std", "rand/std_rng", "dep:tracing"]
 with_serde = ["binary_sv2/with_serde", "serde", "framing_sv2/with_serde", "buffer_sv2/with_serde"]
 with_buffer_pool = ["framing_sv2/with_buffer_pool"]
 

--- a/protocols/v2/codec-sv2/src/encoder.rs
+++ b/protocols/v2/codec-sv2/src/encoder.rs
@@ -34,7 +34,7 @@ use framing_sv2::framing::{Frame, HandShakeFrame};
 #[allow(unused_imports)]
 pub use framing_sv2::header::NOISE_HEADER_ENCRYPTED_SIZE;
 
-#[cfg(feature = "noise_sv2")]
+#[cfg(feature = "tracing")]
 use tracing::error;
 
 #[cfg(feature = "noise_sv2")]
@@ -144,6 +144,7 @@ impl<T: Serialize + GetSize> NoiseEncoder<T> {
 
                 // ENCODE THE SV2 FRAME
                 let i: Sv2Frame<T, Slice> = item.try_into().map_err(|e| {
+                    #[cfg(feature = "tracing")]
                     error!("Error while encoding 1 frame: {:?}", e);
                     Error::FramingError(e)
                 })?;
@@ -198,6 +199,7 @@ impl<T: Serialize + GetSize> NoiseEncoder<T> {
     fn while_handshaking(&mut self, item: Item<T>) -> Result<()> {
         // ENCODE THE SV2 FRAME
         let i: HandShakeFrame = item.try_into().map_err(|e| {
+            #[cfg(feature = "tracing")]
             error!("Error while encoding 2 frame - while_handshaking: {:?}", e);
             Error::FramingError(e)
         })?;

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 secp256k1 = { version = "0.28.2", default-features = false, features = ["hashes", "alloc", "rand"] }
 rand = {version = "0.8.5", default-features = false }
-aes-gcm = "0.10.2"
-chacha20poly1305 = "0.10.1"
+aes-gcm = { version = "0.10.2", features = ["alloc", "aes"], default-features = false }
+chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["alloc"]}
 rand_chacha = { version = "0.3.1", default-features = false }
 const_sv2 = { path = "../../../protocols/v2/const-sv2"}
 

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -376,7 +376,6 @@ dependencies = [
  "derive_codec_sv2",
  "serde",
  "serde_sv2",
- "tracing",
 ]
 
 [[package]]

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -298,7 +298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
 ]
 

--- a/utils/buffer/Cargo.toml
+++ b/utils/buffer/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 criterion = {version = "0.3", optional = true}
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false, optional = true }
-aes-gcm = "0.10.2"
+aes-gcm = { version = "0.10.2", features = ["alloc", "aes"], default-features = false }
 
 [dev-dependencies]
 rand = "0.8.3"


### PR DESCRIPTION
Here are a couple of change to avoid `getrandom` which is [not compatible](https://docs.rs/getrandom/latest/getrandom/#unsupported-targets) with `no_std`.
