### PR TITLE
unify `coinbase_tx_prefix` and `coinbase_tx_suffix` serialization

### DIFF
--- a/roles/translator/src/lib/proxy/next_mining_notify.rs
+++ b/roles/translator/src/lib/proxy/next_mining_notify.rs
@@ -1,7 +1,4 @@
-use roles_logic_sv2::{
-    job_creator::extended_job_to_non_segwit,
-    mining_sv2::{NewExtendedMiningJob, SetNewPrevHash},
-};
+use roles_logic_sv2::mining_sv2::{NewExtendedMiningJob, SetNewPrevHash};
 use tracing::debug;
 use v1::{
     server_to_client,
@@ -17,9 +14,6 @@ pub fn create_notify(
     new_job: NewExtendedMiningJob<'static>,
     clean_jobs: bool,
 ) -> server_to_client::Notify<'static> {
-    // TODO 32 must be changed!
-    let new_job = extended_job_to_non_segwit(new_job, 32)
-        .expect("failed to convert extended job to non segwit");
     // Make sure that SetNewPrevHash + NewExtendedMiningJob is matching (not future)
     let job_id = new_job.job_id.to_string();
 


### PR DESCRIPTION
close #1490 

to be merged after #1442 and #1461

---

we introduce a new `struct Coinbase` into `roles_logic_sv2::utils` that replaces the following from `roles_logic_sv2::job_creator`:
- `struct StrippedCoinbase`
- `fn coinbase -> Result<Transaction, Error>`