### PR TITLE
Rename `pool_signature` field of `channel_factory` into `additional_coinbase_script_data`, and change the type from `String` to `Vec<u8>`

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -993,7 +993,7 @@ pub struct PoolChannelFactory {
     inner: ChannelFactory,
     job_creator: JobsCreators,
     pool_coinbase_outputs: Vec<TxOut>,
-    pool_signature: String,
+    additional_coinbase_script_data: String,
     // extended_channel_id -> SetCustomMiningJob
     negotiated_jobs: HashMap<u32, SetCustomMiningJob<'static>, BuildNoHashHasher<u32>>,
 }
@@ -1007,7 +1007,7 @@ impl PoolChannelFactory {
         share_per_min: f32,
         kind: ExtendedChannelKind,
         pool_coinbase_outputs: Vec<TxOut>,
-        pool_signature: String,
+        additional_coinbase_script_data: String,
     ) -> Self {
         let inner = ChannelFactory {
             ids,
@@ -1034,7 +1034,7 @@ impl PoolChannelFactory {
             inner,
             job_creator,
             pool_coinbase_outputs,
-            pool_signature,
+            additional_coinbase_script_data,
             negotiated_jobs: HashMap::with_hasher(BuildNoHashHasher::default()),
         }
     }
@@ -1107,7 +1107,7 @@ impl PoolChannelFactory {
             m,
             true,
             self.pool_coinbase_outputs.clone(),
-            self.pool_signature.clone(),
+            self.additional_coinbase_script_data.clone(),
         )?;
         self.inner.on_new_extended_mining_job(new_job)
     }
