### PR TITLE
Variable pool shares per min

### DIFF
--- a/roles/pool/config-examples/pool-config-hosted-tp-example.toml
+++ b/roles/pool/config-examples/pool-config-hosted-tp-example.toml
@@ -26,3 +26,4 @@ pool_signature = "Stratum v2 SRI Pool"
 # Hosted testnet TP 
 tp_address = "75.119.150.111:8442"
 tp_authority_public_key = "9bwHCYnjhbHm4AS3pWg9MtAH83mzWohoJJJDELYBqZhDNqszDLc"
+shares_per_minute = 1.0

--- a/roles/pool/config-examples/pool-config-local-tp-example.toml
+++ b/roles/pool/config-examples/pool-config-local-tp-example.toml
@@ -23,3 +23,4 @@ pool_signature = "Stratum v2 SRI Pool"
 # Template Provider config
 # Local TP (this is pointing to localhost so you must run a TP locally for this configuration to work)
 tp_address = "127.0.0.1:8442"
+shares_per_minute = 1.0

--- a/roles/pool/src/lib/config.rs
+++ b/roles/pool/src/lib/config.rs
@@ -16,6 +16,7 @@ pub struct PoolConfig {
     cert_validity_sec: u64,
     coinbase_outputs: Vec<CoinbaseOutput>,
     pool_signature: String,
+    shares_per_minute: f32,
 }
 
 impl PoolConfig {
@@ -25,6 +26,7 @@ impl PoolConfig {
         template_provider: TemplateProviderConfig,
         authority_config: AuthorityConfig,
         coinbase_outputs: Vec<CoinbaseOutput>,
+        shares_per_minute: f32,
     ) -> Self {
         Self {
             listen_address: pool_connection.listen_address,
@@ -35,6 +37,7 @@ impl PoolConfig {
             cert_validity_sec: pool_connection.cert_validity_sec,
             coinbase_outputs,
             pool_signature: pool_connection.signature,
+            shares_per_minute,
         }
     }
 
@@ -81,6 +84,11 @@ impl PoolConfig {
     /// Sets the coinbase outputs.
     pub fn set_coinbase_outputs(&mut self, coinbase_outputs: Vec<CoinbaseOutput>) {
         self.coinbase_outputs = coinbase_outputs;
+    }
+
+    /// Returns the shares per minute.
+    pub fn shares_per_minute(&self) -> f32 {
+        self.shares_per_minute
     }
 }
 

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -451,6 +451,7 @@ impl Pool {
         solution_sender: Sender<SubmitSolution<'static>>,
         sender_message_received_signal: Sender<()>,
         status_tx: status::Sender,
+        shares_per_minute: f32,
     ) -> Arc<Mutex<Self>> {
         let extranonce_len = 32;
         let range_0 = std::ops::Range { start: 0, end: 0 };
@@ -464,13 +465,12 @@ impl Pool {
         info!("PUB KEY: {:?}", pool_coinbase_outputs);
         let extranonces = ExtendedExtranonce::new(range_0, range_1, range_2);
         let creator = JobsCreators::new(extranonce_len as u8);
-        let share_per_min = 1.0;
         let kind = roles_logic_sv2::channel_logic::channel_factory::ExtendedChannelKind::Pool;
         let channel_factory = Arc::new(Mutex::new(PoolChannelFactory::new(
             ids,
             extranonces,
             creator,
-            share_per_min,
+            shares_per_minute,
             kind,
             pool_coinbase_outputs.expect("Invalid coinbase output in config"),
             config.pool_signature().clone().into(),

--- a/roles/pool/src/lib/mod.rs
+++ b/roles/pool/src/lib/mod.rs
@@ -52,6 +52,7 @@ impl PoolSv2 {
             s_solution,
             s_message_recv_signal,
             status::Sender::DownstreamListener(status_tx),
+            config.shares_per_minute(),
         );
 
         // Start the error handling loop

--- a/roles/tests-integration/lib/mod.rs
+++ b/roles/tests-integration/lib/mod.rs
@@ -79,11 +79,13 @@ pub async fn start_pool(template_provider_address: Option<SocketAddr>) -> (PoolS
     let template_provider_config = pool_sv2::config::TemplateProviderConfig::new(tp_address, None);
     let authority_config =
         pool_sv2::config::AuthorityConfig::new(authority_public_key, authority_secret_key);
+    let shares_per_minute = 60.0;
     let config = PoolConfig::new(
         connection_config,
         template_provider_config,
         authority_config,
         coinbase_outputs,
+        shares_per_minute,
     );
     let pool = PoolSv2::new(config);
     let pool_clone = pool.clone();

--- a/test/config/pool-mock-tp.toml
+++ b/test/config/pool-mock-tp.toml
@@ -13,3 +13,4 @@ coinbase_outputs = [
 ]
 # Pool signature (string to be included in coinbase tx)
 pool_signature = "Stratum v2 SRI Pool"
+shares_per_minute = 1.0

--- a/test/config/sv1-test/pool-config.toml
+++ b/test/config/sv1-test/pool-config.toml
@@ -21,3 +21,5 @@ pool_signature = "Stratum v2 SRI Pool - gitgab19"
 # Template Provider config
 # hosted testnet TP
 tp_address = "75.119.150.111:8442"
+
+shares_per_minute = 1.0


### PR DESCRIPTION
Addresses #1229 by adding `shares_per_minute` to the pool configuration toml instead of hard coding to `1.0` in `pool::mining_pool::Pool::start`.