### PR TITLE
Use stable rust in `clippy` check and move to a shell script

### DIFF
--- a/.github/workflows/clippy-lint.yaml
+++ b/.github/workflows/clippy-lint.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.75.0
+          toolchain: stable
           override: true
           components: clippy
       - name: Run Clippy on different workspaces and crates

--- a/.github/workflows/clippy-lint.yaml
+++ b/.github/workflows/clippy-lint.yaml
@@ -28,9 +28,4 @@ jobs:
           override: true
           components: clippy
       - name: Run Clippy on different workspaces and crates
-        run: |
-          cargo clippy --manifest-path=benches/Cargo.toml -- -D warnings -A dead-code
-          cargo clippy --manifest-path=common/Cargo.toml -- -D warnings -A dead-code
-          cargo clippy --manifest-path=protocols/Cargo.toml -- -D warnings -A dead-code
-          cargo clippy --manifest-path=roles/Cargo.toml -- -D warnings -A dead-code
-          cargo clippy --manifest-path=utils/Cargo.toml -- -D warnings -A dead-code
+        run: ./scripts/rust/clippy.sh

--- a/common/src/url.rs
+++ b/common/src/url.rs
@@ -1,4 +1,4 @@
-/// This file contains utility functions for working with URLs.
+//! This file contains utility functions for working with URLs.
 
 /// Checks if a given string is a valid URL.
 ///

--- a/protocols/v1/src/error.rs
+++ b/protocols/v1/src/error.rs
@@ -33,7 +33,7 @@ pub enum Error<'a> {
     InvalidVersionMask(HexU32Be),
 }
 
-impl<'a> std::fmt::Display for Error<'a> {
+impl std::fmt::Display for Error<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Error::BadBytesConvert(ref e) => write!(
@@ -78,19 +78,19 @@ impl<'a> std::fmt::Display for Error<'a> {
     }
 }
 
-impl<'a> From<bitcoin_hashes::Error> for Error<'a> {
+impl From<bitcoin_hashes::Error> for Error<'_> {
     fn from(e: bitcoin_hashes::Error) -> Self {
         Error::BTCHashError(e)
     }
 }
 
-impl<'a> From<hex::FromHexError> for Error<'a> {
+impl From<hex::FromHexError> for Error<'_> {
     fn from(e: hex::FromHexError) -> Self {
         Error::HexError(e)
     }
 }
 
-impl<'a> From<std::convert::Infallible> for Error<'a> {
+impl From<std::convert::Infallible> for Error<'_> {
     fn from(e: std::convert::Infallible) -> Self {
         Error::Infallible(e)
     }
@@ -102,7 +102,7 @@ impl<'a> From<MethodError<'a>> for Error<'a> {
     }
 }
 