@@ -1185,10 +1185,13 @@ impl PoolChannelFactory {
         if self.negotiated_jobs.contains_key(&m.channel_id) {
             let referenced_job = self.negotiated_jobs.get(&m.channel_id).unwrap();
             let merkle_path = referenced_job.merkle_path.to_vec();
-            let pool_signature = self.pool_signature.clone();
-            let extended_job =
-                job_creator::extended_job_from_custom_job(referenced_job, pool_signature, 32)
-                    .unwrap();
+            let additional_coinbase_script_data = self.additional_coinbase_script_data.clone();
+            let extended_job = job_creator::extended_job_from_custom_job(
+                referenced_job,
+                additional_coinbase_script_data,
+                32,
+            )
+            .unwrap();
             let prev_blockhash = crate::utils::u256_to_block_hash(referenced_job.prev_hash.clone());
             let bits = referenced_job.nbits;
             self.inner.check_target(
@@ -1327,7 +1330,7 @@ pub struct ProxyExtendedChannelFactory {
     inner: ChannelFactory,
     job_creator: Option<JobsCreators>,
     pool_coinbase_outputs: Option<Vec<TxOut>>,
-    pool_signature: String,
+    additional_coinbase_script_data: String,
     // Id assigned to the extended channel by upstream
     extended_channel_id: u32,
 }
@@ -1342,7 +1345,7 @@ impl ProxyExtendedChannelFactory {
         share_per_min: f32,
         kind: ExtendedChannelKind,
         pool_coinbase_outputs: Option<Vec<TxOut>>,
-        pool_signature: String,
+        additional_coinbase_script_data: String,
         extended_channel_id: u32,
     ) -> Self {
         match &kind {
@@ -1382,7 +1385,7 @@ impl ProxyExtendedChannelFactory {
             inner,
             job_creator,
             pool_coinbase_outputs,
-            pool_signature,
+            additional_coinbase_script_data,
             extended_channel_id,
         }
     }
@@ -1481,7 +1484,7 @@ impl ProxyExtendedChannelFactory {
                 m,
                 true,
                 pool_coinbase_outputs.clone(),
-                self.pool_signature.clone(),
+                self.additional_coinbase_script_data.clone(),
             )?;
             let id = new_job.job_id;
             if !new_job.is_future() && self.inner.last_prev_hash.is_some() {
@@ -1917,7 +1920,7 @@ mod test {
 
         // Initialize a Channel of type Pool
         let out = TxOut {value: BLOCK_REWARD, script_pubkey: decode_hex("4104c6d0969c2d98a5c19ba7c36c7937c5edbd60ff2a01397c4afe54f16cd641667ea0049ba6f9e1796ba3c8e49e1b504c532ebbaaa1010c3f7d9b83a8ea7fd800e2ac").unwrap().into()};
-        let pool_signature = "".to_string();
+        let additional_coinbase_script_data = "".to_string();
         let creator = JobsCreators::new(7);
         let share_per_min = 1.0;
         // Create an ExtendedExtranonce of len 7:
@@ -1938,7 +1941,7 @@ mod test {
             share_per_min,
             channel_kind,
             vec![out],
-            pool_signature,
+            additional_coinbase_script_data,
         );
 
         // Build a NewTemplate

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -993,7 +993,7 @@ pub struct PoolChannelFactory {
     inner: ChannelFactory,
     job_creator: JobsCreators,
     pool_coinbase_outputs: Vec<TxOut>,
-    additional_coinbase_script_data: String,
+    additional_coinbase_script_data: Vec<u8>,
     // extended_channel_id -> SetCustomMiningJob
     negotiated_jobs: HashMap<u32, SetCustomMiningJob<'static>, BuildNoHashHasher<u32>>,
 }
@@ -1007,7 +1007,7 @@ impl PoolChannelFactory {
         share_per_min: f32,
         kind: ExtendedChannelKind,
         pool_coinbase_outputs: Vec<TxOut>,
-        additional_coinbase_script_data: String,
+        additional_coinbase_script_data: Vec<u8>,
     ) -> Self {
         let inner = ChannelFactory {
             ids,
@@ -1330,7 +1330,7 @@ pub struct ProxyExtendedChannelFactory {
     inner: ChannelFactory,
     job_creator: Option<JobsCreators>,
     pool_coinbase_outputs: Option<Vec<TxOut>>,
-    additional_coinbase_script_data: String,
+    additional_coinbase_script_data: Vec<u8>,
     // Id assigned to the extended channel by upstream
     extended_channel_id: u32,
 }
@@ -1345,7 +1345,7 @@ impl ProxyExtendedChannelFactory {
         share_per_min: f32,
         kind: ExtendedChannelKind,
         pool_coinbase_outputs: Option<Vec<TxOut>>,
-        additional_coinbase_script_data: String,
+        additional_coinbase_script_data: Vec<u8>,
         extended_channel_id: u32,
     ) -> Self {
         match &kind {
@@ -1920,7 +1920,7 @@ mod test {
 
         // Initialize a Channel of type Pool
         let out = TxOut {value: BLOCK_REWARD, script_pubkey: decode_hex("4104c6d0969c2d98a5c19ba7c36c7937c5edbd60ff2a01397c4afe54f16cd641667ea0049ba6f9e1796ba3c8e49e1b504c532ebbaaa1010c3f7d9b83a8ea7fd800e2ac").unwrap().into()};
-        let additional_coinbase_script_data = "".to_string();
+        let additional_coinbase_script_data = "".as_bytes().to_vec();
         let creator = JobsCreators::new(7);
         let share_per_min = 1.0;
         // Create an ExtendedExtranonce of len 7:

--- a/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
@@ -298,7 +298,7 @@ mod tests {
             value: BLOCK_REWARD,
             script_pubkey: Script::new_p2pk(&new_pub_key()),
         };
-        let additional_coinbase_script_data = "Stratum v2 SRI Pool".to_string();
+        let additional_coinbase_script_data = "Stratum v2 SRI Pool".as_bytes().to_vec();
         let mut jobs_creators = JobsCreators::new(32);
         let group_channel_id = 1;
         //Create a template

--- a/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
@@ -298,7 +298,7 @@ mod tests {
             value: BLOCK_REWARD,
             script_pubkey: Script::new_p2pk(&new_pub_key()),
         };
-        let pool_signature = "Stratum v2 SRI Pool".to_string();
+        let additional_coinbase_script_data = "Stratum v2 SRI Pool".to_string();
         let mut jobs_creators = JobsCreators::new(32);
         let group_channel_id = 1;
         //Create a template
@@ -306,7 +306,12 @@ mod tests {
         template.template_id = template.template_id % u64::MAX;
         template.future_template = true;
         let extended_mining_job = jobs_creators
-            .on_new_template(&mut template, false, vec![out], pool_signature)
+            .on_new_template(
+                &mut template,
+                false,
+                vec![out],
+                additional_coinbase_script_data,
+            )
             .expect("Failed to create new job");
 
         // create GroupChannelJobDispatcher

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -492,7 +492,7 @@ impl
                 share_per_min,
                 kind,
                 coinbase_outputs,
-                "SOLO".to_string(),
+                "SOLO".into(),
             );
             self.status.set_channel(channel_factory);
 

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -586,7 +586,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
             share_per_min,
             channel_kind,
             vec![],
-            pool_signature,
+            pool_signature.into(),
         );
         let extranonce: Extranonce = m
             .extranonce_prefix

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -87,7 +87,7 @@ impl ChannelKind {
                     downstream_share_per_minute,
                     kind,
                     Some(vec![]),
-                    String::from(""),
+                    "".into(),
                     up_id,
                 );
                 *self = Self::Extended(Some(factory));

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -618,7 +618,7 @@ impl Pool {
             share_per_min,
             kind,
             pool_coinbase_outputs.expect("Invalid coinbase output in config"),
-            config.pool_signature.clone(),
+            config.pool_signature.clone().into(),
         )));
         let pool = Arc::new(Mutex::new(Pool {
             downstreams: HashMap::with_hasher(BuildNoHashHasher::default()),

--- a/roles/translator/src/lib/proxy/bridge.rs
+++ b/roles/translator/src/lib/proxy/bridge.rs
@@ -101,7 +101,7 @@ impl Bridge {
                 share_per_min,
                 ExtendedChannelKind::Proxy { upstream_target },
                 None,
-                String::from(""),
+                "".into(),
                 up_id,
             ),
             future_jobs: vec![],


### PR DESCRIPTION
close #1436

loosely inspired by https://github.com/stratum-mining/stratum/pull/1248/commits/3f2815b5a10992158f4b04529eeb71c3c902302b from @Fi3 at #1248, but with a few corrections (and split into two different commits)

note: this renaming only happens on `roles_logic_sv2`, but not on SRI application layer (`roles`), where the field remains called `pool_signature`
