### PR TITLE
Add `tracing-subscriber` to itf

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-latest
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            target: x86_64-unknown-linux-gnu
 
     steps:
       - name: Use stable toolchain

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Roles Integration Tests
         run: |
-          cargo test --manifest-path=roles/Cargo.toml --verbose --test '*' -- --nocapture
+         RUST_LOG=debug cargo test --manifest-path=roles/Cargo.toml --verbose --test '*' -- --nocapture

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -76,6 +76,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1413,7 @@ dependencies = [
  "tar",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "translator_sv2",
 ]
 
@@ -1587,6 +1597,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2098,6 +2117,50 @@ checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
@@ -2711,10 +2774,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/roles/tests-integration/Cargo.toml
+++ b/roles/tests-integration/Cargo.toml
@@ -33,6 +33,7 @@ tracing = "0.1.40"
 translator_sv2 = { path = "../translator" }
 rand = "0.8.4"
 stratum-common = { path = "../../common" }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [lib]
 path = "lib/mod.rs"

--- a/roles/tests-integration/lib/mod.rs
+++ b/roles/tests-integration/lib/mod.rs
@@ -3,19 +3,30 @@ use jd_client::JobDeclaratorClient;
 use jd_server::JobDeclaratorServer;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use pool_sv2::PoolSv2;
-use translator_sv2::TranslatorSv2;
-
 use rand::{thread_rng, Rng};
 use std::{
     convert::{TryFrom, TryInto},
     net::SocketAddr,
     str::FromStr,
+    sync::Once,
 };
+use tracing_subscriber::EnvFilter;
+use translator_sv2::TranslatorSv2;
 use utils::get_available_address;
 
 pub mod sniffer;
 pub mod template_provider;
 mod utils;