-impl<'a> From<binary_sv2::Error> for Error<'a> {
+impl From<binary_sv2::Error> for Error<'_> {
     fn from(inner: binary_sv2::Error) -> Self {
         Error::BadBytesConvert(inner)
     }

--- a/protocols/v1/src/methods/client_to_server.rs
+++ b/protocols/v1/src/methods/client_to_server.rs
@@ -127,7 +127,7 @@ pub struct Submit<'a> {
 //"{"params": ["spotbtc1.m30s40x16", "2", "147a3f0000000000", "6436eddf", "41d5deb0", "00000000"],
 //"{"params": "id": 2196, "method": "mining.submit"}"
 
-impl<'a> Submit<'a> {
+impl Submit<'_> {
     pub fn respond(self, is_ok: bool) -> Response {
         // infallibel
         let result = serde_json::to_value(is_ok).unwrap();
@@ -139,7 +139,7 @@ impl<'a> Submit<'a> {
     }
 }
 
-impl<'a> From<Submit<'a>> for Message {
+impl From<Submit<'_>> for Message {
     fn from(submit: Submit) -> Self {
         let ex: String = submit.extra_nonce2.0.inner_as_ref().to_hex();
         let mut params: Vec<Value> = vec![
@@ -161,7 +161,7 @@ impl<'a> From<Submit<'a>> for Message {
     }
 }
 
-impl<'a> TryFrom<StandardRequest> for Submit<'a> {
+impl TryFrom<StandardRequest> for Submit<'_> {
     type Error = ParsingMethodError;
 
     #[allow(clippy::many_single_char_names)]
@@ -230,7 +230,7 @@ impl Arbitrary for Submit<'static> {
         let bits = Option::<u32>::arbitrary(g);
         println!("\nBITS: {:?}\n", bits);
         let extra: Extranonce = extra.try_into().unwrap();
-        let bits = bits.map(|x| HexU32Be(x));
+        let bits = bits.map(HexU32Be);
         println!("\nBITS: {:?}\n", bits);
         Submit {
             user_name: String::arbitrary(g),
@@ -308,7 +308,7 @@ impl<'a> TryFrom<Subscribe<'a>> for Message {
     }
 }
 
-impl<'a> TryFrom<StandardRequest> for Subscribe<'a> {
+impl TryFrom<StandardRequest> for Subscribe<'_> {
     type Error = ParsingMethodError;
 
     fn try_from(msg: StandardRequest) -> Result<Self, Self::Error> {
@@ -669,7 +669,7 @@ fn test_version_extension_with_broken_bit_count() {
                 "version-rolling.min-bit-count":"16"}
             ]
         }"#;
-    let client_message: StandardRequest = serde_json::from_str(&client_message).unwrap();
+    let client_message: StandardRequest = serde_json::from_str(client_message).unwrap();
     let server_configure = Configure::try_from(client_message).unwrap();
     match &server_configure.extensions[0] {
         ConfigureExtension::VersionRolling(params) => {
@@ -688,7 +688,7 @@ fn test_version_extension_with_non_string_bit_count() {
                 "version-rolling.min-bit-count":16}
             ]
         }"#;
-    let client_message: StandardRequest = serde_json::from_str(&client_message).unwrap();
+    let client_message: StandardRequest = serde_json::from_str(client_message).unwrap();
     let server_configure = Configure::try_from(client_message).unwrap();
     match &server_configure.extensions[0] {
         ConfigureExtension::VersionRolling(params) => {
@@ -707,11 +707,11 @@ fn test_version_extension_with_no_bit_count() {
                 {"version-rolling.mask":"ffffffff"}
             ]
         }"#;
-    let client_message: StandardRequest = serde_json::from_str(&client_message).unwrap();
+    let client_message: StandardRequest = serde_json::from_str(client_message).unwrap();
     let server_configure = Configure::try_from(client_message).unwrap();
     match &server_configure.extensions[0] {
         ConfigureExtension::VersionRolling(params) => {
-            assert!(params.min_bit_count.as_ref() == None);
+            assert!(params.min_bit_count.as_ref().is_none());
         }
         _ => panic!(),
     };

--- a/protocols/v1/src/methods/mod.rs
+++ b/protocols/v1/src/methods/mod.rs
@@ -69,7 +69,7 @@ pub enum ParsingMethodError {
     Todo,
 }
 
-impl<'a> From<Error<'a>> for ParsingMethodError {
+impl From<Error<'_>> for ParsingMethodError {
     fn from(inner: Error) -> Self {
         match inner {
             Error::HexError(e) => ParsingMethodError::HexError(Box::new(e)),
@@ -79,8 +79,8 @@ impl<'a> From<Error<'a>> for ParsingMethodError {
     }
 }
 
-impl<'a> ParsingMethodError {
-    pub fn as_method_error(self, msg: Message) -> MethodError<'a> {
+impl ParsingMethodError {
+    pub fn as_method_error(self, msg: Message) -> MethodError<'static> {
         MethodError::ParsingMethodError((self, msg))
     }
 }
@@ -294,7 +294,7 @@ impl<'a> TryFrom<Message> for Method<'a> {
     }
 }
 
-impl<'a> TryFrom<crate::json_rpc::Response> for Server2ClientResponse<'a> {
+impl TryFrom<crate::json_rpc::Response> for Server2ClientResponse<'_> {
     type Error = ParsingMethodError;
 
     fn try_from(msg: Response) -> Result<Self, Self::Error> {

--- a/protocols/v1/src/methods/server_to_client.rs
+++ b/protocols/v1/src/methods/server_to_client.rs
@@ -31,7 +31,7 @@ use crate::{
 /// * Bitcoin block version: Used in the block header.
 ///     * nBits: The encoded network difficulty. Used in the block header.
 ///     * nTime: The current time. nTime rolling should be supported, but should not increase faster
-///     than actual time.
+///       than actual time.
 /// * Clean Jobs: If true, miners should abort their current work and immediately use the new job.
 ///   If false, they can still use the current job, but should move to the new one after exhausting
 ///   the current nonce range.
@@ -48,7 +48,7 @@ pub struct Notify<'a> {
     pub clean_jobs: bool,
 }
 
-impl<'a> From<Notify<'a>> for Message {
+impl From<Notify<'_>> for Message {
     fn from(notify: Notify) -> Self {
         let prev_hash: Value = notify.prev_hash.into();
         let coin_base1: Value = notify.coin_base1.into();
@@ -80,7 +80,7 @@ impl<'a> From<Notify<'a>> for Message {
     }
 }
 
-impl<'a> TryFrom<Notification> for Notify<'a> {
+impl TryFrom<Notification> for Notify<'_> {
     type Error = ParsingMethodError;
 
     #[allow(clippy::many_single_char_names)]
@@ -197,7 +197,7 @@ pub struct SetExtranonce<'a> {
     pub extra_nonce2_size: usize,
 }
 
-impl<'a> From<SetExtranonce<'a>> for Message {
+impl From<SetExtranonce<'_>> for Message {
     fn from(se: SetExtranonce) -> Self {
         let extra_nonce1: Value = se.extra_nonce1.into();
         let extra_nonce2_size: Value = se.extra_nonce2_size.into();
@@ -208,7 +208,7 @@ impl<'a> From<SetExtranonce<'a>> for Message {
     }
 }
 
-impl<'a> TryFrom<Notification> for SetExtranonce<'a> {
+impl TryFrom<Notification> for SetExtranonce<'_> {
     type Error = ParsingMethodError;
 
     fn try_from(msg: Notification) -> Result<Self, Self::Error> {
@@ -356,7 +356,7 @@ pub struct Subscribe<'a> {
     pub subscriptions: Vec<(String, String)>,
 }
 
-impl<'a> From<Subscribe<'a>> for Message {
+impl From<Subscribe<'_>> for Message {
     fn from(su: Subscribe) -> Self {
         let extra_nonce1: Value = su.extra_nonce1.into();
         let extra_nonce2_size: Value = su.extra_nonce2_size.into();
@@ -374,7 +374,7 @@ impl<'a> From<Subscribe<'a>> for Message {
     }
 }
 
-impl<'a> TryFrom<&Response> for Subscribe<'a> {
+impl TryFrom<&Response> for Subscribe<'_> {
     type Error = ParsingMethodError;
 
     fn try_from(msg: &Response) -> Result<Self, Self::Error> {
@@ -561,12 +561,12 @@ fn configure_response_parsing_all_fields() {
                 "minimum-difficulty":false
             }
         }"#;
-    let client_response = serde_json::from_str(&client_response_str).unwrap();
+    let client_response = serde_json::from_str(client_response_str).unwrap();
     let server_configure = Configure::try_from(&client_response).unwrap();
     println!("{:?}", server_configure);
 
     let version_rolling = server_configure.version_rolling.unwrap();
-    assert_eq!(version_rolling.version_rolling, true);
+    assert!(version_rolling.version_rolling);
     assert_eq!(version_rolling.version_rolling_mask, HexU32Be(0x1fffe000));
     assert_eq!(version_rolling.version_rolling_min_bit_count, HexU32Be(5));
 
@@ -582,12 +582,12 @@ fn configure_response_parsing_no_vr_min_bit_count() {
                 "minimum-difficulty":false
             }
         }"#;
-    let client_response = serde_json::from_str(&client_response_str).unwrap();
+    let client_response = serde_json::from_str(client_response_str).unwrap();
     let server_configure = Configure::try_from(&client_response).unwrap();
     println!("{:?}", server_configure);
 
     let version_rolling = server_configure.version_rolling.unwrap();
-    assert_eq!(version_rolling.version_rolling, true);
+    assert!(version_rolling.version_rolling);
     assert_eq!(version_rolling.version_rolling_mask, HexU32Be(0x1fffe000));
     assert_eq!(version_rolling.version_rolling_min_bit_count, HexU32Be(0));
 

--- a/protocols/v1/src/utils.rs
+++ b/protocols/v1/src/utils.rs
@@ -12,7 +12,7 @@ use std::{convert::TryFrom, mem::size_of, ops::BitAnd};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Extranonce<'a>(pub B032<'a>);
 
-impl<'a> Extranonce<'a> {
+impl Extranonce<'_> {
     pub fn len(&self) -> usize {
         self.0.inner_as_ref().len()
     }
@@ -183,18 +183,16 @@ impl<'a> TryFrom<&str> for PrevHash<'a> {
                         .write_u32::<LittleEndian>(prev_hash_word)
                         .expect("Internal error: Could not write buffer");
                 }
-                return Ok(PrevHash(prev_hash_arr.into()));
+                Ok(PrevHash(prev_hash_arr.into()))
             }
-            _ => {
-                return Err(error::Error::BadBytesConvert(
-                    binary_sv2::Error::InvalidU256(prev_hash_stratum_order.len()),
-                ))
-            }
+            _ => Err(error::Error::BadBytesConvert(
+                binary_sv2::Error::InvalidU256(prev_hash_stratum_order.len()),
+            )),
         }
     }
 }
 
-impl<'a> From<PrevHash<'a>> for Value {
+impl From<PrevHash<'_>> for Value {
     fn from(ph: PrevHash) -> Self {
         Into::<String>::into(ph).into()
     }
@@ -202,7 +200,7 @@ impl<'a> From<PrevHash<'a>> for Value {
 
 /// Helper Serializer that peforms the reverse process of converting the prev hash into stratum V1
 /// ordering
-impl<'a> From<PrevHash<'a>> for String {
+impl From<PrevHash<'_>> for String {
     fn from(v: PrevHash) -> Self {
         let mut prev_hash_stratum_cursor = std::io::Cursor::new(Vec::new());
         // swap every u32 from little endian to big endian
@@ -217,7 +215,7 @@ impl<'a> From<PrevHash<'a>> for String {
 }
 
 // / Referencing the internal part of hex bytes
-impl<'a> AsRef<[u8]> for PrevHash<'a> {
+impl AsRef<[u8]> for PrevHash<'_> {
     fn as_ref(&self) -> &[u8] {
         self.0.inner_as_ref()
     }
@@ -231,7 +229,7 @@ impl<'a> AsRef<U256<'a>> for PrevHash<'a> {
 }
 
 /// Referencing the internal part of hex bytes
-impl<'a> AsRef<[u8]> for Extranonce<'a> {
+impl AsRef<[u8]> for Extranonce<'_> {
     fn as_ref(&self) -> &[u8] {
         self.0.inner_as_ref()
     }
@@ -240,7 +238,7 @@ impl<'a> AsRef<[u8]> for Extranonce<'a> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MerkleNode<'a>(pub U256<'a>);
 
-impl<'a> MerkleNode<'a> {
+impl MerkleNode<'_> {
     pub fn is_empty(&self) -> bool {
         self.0.inner_as_ref().is_empty()
     }
@@ -268,7 +266,7 @@ impl<'a> From<MerkleNode<'a>> for Value {
 }
 
 /// Referencing the internal part of hex bytes
-impl<'a> AsRef<[u8]> for MerkleNode<'a> {
+impl AsRef<[u8]> for MerkleNode<'_> {
     fn as_ref(&self) -> &[u8] {
         self.0.inner_as_ref()
     }

--- a/protocols/v2/binary-sv2/codec/src/codec/decodable.rs
+++ b/protocols/v2/binary-sv2/codec/src/codec/decodable.rs
@@ -315,7 +315,7 @@ impl PrimitiveMarker {
     }
 }
 
-impl<'a> GetSize for DecodablePrimitive<'a> {
+impl GetSize for DecodablePrimitive<'_> {
     fn get_size(&self) -> usize {
         match self {
             DecodablePrimitive::U8(v) => v.get_size(),

--- a/protocols/v2/binary-sv2/codec/src/codec/encodable.rs
+++ b/protocols/v2/binary-sv2/codec/src/codec/encodable.rs
@@ -104,7 +104,7 @@ pub enum EncodablePrimitive<'a> {
     B016M(B016M<'a>),
 }
 
-impl<'a> EncodablePrimitive<'a> {
+impl EncodablePrimitive<'_> {
     // Provides the encoding logic for each primitive type.
     //
     // The `encode` method takes the `EncodablePrimitive` variant and serializes it
@@ -160,7 +160,7 @@ impl<'a> EncodablePrimitive<'a> {
 }
 
 // Provides the logic for calculating the size of the encodable field.
-impl<'a> GetSize for EncodablePrimitive<'a> {
+impl GetSize for EncodablePrimitive<'_> {
     fn get_size(&self) -> usize {
         match self {
             Self::U8(v) => v.get_size(),
@@ -200,7 +200,7 @@ pub enum EncodableField<'a> {
     Struct(Vec<EncodableField<'a>>),
 }
 
-impl<'a> EncodableField<'a> {
+impl EncodableField<'_> {
     /// The `encode` method serializes a field into the destination buffer `dst`, starting
     /// at the provided `offset`. If the field is a structure, it recursively encodes
     /// each contained field. If the buffer is too small or encoding fails, the method
@@ -235,7 +235,7 @@ impl<'a> EncodableField<'a> {
     }
 }
 
-impl<'a> GetSize for EncodableField<'a> {
+impl GetSize for EncodableField<'_> {
     fn get_size(&self) -> usize {
         match self {
             Self::Primitive(p) => p.get_size(),

--- a/protocols/v2/binary-sv2/codec/src/codec/impls.rs
+++ b/protocols/v2/binary-sv2/codec/src/codec/impls.rs
@@ -47,42 +47,42 @@ impl GetMarker for u64 {
         FieldMarker::Primitive(PrimitiveMarker::U64)
     }
 }
-impl<'a> GetMarker for U256<'a> {
+impl GetMarker for U256<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::U256)
     }
 }
-impl<'a> GetMarker for ShortTxId<'a> {
+impl GetMarker for ShortTxId<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::ShortTxId)
     }
 }
-impl<'a> GetMarker for Signature<'a> {
+impl GetMarker for Signature<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::Signature)
     }
 }
-impl<'a> GetMarker for B032<'a> {
+impl GetMarker for B032<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::B032)
     }
 }
-impl<'a> GetMarker for B0255<'a> {
+impl GetMarker for B0255<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::B0255)
     }
 }
-impl<'a> GetMarker for B064K<'a> {
+impl GetMarker for B064K<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::B064K)
     }
 }
-impl<'a> GetMarker for B016M<'a> {
+impl GetMarker for B016M<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::B016M)
     }
 }
-impl<'a> GetMarker for U32AsRef<'a> {
+impl GetMarker for U32AsRef<'_> {
     fn get_marker() -> FieldMarker {
         FieldMarker::Primitive(PrimitiveMarker::U32AsRef)
     }
@@ -536,7 +536,7 @@ impl<'a> TryFrom<DecodableField<'a>> for U32AsRef<'a> {
 
 // IMPL FROM PRIMITIVES FOR ENCODED FIELD
 
-impl<'a> From<bool> for EncodableField<'a> {
+impl From<bool> for EncodableField<'_> {
     fn from(v: bool) -> Self {
         EncodableField::Primitive(EncodablePrimitive::Bool(v))
     }
@@ -551,7 +551,7 @@ impl<'a> TryFrom<EncodableField<'a>> for bool {
         }
     }
 }
-impl<'a> From<u8> for EncodableField<'a> {
+impl From<u8> for EncodableField<'_> {
     fn from(v: u8) -> Self {
         EncodableField::Primitive(EncodablePrimitive::U8(v))
     }
@@ -566,7 +566,7 @@ impl<'a> TryFrom<EncodableField<'a>> for u8 {
         }
     }
 }
-impl<'a> From<u16> for EncodableField<'a> {
+impl From<u16> for EncodableField<'_> {
     fn from(v: u16) -> Self {
         EncodableField::Primitive(EncodablePrimitive::U16(v))
     }
@@ -581,7 +581,7 @@ impl<'a> TryFrom<EncodableField<'a>> for u16 {
         }
     }
 }
-impl<'a> From<U24> for EncodableField<'a> {
+impl From<U24> for EncodableField<'_> {
     fn from(v: U24) -> Self {
         EncodableField::Primitive(EncodablePrimitive::U24(v))
     }
@@ -596,7 +596,7 @@ impl<'a> TryFrom<EncodableField<'a>> for U24 {
         }
     }
 }
-impl<'a> From<u32> for EncodableField<'a> {
+impl From<u32> for EncodableField<'_> {
     fn from(v: u32) -> Self {
         EncodableField::Primitive(EncodablePrimitive::U32(v))
     }
@@ -611,7 +611,7 @@ impl<'a> TryFrom<EncodableField<'a>> for u32 {
         }
     }
 }
-impl<'a> From<f32> for EncodableField<'a> {
+impl From<f32> for EncodableField<'_> {
     fn from(v: f32) -> Self {
         EncodableField::Primitive(EncodablePrimitive::F32(v))
     }
@@ -626,7 +626,7 @@ impl<'a> TryFrom<EncodableField<'a>> for f32 {
         }
     }
 }
-impl<'a> From<u64> for EncodableField<'a> {
+impl From<u64> for EncodableField<'_> {
     fn from(v: u64) -> Self {
         EncodableField::Primitive(EncodablePrimitive::U64(v))
     }

--- a/protocols/v2/binary-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
+++ b/protocols/v2/binary-sv2/codec/src/datatypes/non_copy_data_types/inner.rs
@@ -74,7 +74,7 @@ pub enum Inner<
     Owned(Vec<u8>),
 }
 
-impl<'a, const SIZE: usize> Inner<'a, true, SIZE, 0, 0> {
+impl<const SIZE: usize> Inner<'_, true, SIZE, 0, 0> {
     // Converts the inner data to a vector, either by cloning the referenced slice or
     // returning a clone of the owned vector.
     pub fn to_vec(&self) -> Vec<u8> {
@@ -101,8 +101,8 @@ impl<'a, const SIZE: usize> Inner<'a, true, SIZE, 0, 0> {
     }
 }
 
-impl<'a, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    Inner<'a, false, SIZE, HEADERSIZE, MAXSIZE>
+impl<const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    Inner<'_, false, SIZE, HEADERSIZE, MAXSIZE>
 {
     // Similar to the fixed-size variant, this method converts the inner data into a vector.
     // The data is either cloned from the referenced slice or returned as a clone of the
@@ -123,8 +123,8 @@ impl<'a, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    PartialEq for Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    PartialEq for Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     // Provides equality comparison between two `Inner` instances by checking the equality
     // of their data, regardless of whether they are references or owned vectors.
@@ -138,13 +138,13 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize> Eq
-    for Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize> Eq
+    for Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     // Calculates the expected length of the data based on the type's parameters (fixed-size
     // or variable-size). It checks if the length conforms to the specified constraints like
@@ -267,8 +267,8 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    TryFrom<Vec<u8>> for Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    TryFrom<Vec<u8>> for Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     type Error = Error;
 
@@ -299,8 +299,8 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    GetSize for Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize> GetSize
+    for Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     fn get_size(&self) -> usize {
         match self {
@@ -310,8 +310,8 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, const ISFIXED: bool, const HEADERSIZE: usize, const SIZE: usize, const MAXSIZE: usize>
-    SizeHint for Inner<'a, ISFIXED, HEADERSIZE, SIZE, MAXSIZE>
+impl<const ISFIXED: bool, const HEADERSIZE: usize, const SIZE: usize, const MAXSIZE: usize> SizeHint
+    for Inner<'_, ISFIXED, HEADERSIZE, SIZE, MAXSIZE>
 {
     fn size_hint(data: &[u8], offset: usize) -> Result<usize, Error> {
         if offset >= data.len() {
@@ -391,8 +391,8 @@ where
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    IntoOwned for Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    IntoOwned for Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     fn into_owned(self) -> Self {
         match self {
@@ -405,8 +405,8 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     pub fn into_static(self) -> Inner<'static, ISFIXED, SIZE, HEADERSIZE, MAXSIZE> {
         match self {
@@ -420,8 +420,8 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    Clone for Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize> Clone
+    for Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     fn clone(&self) -> Inner<'static, ISFIXED, SIZE, HEADERSIZE, MAXSIZE> {
         match self {
@@ -435,8 +435,8 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
-    AsRef<[u8]> for Inner<'a, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
+impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: usize>
+    AsRef<[u8]> for Inner<'_, ISFIXED, SIZE, HEADERSIZE, MAXSIZE>
 {
     fn as_ref(&self) -> &[u8] {
         match self {

--- a/protocols/v2/binary-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
+++ b/protocols/v2/binary-sv2/codec/src/datatypes/non_copy_data_types/mod.rs
@@ -79,7 +79,7 @@ pub type B064K<'a> = Inner<'a, false, 1, 2, { u16::MAX as usize }>;
 /// represented using the `Inner` type with a 3-byte header.
 pub type B016M<'a> = Inner<'a, false, 1, 3, { 2_usize.pow(24) - 1 }>;
 
-impl<'decoder> From<[u8; 32]> for U256<'decoder> {
+impl From<[u8; 32]> for U256<'_> {
     fn from(v: [u8; 32]) -> Self {
         Inner::Owned(v.into())
     }
@@ -107,7 +107,7 @@ impl<'a> B016M<'a> {
 use core::convert::{TryFrom, TryInto};
 
 // Attempts to convert a `String` into a `Str0255<'a>`.
-impl<'a> TryFrom<String> for Str0255<'a> {
+impl TryFrom<String> for Str0255<'_> {
     type Error = crate::Error;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
@@ -117,7 +117,7 @@ impl<'a> TryFrom<String> for Str0255<'a> {
 
 /// Represents a reference to a 32-bit unsigned integer (`u32`),
 /// providing methods for convenient conversions.
-impl<'a> U32AsRef<'a> {
+impl U32AsRef<'_> {
     /// Returns the `u32` value represented by this reference.
     pub fn as_u32(&self) -> u32 {
         let inner = self.inner_as_ref();
@@ -125,7 +125,7 @@ impl<'a> U32AsRef<'a> {
     }
 }
 
-impl<'a> From<u32> for U32AsRef<'a> {
+impl From<u32> for U32AsRef<'_> {
     fn from(v: u32) -> Self {
         let bytes = v.to_le_bytes();
         let inner = vec![bytes[0], bytes[1], bytes[2], bytes[3]];

--- a/protocols/v2/binary-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
+++ b/protocols/v2/binary-sv2/codec/src/datatypes/non_copy_data_types/seq_inner.rs
@@ -144,7 +144,7 @@ impl<'a, T: 'a> Seq0255<'a, T> {
     }
 }
 
-impl<'a, T: GetSize> GetSize for Seq0255<'a, T> {
+impl<T: GetSize> GetSize for Seq0255<'_, T> {
     // Calculates the total size of the sequence in bytes.
     fn get_size(&self) -> usize {
         let mut size = Self::HEADERSIZE;
@@ -187,7 +187,7 @@ impl<'a, T: 'a> Seq064K<'a, T> {
     }
 }
 
-impl<'a, T: GetSize> GetSize for Seq064K<'a, T> {
+impl<T: GetSize> GetSize for Seq064K<'_, T> {
     fn get_size(&self) -> usize {
         let mut size = Self::HEADERSIZE;
         for with_size in &self.0 {
@@ -372,26 +372,26 @@ impl<'a, T> core::convert::TryFrom<Seq064K<'a, T>> for Vec<T> {
     }
 }
 
-impl<'a, T> From<Vec<T>> for Seq0255<'a, T> {
+impl<T> From<Vec<T>> for Seq0255<'_, T> {
     fn from(v: Vec<T>) -> Self {
         Seq0255(v, PhantomData)
     }
 }
 
-impl<'a, T> From<Vec<T>> for Seq064K<'a, T> {
+impl<T> From<Vec<T>> for Seq064K<'_, T> {
     fn from(v: Vec<T>) -> Self {
         Seq064K(v, PhantomData)
     }
 }
 
-impl<'a, T: Fixed> Seq0255<'a, T> {
+impl<T: Fixed> Seq0255<'_, T> {
     /// converts the lifetime to static
     pub fn into_static(self) -> Seq0255<'static, T> {
         // Safe unwrap cause the initial value is a valid Seq0255
         Seq0255::new(self.0).unwrap()
     }
 }
-impl<'a, T: Fixed> Sv2Option<'a, T> {
+impl<T: Fixed> Sv2Option<'_, T> {
     /// converts the lifetime to static
     pub fn into_static(self) -> Sv2Option<'static, T> {
         Sv2Option::new(self.into_inner())
@@ -425,7 +425,7 @@ impl<'a, const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const 
     }
 }
 
-impl<'a, T: Fixed> Seq064K<'a, T> {
+impl<T: Fixed> Seq064K<'_, T> {
     /// converts the lifetime to static
     pub fn into_static(self) -> Seq064K<'static, T> {
         // Safe unwrap cause the initial value is a valid Seq064K
@@ -513,7 +513,7 @@ impl<'a, T: 'a> Sv2Option<'a, T> {
     }
 }
 
-impl<'a, T: GetSize> GetSize for Sv2Option<'a, T> {
+impl<T: GetSize> GetSize for Sv2Option<'_, T> {
     fn get_size(&self) -> usize {
         let mut size = Self::HEADERSIZE;
         for with_size in &self.0 {

--- a/protocols/v2/binary-sv2/codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/codec/src/lib.rs
@@ -473,7 +473,7 @@ impl GetSize for Vec<u8> {
 }
 
 // Only needed for implement encodable for Frame never called
-impl<'a> From<Vec<u8>> for EncodableField<'a> {
+impl From<Vec<u8>> for EncodableField<'_> {
     fn from(_v: Vec<u8>) -> Self {
         unreachable!()
     }

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -27,6 +27,7 @@ key-utils = { path = "../../../utils/key-utils" }
 default = ["std"]
 std = ["noise_sv2?/std", "rand/std", "rand/std_rng", "dep:tracing"]
 with_buffer_pool = ["framing_sv2/with_buffer_pool"]
+tracing = ["dep:tracing"]
 
 [package.metadata.docs.rs]
 features = ["with_buffer_pool", "noise_sv2", "std"]

--- a/protocols/v2/noise-sv2/src/handshake.rs
+++ b/protocols/v2/noise-sv2/src/handshake.rs
@@ -286,7 +286,7 @@ mod test {
     use alloc::string::ToString;
     use core::convert::TryInto;
     use quickcheck::{Arbitrary, TestResult};
-    use quickcheck_macros;
+
     use secp256k1::SecretKey;
 
     struct TestHandShake {

--- a/protocols/v2/noise-sv2/src/lib.rs
+++ b/protocols/v2/noise-sv2/src/lib.rs
@@ -13,12 +13,12 @@
 //! - AEAD: Ensures confidentiality and integrity of the data.
 //! - `AES-GCM` and `ChaCha20-Poly1305`: Provides encryption, with hardware-optimized and
 //!   software-optimized options.
-//! - Schnorr Signatures: Authenticates messages and verifies the identity of the Sv2 roles.
-//! In practice, the primitives exposed by this crate should be used to secure communication
-//! channels between Sv2 roles. Securing communication between two Sv2 roles on the same local
-//! network (e.g., local mining devices communicating with a local mining proxy) is optional.
-//! However, it is mandatory to secure the communication between two Sv2 roles communicating over a
-//! remote network (e.g., a local mining proxy communicating with a remote pool sever).
+//! - Schnorr Signatures: Authenticates messages and verifies the identity of the Sv2 roles. In
+//!   practice, the primitives exposed by this crate should be used to secure communication channels
+//!   between Sv2 roles. Securing communication between two Sv2 roles on the same local network
+//!   (e.g., local mining devices communicating with a local mining proxy) is optional. However, it
+//!   is mandatory to secure the communication between two Sv2 roles communicating over a remote
+//!   network (e.g., a local mining proxy communicating with a remote pool sever).
 //!
 //! The Noise protocol establishes secure communication between two Sv2 roles via a handshake
 //! performed at the beginning of the connection. The initiator (e.g., a local mining proxy) and

--- a/protocols/v2/noise-sv2/src/signature_message.rs
+++ b/protocols/v2/noise-sv2/src/signature_message.rs
@@ -87,7 +87,6 @@ impl SignatureNoiseMessage {
     ///
     /// The current system time should be provided to avoid relying on `std` and allow `no_std`
     /// environments to use another source of time.
-
     #[inline]
     pub fn verify_with_now(
         self,

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -1980,7 +1980,7 @@ mod test {
             request_id: 100.into(),
             user_identity: "Gigi".to_string().try_into().unwrap(),
             nominal_hash_rate: 100_000_000_000_000.0,
-            max_target: [255; 32].try_into().unwrap(),
+            max_target: [255; 32].into(),
         };
 
         // "Send" the OpenStandardMiningChannel to channel

--- a/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mod.rs
@@ -20,7 +20,7 @@
 //! - `job_declaration`: Manages custom mining job declarations, transactions, and solutions.
 //! - `mining`: Manages standard mining communication (e.g., job dispatch, shares submission).
 //! - `template_distribution`: Handles block templates updates and transaction data.
-//! //! - **Common Messages**: Shared across all Sv2 roles.
+//! - `Common Messages`: Shared across all Sv2 roles.
 //!
 //! ## Return Values
 //!

--- a/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
@@ -55,7 +55,7 @@ struct Header<'a> {
     nonce: u32,
 }
 
-impl<'a> Header<'a> {
+impl Header<'_> {
     // calculates the sha256 blockhash of the header
     #[allow(dead_code)]
     pub fn hash(&self) -> Target {
@@ -303,7 +303,7 @@ mod tests {
         let group_channel_id = 1;
         //Create a template
         let mut template = template_from_gen(&mut Gen::new(255));
-        template.template_id = template.template_id % u64::MAX;
+        template.template_id %= u64::MAX;
         template.future_template = true;
         let extended_mining_job = jobs_creators
             .on_new_template(
@@ -506,7 +506,7 @@ mod tests {
         let mut faulty_shares = shares.clone();
         faulty_shares.job_id += 1;
 
-        for (index, shares) in vec![shares, faulty_shares].iter().enumerate() {
+        for (index, shares) in [shares, faulty_shares].iter().enumerate() {
             match group_channel_job_dispatcher.on_submit_shares(shares.clone()) {
                 SendSharesResponse::Valid(resp) => {
                     assert_eq!(

--- a/protocols/v2/roles-logic-sv2/src/parsers.rs
+++ b/protocols/v2/roles-logic-sv2/src/parsers.rs
@@ -187,7 +187,7 @@ pub enum Mining<'a> {
     UpdateChannelError(UpdateChannelError<'a>),
 }
 
-impl<'a> Mining<'a> {
+impl Mining<'_> {
     /// converter into static lifetime
     pub fn into_static(self) -> Mining<'static> {
         match self {
@@ -236,7 +236,7 @@ pub trait IsSv2Message {
     fn channel_bit(&self) -> bool;
 }
 
-impl<'a> IsSv2Message for CommonMessages<'a> {
+impl IsSv2Message for CommonMessages<'_> {
     fn message_type(&self) -> u8 {
         match self {
             Self::ChannelEndpointChanged(_) => MESSAGE_TYPE_CHANNEL_ENDPOINT_CHANGED,
@@ -256,7 +256,7 @@ impl<'a> IsSv2Message for CommonMessages<'a> {
     }
 }
 
-impl<'a> IsSv2Message for TemplateDistribution<'a> {
+impl IsSv2Message for TemplateDistribution<'_> {
     fn message_type(&self) -> u8 {
         match self {
             Self::CoinbaseOutputDataSize(_) => MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE,
@@ -280,7 +280,7 @@ impl<'a> IsSv2Message for TemplateDistribution<'a> {
         }
     }
 }
-impl<'a> IsSv2Message for JobDeclaration<'a> {
+impl IsSv2Message for JobDeclaration<'_> {
     fn message_type(&self) -> u8 {
         match self {
             Self::AllocateMiningJobToken(_) => MESSAGE_TYPE_ALLOCATE_MINING_JOB_TOKEN,
@@ -316,7 +316,7 @@ impl<'a> IsSv2Message for JobDeclaration<'a> {
         }
     }
 }
-impl<'a> IsSv2Message for Mining<'a> {
+impl IsSv2Message for Mining<'_> {
     fn message_type(&self) -> u8 {
         match self {
             Self::CloseChannel(_) => MESSAGE_TYPE_CLOSE_CHANNEL,
@@ -472,7 +472,7 @@ impl GetSize for TemplateDistribution<'_> {
         }
     }
 }
-impl<'a> GetSize for JobDeclaration<'a> {
+impl GetSize for JobDeclaration<'_> {
     fn get_size(&self) -> usize {
         match self {
             JobDeclaration::AllocateMiningJobToken(a) => a.get_size(),
@@ -1055,7 +1055,7 @@ impl GetSize for AnyMessage<'_> {
     }
 }
 
-impl<'a> IsSv2Message for AnyMessage<'a> {
+impl IsSv2Message for AnyMessage<'_> {
     fn message_type(&self) -> u8 {
         match self {
             AnyMessage::Common(a) => a.message_type(),
@@ -1075,7 +1075,7 @@ impl<'a> IsSv2Message for AnyMessage<'a> {
     }
 }
 
-impl<'a> IsSv2Message for MiningDeviceMessages<'a> {
+impl IsSv2Message for MiningDeviceMessages<'_> {
     fn message_type(&self) -> u8 {
         match self {
             MiningDeviceMessages::Common(a) => a.message_type(),
@@ -1122,7 +1122,7 @@ impl<'a> From<SetupConnection<'a>> for CommonMessages<'a> {
     }
 }
 
-impl<'a> From<SetupConnectionSuccess> for CommonMessages<'a> {
+impl From<SetupConnectionSuccess> for CommonMessages<'_> {
     fn from(v: SetupConnectionSuccess) -> Self {
         CommonMessages::SetupConnectionSuccess(v)
     }
@@ -1232,7 +1232,7 @@ mod test {
 
     #[test]
     fn new_mining_job_serialization() {
-        const CORRECTLY_SERIALIZED_MSG: &'static [u8] = &[
+        const CORRECTLY_SERIALIZED_MSG: &[u8] = &[
             0, 128, 21, 49, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 1, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
             19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
             41, 42, 43, 44, 45, 46, 47, 48,
@@ -1254,25 +1254,25 @@ mod test {
         let mut buffer = [0; 0xffff];
         frame.serialize(&mut buffer).unwrap();
         check_length_consistency(&buffer[..encoded_frame_length]);
-        check_length_consistency(&expected_result);
+        check_length_consistency(expected_result);
         assert_eq!(
             is_channel_msg(&buffer),
-            is_channel_msg(&expected_result),
+            is_channel_msg(expected_result),
             "Unexpected channel_message flag",
         );
         assert_eq!(
             extract_extension_type(&buffer),
-            extract_extension_type(&expected_result),
+            extract_extension_type(expected_result),
             "Unexpected extension type",
         );
         assert_eq!(
             extract_message_type(&buffer),
-            extract_message_type(&expected_result),
+            extract_message_type(expected_result),
             "Unexpected message type",
         );
         assert_eq!(
             extract_payload_length(&buffer),
-            extract_payload_length(&expected_result),
+            extract_payload_length(expected_result),
             "Unexpected message length",
         );
         assert_eq!(
@@ -1282,7 +1282,7 @@ mod test {
         );
         assert_eq!(
             extract_payload(&buffer[..encoded_frame_length]),
-            extract_payload(&expected_result),
+            extract_payload(expected_result),
             "Unexpected payload",
         )
     }

--- a/protocols/v2/roles-logic-sv2/src/routing_logic.rs
+++ b/protocols/v2/roles-logic-sv2/src/routing_logic.rs
@@ -316,12 +316,11 @@ where
     Sel: DownstreamMiningSelector<Down> + D,
 {
     ups.iter()
-        .filter(
-            |up_mutex| match up_mutex.safe_lock(|up| !up.is_header_only()) {
-                Ok(header_only) => header_only,
-                Err(_e) => false,
-            },
-        )
+        .filter(|up_mutex| {
+            up_mutex
+                .safe_lock(|up| !up.is_header_only())
+                .unwrap_or_default()
+        })
         .cloned()
         .collect()
 }

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -1024,9 +1024,7 @@ mod tests {
             .try_into()
             .expect("Slice is incorrect length");
         block_hash_vec.reverse();
-        let block_hash: U256 = block_hash_vec
-            .try_into()
-            .expect("Could not convert `[u8; 32]` to `U256`");
+        let block_hash: U256 = block_hash_vec.into();
 
         // Get prev hash
         let mut prev_hash: Vec<u8> =
@@ -1044,9 +1042,7 @@ mod tests {
         for p in block.path {
             let p_vec = decode_hex(&p).expect("Could not decode hex string to `Vec<u8>`");
             let p_arr: [u8; 32] = p_vec.try_into().expect("Slice is incorrect length");
-            let p_u256: U256 = (p_arr)
-                .try_into()
-                .expect("Could not convert to `U256` from `[u8; 32]`");
+            let p_u256: U256 = (p_arr).into();
             path_vec.push(p_u256);
         }
 
@@ -1091,7 +1087,7 @@ mod tests {
 
         let actual = merkle_root_from_path(
             block.coinbase_tx_prefix.inner_as_ref(),
-            &block.coinbase_tx_suffix.inner_as_ref(),
+            block.coinbase_tx_suffix.inner_as_ref(),
             &block.coinbase_script,
             &block.path.inner_as_ref(),
         )
@@ -1171,7 +1167,7 @@ mod tests {
 
         let mut average: f64 = 0.0;
         for i in &results {
-            average = average + (*i as f64) / attempts as f64;
+            average += (*i as f64) / attempts as f64;
         }
         let delta = (hrs - average) as i64;
         assert!(delta.abs() < 100);

--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -54,7 +54,7 @@ pub struct SetupConnection<'decoder> {
     pub device_id: Str0255<'decoder>,
 }
 
-impl<'decoder> SetupConnection<'decoder> {
+impl SetupConnection<'_> {
     /// Set the flag to indicate that the downstream requires a standard job
     pub fn set_requires_standard_job(&mut self) {
         self.flags |= 0b_0000_0000_0000_0000_0000_0000_0000_0001;
@@ -246,7 +246,7 @@ impl Drop for CSetupConnection {
     }
 }
 
-impl<'a> From<SetupConnection<'a>> for CSetupConnection {
+impl From<SetupConnection<'_>> for CSetupConnection {
     fn from(v: SetupConnection) -> Self {
         Self {
             protocol: v.protocol,
@@ -365,7 +365,7 @@ pub enum Protocol {
     TemplateDistributionProtocol = SV2_TEMPLATE_DISTR_PROTOCOL_DISCRIMINANT,
 }
 
-impl<'a> From<Protocol> for binary_sv2::encodable::EncodableField<'a> {
+impl From<Protocol> for binary_sv2::encodable::EncodableField<'_> {
     fn from(v: Protocol) -> Self {
         let val = v as u8;
         val.into()
@@ -439,25 +439,25 @@ mod test {
     #[test]
     fn test_has_requires_std_job() {
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0001;
-        assert_eq!(has_requires_std_job(flags), true);
+        assert!(has_requires_std_job(flags));
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0010;
-        assert_eq!(has_requires_std_job(flags), false);
+        assert!(!has_requires_std_job(flags));
     }
 
     #[test]
     fn test_has_version_rolling() {
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0010;
-        assert_eq!(has_version_rolling(flags), true);
+        assert!(has_version_rolling(flags));
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0001;
-        assert_eq!(has_version_rolling(flags), false);
+        assert!(!has_version_rolling(flags));
     }
 
     #[test]
     fn test_has_work_selection() {
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0100;
-        assert_eq!(has_work_selection(flags), true);
+        assert!(has_work_selection(flags));
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0001;
-        assert_eq!(has_work_selection(flags), false);
+        assert!(!has_work_selection(flags));
     }
 
     fn create_setup_connection() -> SetupConnection<'static> {

--- a/protocols/v2/subprotocols/mining/src/open_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/open_channel.rs
@@ -36,7 +36,7 @@ pub struct OpenStandardMiningChannel<'decoder> {
     pub max_target: U256<'decoder>,
 }
 
-impl<'decoder> OpenStandardMiningChannel<'decoder> {
+impl OpenStandardMiningChannel<'_> {
     pub fn get_request_id_as_u32(&self) -> u32 {
         (&self.request_id).into()
     }
@@ -73,7 +73,7 @@ pub struct OpenStandardMiningChannelSuccess<'decoder> {
     pub group_channel_id: u32,
 }
 
-impl<'decoder> OpenStandardMiningChannelSuccess<'decoder> {
+impl OpenStandardMiningChannelSuccess<'_> {
     pub fn get_request_id_as_u32(&self) -> u32 {
         (&self.request_id).into()
     }
@@ -128,7 +128,7 @@ pub struct OpenExtendedMiningChannel<'decoder> {
     pub min_extranonce_size: u16,
 }
 
-impl<'decoder> OpenExtendedMiningChannel<'decoder> {
+impl OpenExtendedMiningChannel<'_> {
     pub fn get_request_id_as_u32(&self) -> u32 {
         self.request_id
     }
@@ -172,7 +172,7 @@ pub struct OpenMiningChannelError<'decoder> {
     pub error_code: Str0255<'decoder>,
 }
 
-impl<'a> OpenMiningChannelError<'a> {
+impl OpenMiningChannelError<'_> {
     pub fn new_max_target_out_of_range(request_id: u32) -> Self {
         Self {
             request_id,
@@ -203,7 +203,6 @@ mod tests {
     use crate::tests::from_arbitrary_vec_to_array;
     use alloc::{string::String, vec::Vec};
     use core::convert::TryFrom;
-    use quickcheck_macros;
 
     // *** OPEN STANDARD MINING CHANNEL ***
     #[quickcheck_macros::quickcheck]
@@ -216,11 +215,11 @@ mod tests {
     ) -> bool {
         let max_target: [u8; 32] = from_arbitrary_vec_to_array(max_target);
         let mut osmc = OpenStandardMiningChannel {
-            request_id: U32AsRef::from(request_id.clone()),
-            user_identity: Str0255::try_from(String::from(user_identity.clone()))
+            request_id: U32AsRef::from(request_id),
+            user_identity: Str0255::try_from(user_identity.clone())
                 .expect("could not convert string to Str0255"),
-            nominal_hash_rate: nominal_hash_rate.clone(),
-            max_target: U256::from(max_target.clone()),
+            nominal_hash_rate,
+            max_target: U256::from(max_target),
         };
         let test_request_id_1 = osmc.get_request_id_as_u32();
         osmc.update_id(new_request_id);
@@ -242,9 +241,9 @@ mod tests {
         let target = from_arbitrary_vec_to_array(target);
         let extranonce_prefix = from_arbitrary_vec_to_array(extranonce_prefix);
         let mut osmcs = OpenStandardMiningChannelSuccess {
-            request_id: U32AsRef::from(request_id.clone()),
+            request_id: U32AsRef::from(request_id),
             channel_id,
-            target: U256::from(target.clone()),
+            target: U256::from(target),
             extranonce_prefix: B032::try_from(extranonce_prefix.to_vec()).expect(
                 "OpenStandardMiningChannelSuccess: failed to convert extranonce_prefix to B032",
             ),
@@ -266,11 +265,11 @@ mod tests {
     ) -> bool {
         let max_target: [u8; 32] = from_arbitrary_vec_to_array(max_target);
         let oemc = OpenExtendedMiningChannel {
-            request_id: request_id.clone(),
-            user_identity: Str0255::try_from(String::from(user_identity.clone()))
+            request_id,
+            user_identity: Str0255::try_from(user_identity.clone())
                 .expect("could not convert string to Str0255"),
-            nominal_hash_rate: nominal_hash_rate.clone(),
-            max_target: U256::from(max_target.clone()),
+            nominal_hash_rate,
+            max_target: U256::from(max_target),
             min_extranonce_size,
         };
         let test_request_id_1 = oemc.get_request_id_as_u32();
@@ -290,8 +289,7 @@ mod tests {
         }
     }
 
+    // "placeholder to allow in file unit tests for quickcheck";
     #[test]
-    fn test() {
-        "placeholder to allow in file unit tests for quickcheck";
-    }
+    fn test() {}
 }

--- a/protocols/v2/subprotocols/mining/src/submit_shares.rs
+++ b/protocols/v2/subprotocols/mining/src/submit_shares.rs
@@ -104,7 +104,7 @@ pub struct SubmitSharesError<'decoder> {
     pub error_code: Str0255<'decoder>,
 }
 
-impl<'a> SubmitSharesError<'a> {
+impl SubmitSharesError<'_> {
     pub fn invalid_channel_error_code() -> &'static str {
         "invalid-channel-id"
     }

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -102,7 +102,6 @@ impl<'a> From<NewTemplate<'a>> for CNewTemplate {
 
 impl<'a> CNewTemplate {
     /// Converts from C to Rust representation.
-
     #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<NewTemplate<'a>, Error> {
         let coinbase_prefix: B0255 = self.coinbase_prefix.as_mut_slice().try_into()?;

--- a/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
@@ -72,7 +72,6 @@ pub struct CRequestTransactionDataSuccess {
 
 impl<'a> CRequestTransactionDataSuccess {
     /// Converts C struct to Rust struct.
-
     #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<RequestTransactionDataSuccess<'a>, Error> {
         let excess_data: B064K = self.excess_data.as_mut_slice().try_into()?;
@@ -135,7 +134,6 @@ pub struct CRequestTransactionDataError {
 
 impl<'a> CRequestTransactionDataError {
     /// Converts C struct to Rust struct.
-
     #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<RequestTransactionDataError<'a>, Error> {
         let error_code: Str0255 = self.error_code.as_mut_slice().try_into()?;

--- a/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
@@ -45,7 +45,6 @@ pub struct CSetNewPrevHash {
 
 impl<'a> CSetNewPrevHash {
     /// Converts CSetNewPrevHash(C representation) to SetNewPrevHash(Rust representation).
-
     #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<SetNewPrevHash<'a>, Error> {
         let prev_hash: U256 = self.prev_hash.as_mut_slice().try_into()?;

--- a/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
@@ -51,7 +51,6 @@ pub struct CSubmitSolution {
 
 impl<'a> CSubmitSolution {
     /// Converts CSubmitSolution(C representation) to SubmitSolution(Rust representation).
-
     #[allow(clippy::wrong_self_convention)]
     pub fn to_rust_rep_mut(&'a mut self) -> Result<SubmitSolution<'a>, Error> {
         let coinbase_tx: B064K = self.coinbase_tx.as_mut_slice().try_into()?;

--- a/protocols/v2/sv2-ffi/src/lib.rs
+++ b/protocols/v2/sv2-ffi/src/lib.rs
@@ -52,7 +52,7 @@ pub enum Sv2Message<'a> {
     SetupConnectionSuccess(SetupConnectionSuccess),
 }
 
-impl<'a> Sv2Message<'a> {
+impl Sv2Message<'_> {
     pub fn message_type(&self) -> u8 {
         match self {
             Sv2Message::CoinbaseOutputDataSize(_) => MESSAGE_TYPE_COINBASE_OUTPUT_DATA_SIZE,
@@ -94,7 +94,7 @@ impl<'a> Sv2Message<'a> {
     }
 }
 
-impl<'a> Display for Sv2Message<'a> {
+impl Display for Sv2Message<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", *self)
     }

--- a/roles/jd-client/src/lib/error.rs
+++ b/roles/jd-client/src/lib/error.rs
@@ -58,7 +58,7 @@ pub enum Error<'a> {
     Infallible(std::convert::Infallible),
 }
 
-impl<'a> fmt::Display for Error<'a> {
+impl fmt::Display for Error<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Error::*;
         match self {
@@ -82,55 +82,55 @@ impl<'a> fmt::Display for Error<'a> {
     }
 }
 
-impl<'a> From<binary_sv2::Error> for Error<'a> {
+impl From<binary_sv2::Error> for Error<'_> {
     fn from(e: binary_sv2::Error) -> Self {
         Error::BinarySv2(e)
     }
 }
 
-impl<'a> From<codec_sv2::noise_sv2::Error> for Error<'a> {
+impl From<codec_sv2::noise_sv2::Error> for Error<'_> {
     fn from(e: codec_sv2::noise_sv2::Error) -> Self {
         Error::CodecNoise(e)
     }
 }
 
-impl<'a> From<framing_sv2::Error> for Error<'a> {
+impl From<framing_sv2::Error> for Error<'_> {
     fn from(e: framing_sv2::Error) -> Self {
         Error::FramingSv2(e)
     }
 }
 
-impl<'a> From<std::io::Error> for Error<'a> {
+impl From<std::io::Error> for Error<'_> {
     fn from(e: std::io::Error) -> Self {
         Error::Io(e)
     }
 }
 
-impl<'a> From<std::num::ParseIntError> for Error<'a> {
+impl From<std::num::ParseIntError> for Error<'_> {
     fn from(e: std::num::ParseIntError) -> Self {
         Error::ParseInt(e)
     }
 }
 
-impl<'a> From<roles_logic_sv2::errors::Error> for Error<'a> {
+impl From<roles_logic_sv2::errors::Error> for Error<'_> {
     fn from(e: roles_logic_sv2::errors::Error) -> Self {
         Error::RolesSv2Logic(e)
     }
 }
 
-impl<'a> From<ConfigError> for Error<'a> {
+impl From<ConfigError> for Error<'_> {
     fn from(e: ConfigError) -> Self {
         Error::BadConfigDeserialize(e)
     }
 }
 
-impl<'a> From<async_channel::RecvError> for Error<'a> {
+impl From<async_channel::RecvError> for Error<'_> {
     fn from(e: async_channel::RecvError) -> Self {
         Error::ChannelErrorReceiver(e)
     }
 }
 
-impl<'a> From<tokio::sync::broadcast::error::RecvError> for Error<'a> {
+impl From<tokio::sync::broadcast::error::RecvError> for Error<'_> {
     fn from(e: tokio::sync::broadcast::error::RecvError) -> Self {
         Error::TokioChannelErrorRecv(e)
     }
@@ -172,7 +172,7 @@ impl<'a> From<async_channel::SendError<roles_logic_sv2::mining_sv2::SetNewPrevHa
     }
 }
 
-impl<'a> From<async_channel::SendError<(ExtendedExtranonce, u32)>> for Error<'a> {
+impl From<async_channel::SendError<(ExtendedExtranonce, u32)>> for Error<'_> {
     fn from(e: async_channel::SendError<(ExtendedExtranonce, u32)>) -> Self {
         Error::ChannelErrorSender(ChannelSendError::Extranonce(e))
     }
@@ -208,7 +208,7 @@ impl<'a>
     }
 }
 
-impl<'a> From<std::convert::Infallible> for Error<'a> {
+impl From<std::convert::Infallible> for Error<'_> {
     fn from(e: std::convert::Infallible) -> Self {
         Error::Infallible(e)
     }

--- a/roles/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-client/src/lib/job_declarator/message_handler.rs
@@ -67,7 +67,7 @@ impl ParseServerJobDeclarationMessages for JobDeclarator {
                     None
                 }
             })
-            .ok_or_else(|| Error::UnknownRequestId(message.request_id))?;
+            .ok_or(Error::UnknownRequestId(message.request_id))?;
 
         let unknown_tx_position_list: Vec<u16> = message.unknown_tx_position_list.into_inner();
         let missing_transactions: Vec<binary_sv2::B016M> = unknown_tx_position_list

--- a/roles/jd-server/src/lib/mod.rs
+++ b/roles/jd-server/src/lib/mod.rs
@@ -367,7 +367,7 @@ mod tests {
         let config_path = config_path.to_str().unwrap();
 
         let settings = Config::builder()
-            .add_source(File::new(&config_path, FileFormat::Toml))
+            .add_source(File::new(config_path, FileFormat::Toml))
             .build()
             .expect("Failed to build config");
 

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -583,7 +583,7 @@ mod test {
 
         // Load config
         let config: PoolConfig = match Config::builder()
-            .add_source(File::new(&config_path, FileFormat::Toml))
+            .add_source(File::new(config_path, FileFormat::Toml))
             .build()
         {
             Ok(settings) => match settings.try_deserialize::<PoolConfig>() {
@@ -615,7 +615,7 @@ mod test {
         // build coinbase TX from 'job_creator::coinbase()'
 
         let mut bip34_bytes = get_bip_34_bytes(coinbase_prefix.try_into().unwrap());
-        let script_prefix_length = bip34_bytes.len() + config.pool_signature().as_bytes().len();
+        let script_prefix_length = bip34_bytes.len() + config.pool_signature().len();
         bip34_bytes.extend_from_slice(config.pool_signature().as_bytes());
         bip34_bytes.extend_from_slice(&vec![0; extranonce_len as usize]);
         let witness = match bip34_bytes.len() {

--- a/roles/tests-integration/tests/sniffer_integration.rs
+++ b/roles/tests-integration/tests/sniffer_integration.rs
@@ -122,22 +122,20 @@ async fn test_sniffer_wait_for_message_type_with_remove() {
             )
             .await
     );
-    assert_eq!(
-        sniffer
+    assert!(
+        !(sniffer
             .includes_message_type(
                 MessageDirection::ToDownstream,
                 MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS
             )
-            .await,
-        false
+            .await)
     );
-    assert_eq!(
-        sniffer
+    assert!(
+        !(sniffer
             .includes_message_type(
                 MessageDirection::ToDownstream,
                 MESSAGE_TYPE_SET_NEW_PREV_HASH
             )
-            .await,
-        false
+            .await)
     );
 }

--- a/roles/tests-integration/tests/translator_integration.rs
+++ b/roles/tests-integration/tests/translator_integration.rs
@@ -5,8 +5,8 @@
 // Note that it is enough to call `start_tracing()` once in the test suite to enable tracing for
 // all tests. This is because tracing is a global setting.
 use const_sv2::{
-    MESSAGE_TYPE_MINING_SET_NEW_PREV_HASH, MESSAGE_TYPE_SETUP_CONNECTION,
-    MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED, MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
+    MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
+    MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
 };
 use integration_tests_sv2::{sniffer::*, *};
 use roles_logic_sv2::parsers::{AnyMessage, CommonMessages, Mining};

--- a/roles/translator/src/lib/error.rs
+++ b/roles/translator/src/lib/error.rs
@@ -75,7 +75,7 @@ pub enum Error<'a> {
     Sv1MessageTooLong,
 }
 
-impl<'a> fmt::Display for Error<'a> {
+impl fmt::Display for Error<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Error::*;
         match self {
@@ -114,49 +114,49 @@ impl<'a> fmt::Display for Error<'a> {
     }
 }
 
-impl<'a> From<binary_sv2::Error> for Error<'a> {
+impl From<binary_sv2::Error> for Error<'_> {
     fn from(e: binary_sv2::Error) -> Self {
         Error::BinarySv2(e)
     }
 }
 
-impl<'a> From<codec_sv2::noise_sv2::Error> for Error<'a> {
+impl From<codec_sv2::noise_sv2::Error> for Error<'_> {
     fn from(e: codec_sv2::noise_sv2::Error) -> Self {
         Error::CodecNoise(e)
     }
 }
 
-impl<'a> From<framing_sv2::Error> for Error<'a> {
+impl From<framing_sv2::Error> for Error<'_> {
     fn from(e: framing_sv2::Error) -> Self {
         Error::FramingSv2(e)
     }
 }
 
-impl<'a> From<std::io::Error> for Error<'a> {
+impl From<std::io::Error> for Error<'_> {
     fn from(e: std::io::Error) -> Self {
         Error::Io(e)
     }
 }
 
-impl<'a> From<std::num::ParseIntError> for Error<'a> {
+impl From<std::num::ParseIntError> for Error<'_> {
     fn from(e: std::num::ParseIntError) -> Self {
         Error::ParseInt(e)
     }
 }
 
-impl<'a> From<roles_logic_sv2::errors::Error> for Error<'a> {
+impl From<roles_logic_sv2::errors::Error> for Error<'_> {
     fn from(e: roles_logic_sv2::errors::Error) -> Self {
         Error::RolesSv2Logic(e)
     }
 }
 
-impl<'a> From<serde_json::Error> for Error<'a> {
+impl From<serde_json::Error> for Error<'_> {
     fn from(e: serde_json::Error) -> Self {
         Error::BadSerdeJson(e)
     }
 }
 
-impl<'a> From<ConfigError> for Error<'a> {
+impl From<ConfigError> for Error<'_> {
     fn from(e: ConfigError) -> Self {
         Error::BadConfigDeserialize(e)
     }
@@ -168,20 +168,20 @@ impl<'a> From<v1::error::Error<'a>> for Error<'a> {
     }
 }
 
-impl<'a> From<async_channel::RecvError> for Error<'a> {
+impl From<async_channel::RecvError> for Error<'_> {
     fn from(e: async_channel::RecvError) -> Self {
         Error::ChannelErrorReceiver(e)
     }
 }
 
-impl<'a> From<tokio::sync::broadcast::error::RecvError> for Error<'a> {
+impl From<tokio::sync::broadcast::error::RecvError> for Error<'_> {
     fn from(e: tokio::sync::broadcast::error::RecvError) -> Self {
         Error::TokioChannelErrorRecv(e)
     }
 }
 
 //*** LOCK ERRORS ***
-impl<'a, T> From<PoisonError<T>> for Error<'a> {
+impl<T> From<PoisonError<T>> for Error<'_> {
     fn from(_e: PoisonError<T>) -> Self {
         Error::PoisonLock
     }
@@ -212,13 +212,13 @@ impl<'a> From<tokio::sync::broadcast::error::SendError<Notify<'a>>> for Error<'a
     }
 }
 
-impl<'a> From<async_channel::SendError<v1::Message>> for Error<'a> {
+impl From<async_channel::SendError<v1::Message>> for Error<'_> {
     fn from(e: async_channel::SendError<v1::Message>) -> Self {
         Error::ChannelErrorSender(ChannelSendError::V1Message(e))
     }
 }
 
-impl<'a> From<async_channel::SendError<(ExtendedExtranonce, u32)>> for Error<'a> {
+impl From<async_channel::SendError<(ExtendedExtranonce, u32)>> for Error<'_> {
     fn from(e: async_channel::SendError<(ExtendedExtranonce, u32)>) -> Self {
         Error::ChannelErrorSender(ChannelSendError::Extranonce(e))
     }
@@ -254,19 +254,19 @@ impl<'a>
     }
 }
 
-impl<'a> From<Vec<u8>> for Error<'a> {
+impl From<Vec<u8>> for Error<'_> {
     fn from(e: Vec<u8>) -> Self {
         Error::VecToSlice32(e)
     }
 }
 
-impl<'a> From<SetDifficulty> for Error<'a> {
+impl From<SetDifficulty> for Error<'_> {
     fn from(e: SetDifficulty) -> Self {
         Error::SetDifficultyToMessage(e)
     }
 }
 
-impl<'a> From<std::convert::Infallible> for Error<'a> {
+impl From<std::convert::Infallible> for Error<'_> {
     fn from(e: std::convert::Infallible) -> Self {
         Error::Infallible(e)
     }

--- a/scripts/rust/clippy.sh
+++ b/scripts/rust/clippy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+workspaces=("benches" "common" "roles" "protocols" "utils")
+
+# print current rust version
+echo "Rust version: $(rustc --version)"
+
+for workspace in "${workspaces[@]}"; do
+  echo "Running clippy for workspace: $workspace"
+  cargo clippy --manifest-path="$workspace/Cargo.toml" -- -D warnings
+  if [[ $? -ne 0 ]]; then
+    echo "Clippy failed for workspace: $workspace"
+    exit 1
+  else
+    echo "Clippy passed for workspace: $workspace"
+  fi
+done
+
+echo "Clippy success!"
+exit 0


### PR DESCRIPTION
Part of #1272 

The most notable fix/change in this pr is adding this https://github.com/stratum-mining/stratum/pull/1492/files#diff-40acd8e96b9e30ae1cfa538fb7ae0cdf80358930dd6f4167375f85980ee019e4 because `tracing` feature is used withing the code but did not exist in Cargo.toml

Probably eventually whats called now `Clippy-lint.yml` would become `rust-checks` and we will have in it clippy/fmt/test/.. all cargo/rust stuff that we want in the same place