### PR TITLE
`PoolMessages` removal in favor of generic `AnyMessage`

### DIFF
--- a/protocols/fuzz-tests/src/main.rs
+++ b/protocols/fuzz-tests/src/main.rs
@@ -3,13 +3,13 @@ use libfuzzer_sys::fuzz_target;
 use binary_codec_sv2::{Seq064K,U256,B0255,Seq0255};
 use binary_codec_sv2::from_bytes;
 use codec_sv2::{StandardDecoder,Sv2Frame};
-use roles_logic_sv2::parsers::PoolMessages;
+use roles_logic_sv2::parsers::AnyMessage;
 
-type F = Sv2Frame<PoolMessages<'static>,Vec<u8>>;
+type F = Sv2Frame<AnyMessage<'static>,Vec<u8>>;
 
 fuzz_target!(|data: Vec<u8>| {
     let mut data = data;
-    let mut decoder = StandardDecoder::<PoolMessages>::new();
+    let mut decoder = StandardDecoder::<AnyMessage>::new();
     let _: Result<Seq064K<bool>,_> = from_bytes(&mut data);
     let _: Result<Seq064K<u64>,_> = from_bytes(&mut data);
     let _: Result<U256,_> = from_bytes(&mut data);

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -4,8 +4,7 @@
 //! module. It includes the [`Error`] enum for representing various errors.
 
 use crate::{
-    common_properties::CommonDownstreamData, parsers::PoolMessages as AllMessages,
-    utils::InputError,
+    common_properties::CommonDownstreamData, parsers::AnyMessage as AllMessages, utils::InputError,
 };
 use binary_sv2::Error as BinarySv2Error;
 use std::fmt::{self, Display, Formatter};

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -15,7 +15,7 @@ use roles_logic_sv2::{
     },
     job_creator::JobsCreators,
     mining_sv2::*,
-    parsers::{Mining, MiningDeviceMessages, PoolMessages},
+    parsers::{AnyMessage, Mining, MiningDeviceMessages},
     template_distribution_sv2::{NewTemplate, SubmitSolution},
     utils::Mutex,
 };
@@ -275,7 +275,7 @@ impl DownstreamMiningNode {
     ) {
         match next_message_to_send {
             Ok(SendTo::RelaySameMessageToRemote(upstream_mutex)) => {
-                let sv2_frame: codec_sv2::Sv2Frame<PoolMessages, buffer_sv2::Slice> =
+                let sv2_frame: codec_sv2::Sv2Frame<AnyMessage, buffer_sv2::Slice> =
                     incoming.unwrap().map(|payload| payload.try_into().unwrap());
                 UpstreamMiningNode::send(&upstream_mutex, sv2_frame)
                     .await
@@ -304,16 +304,16 @@ impl DownstreamMiningNode {
                     job_id
                 );
                 let message = Mining::SubmitSharesExtended(share);
-                let message: PoolMessages = PoolMessages::Mining(message);
-                let sv2_frame: codec_sv2::Sv2Frame<PoolMessages, buffer_sv2::Slice> =
+                let message: AnyMessage = AnyMessage::Mining(message);
+                let sv2_frame: codec_sv2::Sv2Frame<AnyMessage, buffer_sv2::Slice> =
                     message.try_into().unwrap();
                 UpstreamMiningNode::send(&upstream_mutex, sv2_frame)
                     .await
                     .unwrap();
             }
             Ok(SendTo::RelayNewMessage(message)) => {
-                let message: PoolMessages = PoolMessages::Mining(message);
-                let sv2_frame: codec_sv2::Sv2Frame<PoolMessages, buffer_sv2::Slice> =
+                let message: AnyMessage = AnyMessage::Mining(message);
+                let sv2_frame: codec_sv2::Sv2Frame<AnyMessage, buffer_sv2::Slice> =
                     message.try_into().unwrap();
                 let upstream_mutex = self_mutex.safe_lock(|s| s.status.get_upstream().expect("We should return RelayNewMessage only if we are not in solo mining mode")).unwrap();
                 UpstreamMiningNode::send(&upstream_mutex, sv2_frame)

--- a/roles/jd-client/src/lib/job_declarator/setup_connection.rs
+++ b/roles/jd-client/src/lib/job_declarator/setup_connection.rs
@@ -3,12 +3,12 @@ use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     handlers::common::{ParseUpstreamCommonMessages, SendTo},
-    parsers::PoolMessages,
+    parsers::AnyMessage,
     routing_logic::{CommonRoutingLogic, NoRouting},
     utils::Mutex,
 };
 use std::{convert::TryInto, net::SocketAddr, sync::Arc};
-pub type Message = PoolMessages<'static>;
+pub type Message = AnyMessage<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;
 pub struct SetupConnectionHandler {}
@@ -48,7 +48,7 @@ impl SetupConnectionHandler {
     ) -> Result<(), ()> {
         let setup_connection = Self::get_setup_connection_message(proxy_address);
 
-        let sv2_frame: StdFrame = PoolMessages::Common(setup_connection.into())
+        let sv2_frame: StdFrame = AnyMessage::Common(setup_connection.into())
             .try_into()
             .unwrap();
         let sv2_frame = sv2_frame.into();

--- a/roles/jd-client/src/lib/template_receiver/mod.rs
+++ b/roles/jd-client/src/lib/template_receiver/mod.rs
@@ -7,7 +7,7 @@ use network_helpers_sv2::noise_connection::Connection;
 use roles_logic_sv2::{
     handlers::{template_distribution::ParseServerTemplateDistributionMessages, SendTo_},
     job_declaration_sv2::AllocateMiningJobTokenSuccess,
-    parsers::{PoolMessages, TemplateDistribution},
+    parsers::{AnyMessage, TemplateDistribution},
     template_distribution_sv2::{
         CoinbaseOutputDataSize, NewTemplate, RequestTransactionData, SubmitSolution,
     },
@@ -23,7 +23,7 @@ mod message_handler;
 mod setup_connection;
 
 pub type SendTo = SendTo_<roles_logic_sv2::parsers::TemplateDistribution<'static>, ()>;
-pub type Message = PoolMessages<'static>;
+pub type Message = AnyMessage<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;
 
@@ -116,7 +116,7 @@ impl TemplateRx {
     }
 
     pub async fn send_max_coinbase_size(self_mutex: &Arc<Mutex<Self>>, size: u32) {
-        let coinbase_output_data_size = PoolMessages::TemplateDistribution(
+        let coinbase_output_data_size = AnyMessage::TemplateDistribution(
             TemplateDistribution::CoinbaseOutputDataSize(CoinbaseOutputDataSize {
                 coinbase_output_max_additional_size: size,
             }),
@@ -129,7 +129,7 @@ impl TemplateRx {
         self_mutex: &Arc<Mutex<Self>>,
         new_template: NewTemplate<'static>,
     ) {
-        let tx_data_request = PoolMessages::TemplateDistribution(
+        let tx_data_request = AnyMessage::TemplateDistribution(
             TemplateDistribution::RequestTransactionData(RequestTransactionData {
                 template_id: new_template.template_id,
             }),
@@ -319,7 +319,7 @@ impl TemplateRx {
                 .safe_lock(|s| s.test_only_do_not_send_solution_to_tp)
                 .unwrap()
             {
-                let sv2_frame: StdFrame = PoolMessages::TemplateDistribution(
+                let sv2_frame: StdFrame = AnyMessage::TemplateDistribution(
                     TemplateDistribution::SubmitSolution(solution),
                 )
                 .try_into()

--- a/roles/jd-client/src/lib/template_receiver/setup_connection.rs
+++ b/roles/jd-client/src/lib/template_receiver/setup_connection.rs
@@ -3,12 +3,12 @@ use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
     handlers::common::{ParseUpstreamCommonMessages, SendTo},
-    parsers::PoolMessages,
+    parsers::AnyMessage,
     routing_logic::{CommonRoutingLogic, NoRouting},
     utils::Mutex,
 };
 use std::{convert::TryInto, net::SocketAddr, sync::Arc};
-pub type Message = PoolMessages<'static>;
+pub type Message = AnyMessage<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;
 pub struct SetupConnectionHandler {}
@@ -41,7 +41,7 @@ impl SetupConnectionHandler {
     ) -> Result<(), ()> {
         let setup_connection = Self::get_setup_connection_message(address);
 
-        let sv2_frame: StdFrame = PoolMessages::Common(setup_connection.into())
+        let sv2_frame: StdFrame = AnyMessage::Common(setup_connection.into())
             .try_into()
             .unwrap();
         let sv2_frame = sv2_frame.into();

--- a/roles/jd-client/src/lib/upstream_sv2/mod.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/mod.rs
@@ -1,9 +1,9 @@
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use roles_logic_sv2::parsers::PoolMessages;
+use roles_logic_sv2::parsers::AnyMessage;
 
 pub mod upstream;
 pub use upstream::Upstream;
 
-pub type Message = PoolMessages<'static>;
+pub type Message = AnyMessage<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -25,7 +25,7 @@ use roles_logic_sv2::{
     },
     job_declaration_sv2::DeclareMiningJob,
     mining_sv2::{ExtendedExtranonce, Extranonce, SetCustomMiningJob},
-    parsers::{Mining, MiningDeviceMessages, PoolMessages},
+    parsers::{AnyMessage, Mining, MiningDeviceMessages},
     routing_logic::{CommonRoutingLogic, MiningRoutingLogic, NoRouting},
     selectors::NullDownstreamMiningSelector,
     utils::{Id, Mutex},
@@ -299,7 +299,7 @@ impl Upstream {
             merkle_path,
             extranonce_size: 0,
         };
-        let message = PoolMessages::Mining(Mining::SetCustomMiningJob(to_send));
+        let message = AnyMessage::Mining(Mining::SetCustomMiningJob(to_send));
         let frame: StdFrame = message.try_into().unwrap();
         self_
             .safe_lock(|s| {

--- a/roles/jd-server/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-server/src/lib/job_declarator/message_handler.rs
@@ -15,7 +15,7 @@ pub type SendTo = SendTo_<JobDeclaration<'static>, ()>;
 use crate::mempool::JDsMempool;
 
 use super::{signed_token, TransactionState};
-use roles_logic_sv2::{errors::Error, parsers::PoolMessages as AllMessages};
+use roles_logic_sv2::{errors::Error, parsers::AnyMessage as AllMessages};
 use stratum_common::bitcoin::consensus::Decodable;
 use tracing::{debug, info};
 

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -14,7 +14,7 @@ use roles_logic_sv2::{
     },
     handlers::job_declaration::{ParseClientJobDeclarationMessages, SendTo},
     job_declaration_sv2::{DeclareMiningJob, SubmitSolutionJd},
-    parsers::{JobDeclaration, PoolMessages as JdsMessages},
+    parsers::{AnyMessage as JdsMessages, JobDeclaration},
     utils::{Id, Mutex},
 };
 use std::{collections::HashMap, convert::TryInto, sync::Arc};

--- a/roles/jd-server/src/lib/mod.rs
+++ b/roles/jd-server/src/lib/mod.rs
@@ -11,7 +11,7 @@ use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use mempool::error::JdsMempoolError;
 use roles_logic_sv2::{
     errors::Error,
-    parsers::PoolMessages as JdsMessages,
+    parsers::AnyMessage as JdsMessages,
     utils::{CoinbaseOutput as CoinbaseOutput_, Mutex},
 };
 use serde::Deserialize;

--- a/roles/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/mining-proxy/src/lib/downstream_mining.rs
@@ -15,7 +15,7 @@ use roles_logic_sv2::{
         mining::{ParseDownstreamMiningMessages, SendTo, SupportedChannelTypes},
     },
     mining_sv2::*,
-    parsers::{Mining, MiningDeviceMessages, PoolMessages},
+    parsers::{AnyMessage, Mining, MiningDeviceMessages},
     routing_logic::MiningProxyRoutingLogic,
     utils::Mutex,
 };
@@ -204,14 +204,14 @@ impl DownstreamMiningNode {
 
         match next_message_to_send {
             Ok(SendTo::RelaySameMessageToRemote(upstream_mutex)) => {
-                let sv2_frame: codec_sv2::Sv2Frame<PoolMessages, buffer_sv2::Slice> =
+                let sv2_frame: codec_sv2::Sv2Frame<AnyMessage, buffer_sv2::Slice> =
                     incoming.map(|payload| payload.try_into().unwrap());
                 UpstreamMiningNode::send(upstream_mutex.clone(), sv2_frame)
                     .await
                     .unwrap();
             }
             Ok(SendTo::RelayNewMessageToRemote(upstream_mutex, message)) => {
-                let message = PoolMessages::Mining(message);
+                let message = AnyMessage::Mining(message);
                 let frame: UpstreamFrame = message.try_into().unwrap();
                 UpstreamMiningNode::send(upstream_mutex.clone(), frame)
                     .await

--- a/roles/mining-proxy/src/lib/error.rs
+++ b/roles/mining-proxy/src/lib/error.rs
@@ -1,9 +1,9 @@
 use async_channel::SendError;
 use codec_sv2::StandardEitherFrame;
-use roles_logic_sv2::parsers::PoolMessages;
+use roles_logic_sv2::parsers::AnyMessage;
 use std::net::SocketAddr;
 
-pub type Message = PoolMessages<'static>;
+pub type Message = AnyMessage<'static>;
 pub type EitherFrame = StandardEitherFrame<Message>;
 
 #[derive(Debug)]

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -18,7 +18,7 @@ use roles_logic_sv2::{
     handlers::mining::{ParseDownstreamMiningMessages, SendTo},
     job_creator::JobsCreators,
     mining_sv2::{ExtendedExtranonce, SetNewPrevHash as SetNPH},
-    parsers::{Mining, PoolMessages},
+    parsers::{AnyMessage, Mining},
     routing_logic::MiningRoutingLogic,
     template_distribution_sv2::{NewTemplate, SetNewPrevHash, SubmitSolution},
     utils::{CoinbaseOutput as CoinbaseOutput_, Mutex},
@@ -36,7 +36,7 @@ use setup_connection::SetupConnectionHandler;
 
 pub mod message_handler;
 
-pub type Message = PoolMessages<'static>;
+pub type Message = AnyMessage<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;
 
@@ -231,7 +231,7 @@ impl Downstream {
         //} else {
         //    message
         //};
-        let sv2_frame: StdFrame = PoolMessages::Mining(message).try_into()?;
+        let sv2_frame: StdFrame = AnyMessage::Mining(message).try_into()?;
         let sender = self_mutex.safe_lock(|self_| self_.sender.clone())?;
         sender.send(sv2_frame.into()).await?;
         Ok(())

--- a/roles/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/pool/src/lib/mining_pool/setup_connection.rs
@@ -11,7 +11,7 @@ use roles_logic_sv2::{
     common_properties::CommonDownstreamData,
     errors::Error,
     handlers::common::ParseDownstreamCommonMessages,
-    parsers::{CommonMessages, PoolMessages},
+    parsers::{AnyMessage, CommonMessages},
     routing_logic::{CommonRoutingLogic, NoRouting},
     utils::Mutex,
 };
@@ -74,7 +74,7 @@ impl SetupConnectionHandler {
             roles_logic_sv2::Error::NoDownstreamsConnected,
         ))?;
 
-        let sv2_frame: StdFrame = PoolMessages::Common(message.clone()).try_into()?;
+        let sv2_frame: StdFrame = AnyMessage::Common(message.clone()).try_into()?;
         let sv2_frame = sv2_frame.into();
         sender.send(sv2_frame).await?;
         self_.safe_lock(|s| s.header_only)?;

--- a/roles/pool/src/lib/template_receiver/mod.rs
+++ b/roles/pool/src/lib/template_receiver/mod.rs
@@ -10,7 +10,7 @@ use key_utils::Secp256k1PublicKey;
 use network_helpers_sv2::noise_connection::Connection;
 use roles_logic_sv2::{
     handlers::template_distribution::ParseServerTemplateDistributionMessages,
-    parsers::{PoolMessages, TemplateDistribution},
+    parsers::{AnyMessage, TemplateDistribution},
     template_distribution_sv2::{
         CoinbaseOutputDataSize, NewTemplate, SetNewPrevHash, SubmitSolution,
     },
@@ -82,9 +82,9 @@ impl TemplateRx {
         let c_additional_size = CoinbaseOutputDataSize {
             coinbase_output_max_additional_size: coinbase_out_len,
         };
-        let frame = PoolMessages::TemplateDistribution(
-            TemplateDistribution::CoinbaseOutputDataSize(c_additional_size),
-        )
+        let frame = AnyMessage::TemplateDistribution(TemplateDistribution::CoinbaseOutputDataSize(
+            c_additional_size,
+        ))
         .try_into()?;
 
         Self::send(self_.clone(), frame).await?;
@@ -170,7 +170,7 @@ impl TemplateRx {
         while let Ok(solution) = rx.recv().await {
             info!("Sending Solution to TP: {:?}", &solution);
             let sv2_frame_res: Result<StdFrame, _> =
-                PoolMessages::TemplateDistribution(TemplateDistribution::SubmitSolution(solution))
+                AnyMessage::TemplateDistribution(TemplateDistribution::SubmitSolution(solution))
                     .try_into();
             match sv2_frame_res {
                 Ok(frame) => {

--- a/roles/pool/src/lib/template_receiver/setup_connection.rs
+++ b/roles/pool/src/lib/template_receiver/setup_connection.rs
@@ -7,7 +7,7 @@ use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, SetupConnectionError},
     errors::Error,
     handlers::common::{ParseUpstreamCommonMessages, SendTo},
-    parsers::{CommonMessages, PoolMessages},
+    parsers::{AnyMessage, CommonMessages},
     routing_logic::{CommonRoutingLogic, NoRouting},
     utils::Mutex,
 };
@@ -44,7 +44,7 @@ impl SetupConnectionHandler {
     ) -> PoolResult<()> {
         let setup_connection = Self::get_setup_connection_message(address)?;
 
-        let sv2_frame: StdFrame = PoolMessages::Common(setup_connection.into()).try_into()?;
+        let sv2_frame: StdFrame = AnyMessage::Common(setup_connection.into()).try_into()?;
         let sv2_frame = sv2_frame.into();
         sender.send(sv2_frame).await?;
 

--- a/roles/tests-integration/lib/sniffer.rs
+++ b/roles/tests-integration/lib/sniffer.rs
@@ -13,7 +13,6 @@ use roles_logic_sv2::{
             IdentifyTransactionsSuccess, ProvideMissingTransactions,
             ProvideMissingTransactionsSuccess, SubmitSolution,
         },
-        PoolMessages,
         TemplateDistribution::{self, CoinbaseOutputDataSize},
     },
     utils::Mutex,
@@ -67,7 +66,7 @@ pub struct Sniffer {
 pub struct InterceptMessage {
     direction: MessageDirection,
     expected_message_type: MsgType,
-    replacement_message: PoolMessages<'static>,
+    replacement_message: AnyMessage<'static>,
 }
 
 impl InterceptMessage {
@@ -79,7 +78,7 @@ impl InterceptMessage {
     pub fn new(
         direction: MessageDirection,
         expected_message_type: MsgType,
-        replacement_message: PoolMessages<'static>,
+        replacement_message: AnyMessage<'static>,
     ) -> Self {
         Self {
             direction,
@@ -510,9 +509,9 @@ impl Sniffer {
 //  $expected_property, $expected_property_value, ...);`.
 //  Note that you can provide any number of properties and values.
 //
-//  In both cases, the `$message_group` could be any variant of `PoolMessages::$message_group` and
+//  In both cases, the `$message_group` could be any variant of `AnyMessage::$message_group` and
 //  the `$nested_message_group` could be any variant of
-//  `PoolMessages::$message_group($nested_message_group)`.
+//  `AnyMessage::$message_group($nested_message_group)`.
 //
 //  If you dont want to provide the `$message_group` and `$nested_message_group` arguments, you can
 //  utilize `assert_common_message!`, `assert_tp_message!`, `assert_mining_message!`, and
@@ -525,7 +524,7 @@ macro_rules! assert_message {
    $($expected_property:ident, $expected_property_value:expr),*) => { match $msg {
 	  Some((_, message)) => {
 		match message {
-		  PoolMessages::$message_group($nested_message_group::$expected_message_variant(
+		  AnyMessage::$message_group($nested_message_group::$expected_message_variant(
 			  $expected_message_variant {
 				$($expected_property,)*
 				  ..
@@ -550,7 +549,7 @@ macro_rules! assert_message {
 	match $msg {
 	  Some((_, message)) => {
 		match message {
-		  PoolMessages::$message_group($nested_message_group::$expected_message_variant(_)) => {}
+		  AnyMessage::$message_group($nested_message_group::$expected_message_variant(_)) => {}
 		  _ => {
 			panic!(
 			  "Sent wrong message: {:?}",

--- a/roles/tests-integration/tests/jd_integration.rs
+++ b/roles/tests-integration/tests/jd_integration.rs
@@ -6,7 +6,7 @@
 // all tests. This is because tracing is a global setting.
 use const_sv2::{MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS};
 use integration_tests_sv2::*;
-use roles_logic_sv2::parsers::{CommonMessages, PoolMessages};
+use roles_logic_sv2::parsers::{AnyMessage, CommonMessages};
 use sniffer::MessageDirection;
 
 // This test verifies that jd-server does not exit when a connected jd-client shuts down.

--- a/roles/tests-integration/tests/pool_integration.rs
+++ b/roles/tests-integration/tests/pool_integration.rs
@@ -12,7 +12,7 @@ use const_sv2::{
 use integration_tests_sv2::*;
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection},
-    parsers::{AnyMessage, CommonMessages, Mining, PoolMessages, TemplateDistribution},
+    parsers::{AnyMessage, CommonMessages, Mining, TemplateDistribution},
 };
 
 // This test starts a Template Provider and a Pool, and checks if they exchange the correct

--- a/roles/tests-integration/tests/sniffer_integration.rs
+++ b/roles/tests-integration/tests/sniffer_integration.rs
@@ -13,7 +13,7 @@ use const_sv2::{
 use integration_tests_sv2::*;
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, SetupConnectionError},
-    parsers::{CommonMessages, PoolMessages},
+    parsers::{AnyMessage, CommonMessages},
 };
 use sniffer::{InterceptMessage, MessageDirection};
 use std::convert::TryInto;
@@ -27,7 +27,7 @@ async fn test_sniffer_intercept_to_downstream() {
     start_tracing();
     let (_tp, tp_addr) = start_template_provider(None);
     let message_replacement =
-        PoolMessages::Common(CommonMessages::SetupConnectionError(SetupConnectionError {
+        AnyMessage::Common(CommonMessages::SetupConnectionError(SetupConnectionError {
             flags: 0,
             error_code: "unsupported-feature-flags"
                 .to_string()
@@ -74,8 +74,7 @@ async fn test_sniffer_intercept_to_upstream() {
         firmware: "abcX".to_string().into_bytes().try_into().unwrap(),
         device_id: "89567".to_string().into_bytes().try_into().unwrap(),
     };
-    let message_replacement =
-        PoolMessages::Common(CommonMessages::SetupConnection(setup_connection));
+    let message_replacement = AnyMessage::Common(CommonMessages::SetupConnection(setup_connection));
     let intercept = InterceptMessage::new(
         MessageDirection::ToUpstream,
         MESSAGE_TYPE_SETUP_CONNECTION,

--- a/roles/tests-integration/tests/translator_integration.rs
+++ b/roles/tests-integration/tests/translator_integration.rs
@@ -9,7 +9,7 @@ use const_sv2::{
     MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED, MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
 };
 use integration_tests_sv2::{sniffer::*, *};
-use roles_logic_sv2::parsers::{CommonMessages, Mining, PoolMessages};
+use roles_logic_sv2::parsers::{AnyMessage, CommonMessages, Mining};
 
 // This test runs an sv2 translator between an sv1 mining device and a pool. the connection between
 // the translator and the pool is intercepted by a sniffer. The test checks if the translator and

--- a/roles/translator/src/lib/upstream_sv2/mod.rs
+++ b/roles/translator/src/lib/upstream_sv2/mod.rs
@@ -1,5 +1,5 @@
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use roles_logic_sv2::parsers::PoolMessages;
+use roles_logic_sv2::parsers::AnyMessage;
 
 pub mod diff_management;
 pub mod upstream;
@@ -7,7 +7,7 @@ pub mod upstream_connection;
 pub use upstream::Upstream;
 pub use upstream_connection::UpstreamConnection;
 
-pub type Message = PoolMessages<'static>;
+pub type Message = AnyMessage<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;
 


### PR DESCRIPTION
This PR remove the wrong `PoolMessages` parser, in favor of a more appropriate `AnyMessage`, as agreed on [this discussion](https://github.com/stratum-mining/stratum/discussions/1256#discussioncomment-11329317).

It needs a MAJOR bump on `roles_logic_sv2` because of the public `PoolMessages` struct which is removed in favor of the `AnyMessage` one.

Closes #1444 