### PR TITLE
Add coinbase_output_max_additional_sigops to SRI

### DIFF
--- a/protocols/v2/const-sv2/Cargo.toml
+++ b/protocols/v2/const-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_sv2"
-version = "3.0.0"
+version = "4.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/const-sv2/src/lib.rs
+++ b/protocols/v2/const-sv2/src/lib.rs
@@ -183,7 +183,7 @@ pub const MESSAGE_TYPE_DECLARE_MINING_JOB_ERROR: u8 = 0x59;
 pub const MESSAGE_TYPE_SUBMIT_SOLUTION_JD: u8 = 0x60;
 
 // Template Distribution Protocol message types.
-pub const MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE: u8 = 0x70;
+pub const MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS: u8 = 0x70;
 pub const MESSAGE_TYPE_NEW_TEMPLATE: u8 = 0x71;
 pub const MESSAGE_TYPE_SET_NEW_PREV_HASH: u8 = 0x72;
 pub const MESSAGE_TYPE_REQUEST_TRANSACTION_DATA: u8 = 0x73;
@@ -204,7 +204,7 @@ pub const CHANNEL_BIT_SETUP_CONNECTION_ERROR: bool = false;
 pub const CHANNEL_BIT_CHANNEL_ENDPOINT_CHANGED: bool = true;
 
 // For the Template Distribution protocol, the channel bit is always unset.
-pub const CHANNEL_BIT_COINBASE_OUTPUT_DATA_SIZE: bool = false;
+pub const CHANNEL_BIT_COINBASE_OUTPUT_CONSTRAINTS: bool = false;
 pub const CHANNEL_BIT_NEW_TEMPLATE: bool = false;
 pub const CHANNEL_BIT_SET_NEW_PREV_HASH: bool = false;
 pub const CHANNEL_BIT_REQUEST_TRANSACTION_DATA: bool = false;

--- a/protocols/v2/roles-logic-sv2/src/handlers/template_distribution.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/template_distribution.rs
@@ -28,7 +28,7 @@
 use super::SendTo_;
 use crate::{errors::Error, parsers::TemplateDistribution, utils::Mutex};
 use template_distribution_sv2::{
-    CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, RequestTransactionDataError,
+    CoinbaseOutputConstraints, NewTemplate, RequestTransactionData, RequestTransactionDataError,
     RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution,
 };
 
@@ -109,9 +109,9 @@ where
                     .safe_lock(|x| x.handle_request_tx_data_error(m))
                     .map_err(|e| crate::Error::PoisonLock(e.to_string()))?
             }
-            Ok(TemplateDistribution::CoinbaseOutputDataSize(_)) => Err(Error::UnexpectedMessage(
-                MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE,
-            )),
+            Ok(TemplateDistribution::CoinbaseOutputConstraints(_)) => Err(
+                Error::UnexpectedMessage(MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS),
+            ),
             Ok(TemplateDistribution::RequestTransactionData(_)) => Err(Error::UnexpectedMessage(
                 MESSAGE_TYPE_REQUEST_TRANSACTION_DATA,
             )),
@@ -184,7 +184,7 @@ where
     ) -> Result<SendTo, Error> {
         // Is ok to unwrap a safe_lock result
         match message {
-            Ok(TemplateDistribution::CoinbaseOutputDataSize(m)) => self_
+            Ok(TemplateDistribution::CoinbaseOutputConstraints(m)) => self_
                 .safe_lock(|x| x.handle_coinbase_out_data_size(m))
                 .map_err(|e| crate::Error::PoisonLock(e.to_string()))?,
             Ok(TemplateDistribution::RequestTransactionData(m)) => self_
@@ -209,11 +209,13 @@ where
         }
     }
 
-    /// Handles a `CoinbaseOutputDataSize` message.
+    /// Handles a `CoinbaseOutputConstraints` message.
     ///
     /// This method processes a message that includes the coinbase output data size.
