### PR TITLE
update action checkout version semver

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Currently the semver ci is failing because of outdated ci checkout version. This PR fixes that. Closes: #1495 