### PR TITLE
disable codecov github checks annotation

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,3 +11,5 @@ coverage:
         target: auto
         threshold: 100%
         base: auto
+github_checks:
+    annotations: false


### PR DESCRIPTION
This PR removes the GitHub check annotations from being displayed in the pull request.
![Screenshot from 2025-01-26 21-37-50](https://github.com/user-attachments/assets/895ca45e-ba50-433c-be1e-bb49614955a6)