-    fn handle_coinbase_out_data_size(&mut self, m: CoinbaseOutputDataSize)
-        -> Result<SendTo, Error>;
+    fn handle_coinbase_out_data_size(
+        &mut self,
+        m: CoinbaseOutputConstraints,
+    ) -> Result<SendTo, Error>;
 
     /// Handles a `RequestTransactionData` message.
     ///

--- a/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
@@ -25,11 +25,12 @@ pub struct AllocateMiningJobTokenSuccess<'decoder> {
     /// A token that makes the JDC eligible for committing a mining job for approval/transactions
     /// declaration or for identifying custom mining job on mining connection.
     pub mining_job_token: B0255<'decoder>,
-    /// The maximum additional size that can be added to the coinbase output.
-    ///
     /// The maximum additional serialized bytes which the JDS will add in coinbase transaction
     /// outputs.
     pub coinbase_output_max_additional_size: u32,
+    /// The maximum additional sigops which the JDS will add in coinbase transaction
+    /// outputs.
+    pub coinbase_output_max_additional_sigops: u16,
     /// Bitcoin transaction outputs added by JDS.
     pub coinbase_output: B064K<'decoder>,
     /// Whether the client is allowed to mine asynchronously.

--- a/protocols/v2/subprotocols/template-distribution/src/coinbase_output_constraints.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/coinbase_output_constraints.rs
@@ -24,7 +24,9 @@ use core::convert::TryInto;
 /// [`NewTemplate`]: crate::NewTemplate
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
-pub struct CoinbaseOutputDataSize {
+pub struct CoinbaseOutputConstraints {
     /// Additional serialized bytes needed in coinbase transaction outputs.
     pub coinbase_output_max_additional_size: u32,
+    /// Additional sigops needed in coinbase transaction outputs.
+    pub coinbase_output_max_additional_sigops: u16,
 }

--- a/protocols/v2/subprotocols/template-distribution/src/lib.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/lib.rs
@@ -24,13 +24,13 @@ use core::convert::TryInto;
 #[cfg(feature = "prop_test")]
 use quickcheck::{Arbitrary, Gen};
 
-mod coinbase_output_data_size;
+mod coinbase_output_constraints;
 mod new_template;
 mod request_transaction_data;
 mod set_new_prev_hash;
 mod submit_solution;
 
-pub use coinbase_output_data_size::CoinbaseOutputDataSize;
+pub use coinbase_output_constraints::CoinbaseOutputConstraints;
 pub use new_template::{CNewTemplate, NewTemplate};
 pub use request_transaction_data::{
     CRequestTransactionDataError, CRequestTransactionDataSuccess, RequestTransactionData,
@@ -39,9 +39,9 @@ pub use request_transaction_data::{
 pub use set_new_prev_hash::{CSetNewPrevHash, SetNewPrevHash};
 pub use submit_solution::{CSubmitSolution, SubmitSolution};
 
-/// Exports the [`CoinbaseOutputDataSize`] struct to C.
+/// Exports the [`CoinbaseOutputConstraints`] struct to C.
 #[no_mangle]
-pub extern "C" fn _c_export_coinbase_out(_a: CoinbaseOutputDataSize) {}
+pub extern "C" fn _c_export_coinbase_out(_a: CoinbaseOutputConstraints) {}
 
 /// Exports the [`RequestTransactionData`] struct to C.
 #[no_mangle]
@@ -82,10 +82,11 @@ impl NewTemplate<'static> {
     }
 }
 #[cfg(feature = "prop_test")]
-impl CoinbaseOutputDataSize {
+impl CoinbaseOutputConstraints {
     pub fn from_gen(g: &mut Gen) -> Self {
-        coinbase_output_data_size::CoinbaseOutputDataSize {
+        CoinbaseOutputConstraints {
             coinbase_output_max_additional_size: u32::arbitrary(g).try_into().unwrap(),
+            coinbase_output_max_additional_sigops: u16::arbitrary(g).try_into().unwrap(),
         }
     }
 }

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -10,7 +10,7 @@ use common_messages_sv2::{
 };
 use template_distribution_sv2::{
     CNewTemplate, CRequestTransactionDataError, CRequestTransactionDataSuccess, CSetNewPrevHash,
-    CSubmitSolution, CoinbaseOutputDataSize, NewTemplate, RequestTransactionData,
+    CSubmitSolution, CoinbaseOutputConstraints, NewTemplate, RequestTransactionData,
     RequestTransactionDataError, RequestTransactionDataSuccess, SetNewPrevHash, SubmitSolution,
 };
 
@@ -22,13 +22,13 @@ use binary_sv2::{
 };
 
 use const_sv2::{
-    CHANNEL_BIT_CHANNEL_ENDPOINT_CHANGED, CHANNEL_BIT_COINBASE_OUTPUT_DATA_SIZE,
+    CHANNEL_BIT_CHANNEL_ENDPOINT_CHANGED, CHANNEL_BIT_COINBASE_OUTPUT_CONSTRAINTS,
     CHANNEL_BIT_NEW_TEMPLATE, CHANNEL_BIT_REQUEST_TRANSACTION_DATA,
     CHANNEL_BIT_REQUEST_TRANSACTION_DATA_ERROR, CHANNEL_BIT_REQUEST_TRANSACTION_DATA_SUCCESS,
     CHANNEL_BIT_SETUP_CONNECTION, CHANNEL_BIT_SETUP_CONNECTION_ERROR,
     CHANNEL_BIT_SETUP_CONNECTION_SUCCESS, CHANNEL_BIT_SET_NEW_PREV_HASH,
     CHANNEL_BIT_SUBMIT_SOLUTION, EXTENSION_TYPE_NO_EXTENSION,
-    MESSAGE_TYPE_CHANNEL_ENDPOINT_CHANGED, MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE,
+    MESSAGE_TYPE_CHANNEL_ENDPOINT_CHANGED, MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS,
     MESSAGE_TYPE_NEW_TEMPLATE, MESSAGE_TYPE_REQUEST_TRANSACTION_DATA,
     MESSAGE_TYPE_REQUEST_TRANSACTION_DATA_ERROR, MESSAGE_TYPE_REQUEST_TRANSACTION_DATA_SUCCESS,
     MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
@@ -39,7 +39,7 @@ use core::convert::{TryFrom, TryInto};
 
 #[derive(Clone, Debug)]
 pub enum Sv2Message<'a> {
-    CoinbaseOutputDataSize(CoinbaseOutputDataSize),
+    CoinbaseOutputConstraints(CoinbaseOutputConstraints),
     NewTemplate(NewTemplate<'a>),
     RequestTransactionData(RequestTransactionData),
     RequestTransactionDataError(RequestTransactionDataError<'a>),
@@ -55,7 +55,7 @@ pub enum Sv2Message<'a> {
 impl Sv2Message<'_> {
     pub fn message_type(&self) -> u8 {
         match self {
-            Sv2Message::CoinbaseOutputDataSize(_) => MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE,
+            Sv2Message::CoinbaseOutputConstraints(_) => MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS,
             Sv2Message::NewTemplate(_) => MESSAGE_TYPE_NEW_TEMPLATE,
             Sv2Message::RequestTransactionData(_) => MESSAGE_TYPE_REQUEST_TRANSACTION_DATA,
             Sv2Message::RequestTransactionDataError(_) => {
@@ -75,7 +75,7 @@ impl Sv2Message<'_> {
 
     pub fn channel_bit(&self) -> bool {
         match self {
-            Sv2Message::CoinbaseOutputDataSize(_) => CHANNEL_BIT_COINBASE_OUTPUT_DATA_SIZE,
+            Sv2Message::CoinbaseOutputConstraints(_) => CHANNEL_BIT_COINBASE_OUTPUT_CONSTRAINTS,
             Sv2Message::NewTemplate(_) => CHANNEL_BIT_NEW_TEMPLATE,
             Sv2Message::RequestTransactionData(_) => CHANNEL_BIT_REQUEST_TRANSACTION_DATA,
             Sv2Message::RequestTransactionDataError(_) => {
@@ -102,7 +102,7 @@ impl Display for Sv2Message<'_> {
 
 #[repr(C)]
 pub enum CSv2Message {
-    CoinbaseOutputDataSize(CoinbaseOutputDataSize),
+    CoinbaseOutputConstraints(CoinbaseOutputConstraints),
     NewTemplate(CNewTemplate),
     RequestTransactionData(RequestTransactionData),
     RequestTransactionDataError(CRequestTransactionDataError),
@@ -118,7 +118,7 @@ pub enum CSv2Message {
 #[no_mangle]
 pub extern "C" fn drop_sv2_message(s: CSv2Message) {
     match s {
-        CSv2Message::CoinbaseOutputDataSize(_) => (),
+        CSv2Message::CoinbaseOutputConstraints(_) => (),
         CSv2Message::NewTemplate(a) => drop(a),
         CSv2Message::RequestTransactionData(_) => (),
         CSv2Message::RequestTransactionDataError(a) => drop(a),
@@ -151,7 +151,7 @@ pub extern "C" fn drop_sv2_error(s: Sv2Error) {
 impl<'a> From<Sv2Message<'a>> for CSv2Message {
     fn from(v: Sv2Message<'a>) -> Self {
         match v {
-            Sv2Message::CoinbaseOutputDataSize(a) => Self::CoinbaseOutputDataSize(a),
+            Sv2Message::CoinbaseOutputConstraints(a) => Self::CoinbaseOutputConstraints(a),
             Sv2Message::NewTemplate(a) => Self::NewTemplate(a.into()),
             Sv2Message::RequestTransactionData(a) => Self::RequestTransactionData(a),
             Sv2Message::RequestTransactionDataError(a) => {
@@ -181,7 +181,9 @@ impl<'a> CSv2Message {
                 Ok(Sv2Message::SetupConnectionError(v.to_rust_rep_mut()?))
             }
             CSv2Message::SetupConnectionSuccess(v) => Ok(Sv2Message::SetupConnectionSuccess(*v)),
-            CSv2Message::CoinbaseOutputDataSize(v) => Ok(Sv2Message::CoinbaseOutputDataSize(*v)),
+            CSv2Message::CoinbaseOutputConstraints(v) => {
+                Ok(Sv2Message::CoinbaseOutputConstraints(*v))
+            }
             CSv2Message::RequestTransactionData(v) => Ok(Sv2Message::RequestTransactionData(*v)),
             CSv2Message::RequestTransactionDataError(v) => Ok(
                 Sv2Message::RequestTransactionDataError(v.to_rust_rep_mut()?),
@@ -200,7 +202,7 @@ impl<'a> CSv2Message {
 impl<'decoder> From<Sv2Message<'decoder>> for EncodableField<'decoder> {
     fn from(m: Sv2Message<'decoder>) -> Self {
         match m {
-            Sv2Message::CoinbaseOutputDataSize(a) => a.into(),
+            Sv2Message::CoinbaseOutputConstraints(a) => a.into(),
             Sv2Message::NewTemplate(a) => a.into(),
             Sv2Message::RequestTransactionData(a) => a.into(),
             Sv2Message::RequestTransactionDataError(a) => a.into(),
@@ -218,7 +220,7 @@ impl<'decoder> From<Sv2Message<'decoder>> for EncodableField<'decoder> {
 impl binary_sv2::GetSize for Sv2Message<'_> {
     fn get_size(&self) -> usize {
         match self {
-            Sv2Message::CoinbaseOutputDataSize(a) => a.get_size(),
+            Sv2Message::CoinbaseOutputConstraints(a) => a.get_size(),
             Sv2Message::NewTemplate(a) => a.get_size(),
             Sv2Message::RequestTransactionData(a) => a.get_size(),
             Sv2Message::RequestTransactionDataError(a) => a.get_size(),
@@ -266,9 +268,9 @@ impl<'a> TryFrom<(u8, &'a mut [u8])> for Sv2Message<'a> {
                 let message: ChannelEndpointChanged = from_bytes(v.1)?;
                 Ok(Sv2Message::ChannelEndpointChanged(message))
             }
-            MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE => {
-                let message: CoinbaseOutputDataSize = from_bytes(v.1)?;
-                Ok(Sv2Message::CoinbaseOutputDataSize(message))
+            MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS => {
+                let message: CoinbaseOutputConstraints = from_bytes(v.1)?;
+                Ok(Sv2Message::CoinbaseOutputConstraints(message))
             }
             MESSAGE_TYPE_NEW_TEMPLATE => {
                 let message: NewTemplate<'a> = from_bytes(v.1)?;
@@ -491,13 +493,14 @@ mod tests {
     use core::convert::TryInto;
     use quickcheck::{Arbitrary, Gen};
     use quickcheck_macros;
+    use template_distribution_sv2::CoinbaseOutputConstraints;
 
     #[derive(Clone, Debug)]
-    pub struct RandomCoinbaseOutputDataSize(pub CoinbaseOutputDataSize);
+    pub struct RandomCoinbaseOutputConstraints(pub CoinbaseOutputConstraints);
 
-    impl Arbitrary for RandomCoinbaseOutputDataSize {
+    impl Arbitrary for RandomCoinbaseOutputConstraints {
         fn arbitrary(g: &mut Gen) -> Self {
-            RandomCoinbaseOutputDataSize(CoinbaseOutputDataSize::from_gen(g))
+            RandomCoinbaseOutputConstraints(CoinbaseOutputConstraints::from_gen(g))
         }
     }
 
@@ -544,11 +547,12 @@ mod tests {
 
     #[test]
     fn test_message_type_cb_output_data_size() {
-        let expect = MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE;
-        let cb_output_data_size = CoinbaseOutputDataSize {
+        let expect = MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS;
+        let cb_output_data_size = CoinbaseOutputConstraints {
             coinbase_output_max_additional_size: 0,
+            coinbase_output_max_additional_sigops: 0,
         };
-        let sv2_message = Sv2Message::CoinbaseOutputDataSize(cb_output_data_size);
+        let sv2_message = Sv2Message::CoinbaseOutputConstraints(cb_output_data_size);
         let actual = sv2_message.message_type();
 
         assert_eq!(expect, actual);
@@ -730,15 +734,15 @@ mod tests {
     // RR
 
     #[quickcheck_macros::quickcheck]
-    fn encode_with_c_coinbase_output_data_size(message: RandomCoinbaseOutputDataSize) -> bool {
+    fn encode_with_c_coinbase_output_data_size(message: RandomCoinbaseOutputConstraints) -> bool {
         let expected = message.clone().0;
 
-        let mut encoder = Encoder::<CoinbaseOutputDataSize>::new();
+        let mut encoder = Encoder::<CoinbaseOutputConstraints>::new();
         let mut decoder = StandardDecoder::<Sv2Message<'static>>::new();
 
         let frame = StandardSv2Frame::from_message(
             message.0,
-            MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE,
+            MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS,
             0,
             false,
         )
@@ -762,7 +766,7 @@ mod tests {
         let payload = decoded.payload();
         let decoded_message: Sv2Message = (msg_type, payload).try_into().unwrap();
         let decoded_message = match decoded_message {
-            Sv2Message::CoinbaseOutputDataSize(m) => m,
+            Sv2Message::CoinbaseOutputConstraints(m) => m,
             _ => panic!(),
         };
 

--- a/protocols/v2/sv2-ffi/sv2.h
+++ b/protocols/v2/sv2-ffi/sv2.h
@@ -137,7 +137,7 @@ static const uint8_t MESSAGE_TYPE_DECLARE_MINING_JOB_ERROR = 89;
 
 static const uint8_t MESSAGE_TYPE_SUBMIT_SOLUTION_JD = 96;
 
-static const uint8_t MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE = 112;
+static const uint8_t MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS = 112;
 
 static const uint8_t MESSAGE_TYPE_NEW_TEMPLATE = 113;
 
@@ -159,7 +159,7 @@ static const bool CHANNEL_BIT_SETUP_CONNECTION_ERROR = false;
 
 static const bool CHANNEL_BIT_CHANNEL_ENDPOINT_CHANGED = true;
 
-static const bool CHANNEL_BIT_COINBASE_OUTPUT_DATA_SIZE = false;
+static const bool CHANNEL_BIT_COINBASE_OUTPUT_CONSTRAINTS = false;
 
 static const bool CHANNEL_BIT_NEW_TEMPLATE = false;
 
@@ -419,6 +419,7 @@ void free_setup_connection_error(CSetupConnectionError s);
 struct CoinbaseOutputConstraints {
   /// Additional serialized bytes needed in coinbase transaction outputs.
   uint32_t coinbase_output_max_additional_size;
+  /// Additional sigops needed in coinbase transaction outputs.
   uint16_t coinbase_output_max_additional_sigops;
 };
 

--- a/protocols/v2/sv2-ffi/sv2.h
+++ b/protocols/v2/sv2-ffi/sv2.h
@@ -416,9 +416,10 @@ void free_setup_connection_error(CSetupConnectionError s);
 /// transaction when complying with the size limits.
 ///
 /// [`NewTemplate`]: crate::NewTemplate
-struct CoinbaseOutputDataSize {
+struct CoinbaseOutputConstraints {
   /// Additional serialized bytes needed in coinbase transaction outputs.
   uint32_t coinbase_output_max_additional_size;
+  uint16_t coinbase_output_max_additional_sigops;
 };
 
 /// Message used by a downstream to request data about all transactions in a block template.
@@ -481,8 +482,8 @@ struct CSubmitSolution {
 
 extern "C" {
 
-/// Exports the [`CoinbaseOutputDataSize`] struct to C.
-void _c_export_coinbase_out(CoinbaseOutputDataSize _a);
+/// Exports the [`CoinbaseOutputConstraints`] struct to C.
+void _c_export_coinbase_out(CoinbaseOutputConstraints _a);
 
 /// Exports the [`RequestTransactionData`] struct to C.
 void _c_export_req_tx_data(RequestTransactionData _a);
@@ -569,7 +570,7 @@ struct EncoderWrapper;
 
 struct CSv2Message {
   enum class Tag {
-    CoinbaseOutputDataSize,
+    CoinbaseOutputConstraints,
     NewTemplate,
     RequestTransactionData,
     RequestTransactionDataError,
@@ -582,8 +583,8 @@ struct CSv2Message {
     SetupConnectionSuccess,
   };
 
-  struct CoinbaseOutputDataSize_Body {
-    CoinbaseOutputDataSize _0;
+  struct CoinbaseOutputConstraints_Body {
+    CoinbaseOutputConstraints _0;
   };
 
   struct NewTemplate_Body {
@@ -628,7 +629,7 @@ struct CSv2Message {
 
   Tag tag;
   union {
-    CoinbaseOutputDataSize_Body coinbase_output_data_size;
+    CoinbaseOutputConstraints_Body coinbase_output_constraints;
     NewTemplate_Body new_template;
     RequestTransactionData_Body request_transaction_data;
     RequestTransactionDataError_Body request_transaction_data_error;

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "const_sv2"
-version = "3.0.0"
+version = "4.0.0"
 
 [[package]]
 name = "convert_case"

--- a/roles/jd-client/Cargo.toml
+++ b/roles/jd-client/Cargo.toml
@@ -16,7 +16,7 @@ name = "jd_client"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-common = { path = "../../common" }
+stratum-common = { path = "../../common", features=["bitcoin"]}
 async-channel = "1.5.1"
 async-recursion = "0.3.2"
 binary_sv2 = { path = "../../protocols/v2/binary-sv2" }

--- a/roles/jd-server/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-server/src/lib/job_declarator/message_handler.rs
@@ -54,6 +54,7 @@ impl ParseClientJobDeclarationMessages for JobDeclaratorDownstream {
             coinbase_output_max_additional_size: 100,
             async_mining_allowed: self.async_mining_allowed,
             coinbase_output: self.coinbase_output.clone().try_into().unwrap(),
+            coinbase_output_max_additional_sigops: self.coinbase_output_sigops,
         };
         let message_enum = JobDeclaration::AllocateMiningJobTokenSuccess(message_success);
         info!(

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -56,6 +56,7 @@ pub struct JobDeclaratorDownstream {
     #[allow(dead_code)]
     // TODO: use coinbase output
     coinbase_output: Vec<u8>,
+    coinbase_output_sigops: u16,
     token_to_job_map: HashMap<u32, Option<u8>, BuildNoHashHasher<u32>>,
     tokens: Id,
     public_key: Secp256k1PublicKey,
@@ -93,12 +94,18 @@ impl JobDeclaratorDownstream {
             .expect("Invalid coinbase output in config")[0]
             .consensus_encode(&mut coinbase_output)
             .expect("Invalid coinbase output in config");
+        let coinbase_output_sigops = config
+            .get_txout()
+            .expect("Invalid coinbase output in config")[0]
+            .script_pubkey
+            .count_sigops() as u16;
 
         Self {
             async_mining_allowed,
             receiver,
             sender,
             coinbase_output,
+            coinbase_output_sigops,
             token_to_job_map,
             tokens,
             public_key: *config.authority_public_key(),

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -17,7 +17,7 @@ name = "pool_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-common = { path = "../../common" }
+stratum-common = { path = "../../common", features=["bitcoin"]}
 async-channel = "1.5.1"
 binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 buffer_sv2 = { path = "../../utils/buffer" }

--- a/roles/tests-integration/lib/sniffer.rs
+++ b/roles/tests-integration/lib/sniffer.rs
@@ -13,7 +13,7 @@ use roles_logic_sv2::{
             IdentifyTransactionsSuccess, ProvideMissingTransactions,
             ProvideMissingTransactionsSuccess, SubmitSolution,
         },
-        TemplateDistribution::{self, CoinbaseOutputDataSize},
+        TemplateDistribution::{self, CoinbaseOutputConstraints},
     },
     utils::Mutex,
 };
@@ -454,8 +454,8 @@ impl Sniffer {
                 SubmitSolution(m) => AnyMessage::JobDeclaration(SubmitSolution(m.into_static())),
             },
             AnyMessage::TemplateDistribution(m) => match m {
-                CoinbaseOutputDataSize(m) => {
-                    AnyMessage::TemplateDistribution(CoinbaseOutputDataSize(m.into_static()))
+                CoinbaseOutputConstraints(m) => {
+                    AnyMessage::TemplateDistribution(CoinbaseOutputConstraints(m.into_static()))
                 }
                 TemplateDistribution::NewTemplate(m) => AnyMessage::TemplateDistribution(
                     TemplateDistribution::NewTemplate(m.into_static()),

--- a/roles/tests-integration/tests/pool_integration.rs
+++ b/roles/tests-integration/tests/pool_integration.rs
@@ -47,7 +47,7 @@ async fn success_pool_template_provider_connection() {
     );
     assert_tp_message!(
         &sniffer.next_message_from_downstream(),
-        CoinbaseOutputDataSize
+        CoinbaseOutputConstraints
     );
     sniffer
         .wait_for_message_type(MessageDirection::ToDownstream, MESSAGE_TYPE_NEW_TEMPLATE)


### PR DESCRIPTION
This PR adds the `coinbase_output_max_additional_sigops` and renames `CoinbaseOutputDataSize` message into `CoinbaseOutputConstraints`.

Closes #1412 