### PR TITLE
add `RUST_BACKTRACE=1` on Integration Tests CI

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Roles Integration Tests
         run: |
-         RUST_LOG=debug cargo test --manifest-path=roles/Cargo.toml --verbose --test '*' -- --nocapture
+         RUST_BACKTRACE=1 RUST_LOG=debug cargo test --manifest-path=roles/Cargo.toml --verbose --test '*' -- --nocapture


### PR DESCRIPTION
this will allow us to better debug stack traces on panics