+
+static LOGGER: Once = Once::new();
+
+pub fn start_tracing() {
+    LOGGER.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .init();
+    });
+}
 
 pub async fn start_sniffer(
     identifier: String,

--- a/roles/tests-integration/tests/jd_integration.rs
+++ b/roles/tests-integration/tests/jd_integration.rs
@@ -1,9 +1,15 @@
+// This file contains integration tests for the `JDC/S` module.
+//
+// `JDC/S` are modules that implements the Job Decleration roles in the Stratum V2 protocol.
+//
+// Note that it is enough to call `start_tracing()` once in the test suite to enable tracing for
+// all tests. This is because tracing is a global setting.
 use integration_tests_sv2::*;
 
 use roles_logic_sv2::parsers::{CommonMessages, PoolMessages};
 
-// This test verifies that the `jds` (Job Distributor Server) does not panic when the `jdc`
-// (Job Distributor Client) shuts down.
+// This test verifies that the `jds` (Job Decleration Server) does not panic when the `jdc`
+// (Job Decleration Client) shuts down.
 //
 // The test follows these steps:
 // 1. Start a Template Provider (`tp`) and a Pool.

--- a/roles/tests-integration/tests/pool_integration.rs
+++ b/roles/tests-integration/tests/pool_integration.rs
@@ -1,10 +1,9 @@
-use integration_tests_sv2::*;
-
 use crate::sniffer::MessageDirection;
 use const_sv2::{
     MESSAGE_TYPE_MINING_SET_NEW_PREV_HASH, MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
     MESSAGE_TYPE_NEW_TEMPLATE,
 };
+use integration_tests_sv2::*;
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     parsers::{AnyMessage, CommonMessages, Mining, PoolMessages, TemplateDistribution},
@@ -16,6 +15,7 @@ use roles_logic_sv2::{
 // Pool will connect to the Sniffer, and the Sniffer will connect to the Template Provider.
 #[tokio::test]
 async fn success_pool_template_provider_connection() {
+    start_tracing();
     let (_tp, tp_addr) = start_template_provider(None).await;
     let (sniffer, sniffer_addr) = start_sniffer("".to_string(), tp_addr, true, None).await;
     let _ = start_pool(Some(sniffer_addr)).await;

--- a/roles/tests-integration/tests/pool_integration.rs
+++ b/roles/tests-integration/tests/pool_integration.rs
@@ -1,3 +1,9 @@
+// This file contains integration tests for the `PoolSv2` module.
+//
+// `PoolSv2` is a module that implements the Pool role in the Stratum V2 protocol.
+//
+// Note that it is enough to call `start_tracing()` once in the test suite to enable tracing for
+// all tests. This is because tracing is a global setting.
 use crate::sniffer::MessageDirection;
 use const_sv2::{
     MESSAGE_TYPE_MINING_SET_NEW_PREV_HASH, MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,

--- a/roles/tests-integration/tests/sniffer_integration.rs
+++ b/roles/tests-integration/tests/sniffer_integration.rs
@@ -16,6 +16,7 @@ use std::convert::TryInto;
 // TP -> sniffer_a -> sniffer_b -> Pool
 #[tokio::test]
 async fn test_sniffer_intercept_to_downstream() {
+    start_tracing();
     let (_tp, tp_addr) = start_template_provider(None).await;
     let message_replacement =
         PoolMessages::Common(CommonMessages::SetupConnectionError(SetupConnectionError {

--- a/roles/tests-integration/tests/sniffer_integration.rs
+++ b/roles/tests-integration/tests/sniffer_integration.rs
@@ -1,3 +1,11 @@
+// This file contains integration tests for the `Sniffer` module.
+//
+// `Sniffer` is a useful tool to perform Man-in-the-Middle setups for testing purposes.  It can
+// intercept messages and replace them with others, as well as assert that certain messages were
+// received.
+//
+// Note that it is enough to call `start_tracing()` once in the test suite to enable tracing for
+// all tests. This is because tracing is a global setting.
 use const_sv2::{
     MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
     MESSAGE_TYPE_SET_NEW_PREV_HASH,

--- a/roles/tests-integration/tests/translator_integration.rs
+++ b/roles/tests-integration/tests/translator_integration.rs
@@ -13,7 +13,7 @@ use roles_logic_sv2::parsers::{CommonMessages, Mining, PoolMessages};
 // the pool exchange the correct messages upon connection. And that the miner is able to submit
 // shares.
 #[tokio::test]
-async fn translation_proxy() {
+async fn translate_sv1_to_sv2_successfully() {
     start_tracing();
     let (_tp, tp_addr) = start_template_provider(None).await;
     let (_pool, pool_addr) = start_pool(Some(tp_addr)).await;

--- a/roles/tests-integration/tests/translator_integration.rs
+++ b/roles/tests-integration/tests/translator_integration.rs
@@ -1,3 +1,9 @@
+// This file contains integration tests for the `TranslatorSv2` module.
+//
+// `TranslatorSv2` is a module that implements the Translator role in the Stratum V2 protocol.
+//
+// Note that it is enough to call `start_tracing()` once in the test suite to enable tracing for
+// all tests. This is because tracing is a global setting.
 use const_sv2::{MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED};
 use integration_tests_sv2::{sniffer::*, *};
 use roles_logic_sv2::parsers::{CommonMessages, Mining, PoolMessages};

--- a/roles/tests-integration/tests/translator_integration.rs
+++ b/roles/tests-integration/tests/translator_integration.rs
@@ -8,6 +8,7 @@ use roles_logic_sv2::parsers::{CommonMessages, Mining, PoolMessages};
 // shares.
 #[tokio::test]
 async fn translation_proxy() {
+    start_tracing();
     let (_tp, tp_addr) = start_template_provider(None).await;
     let (_pool, pool_addr) = start_pool(Some(tp_addr)).await;
     let (pool_translator_sniffer, pool_translator_sniffer_addr) =


### PR DESCRIPTION
This should allow us to examine the logs from the roles that are using `tracing` crate for logging. As a default only ERROR logs will be shown, in order to examine a different level of logging, `RUST_LOG` env variable should be modified.

For example `RUST_LOG=info cargo test --test '*'`

resolves #1370 