### PR TITLE
Drop `AbortHandle` from `Connection::new`

### DIFF
--- a/examples/ping-pong-encrypted/src/client.rs
+++ b/examples/ping-pong-encrypted/src/client.rs
@@ -18,7 +18,7 @@ pub async fn start_client(address: &str, k_pub: String) -> Result<(), Error> {
     let initiator = Initiator::from_raw_k(k_pub.into_bytes())?;
 
     // channels for encrypted connection
-    let (receiver, sender, _, _) =
+    let (receiver, sender) =
         Connection::new(stream, HandshakeRole::Initiator(initiator)).await?;
 
     // create Ping message

--- a/examples/ping-pong-encrypted/src/server.rs
+++ b/examples/ping-pong-encrypted/src/server.rs
@@ -36,7 +36,7 @@ pub async fn start_server(
             )?;
 
             // channels for encrypted connection
-            let (receiver, sender, _, _) =
+            let (receiver, sender) =
                 Connection::new(stream, HandshakeRole::Responder(responder)).await?;
 
             // handle encrypted connection

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -744,7 +744,7 @@ pub async fn listen_for_downstream_mining(
                     std::time::Duration::from_secs(cert_validity_sec),
                 )
                 .unwrap();
-                let (receiver, sender, recv_task_abort_handler, send_task_abort_handler) =
+                let (receiver, sender) =
                     Connection::new(stream, HandshakeRole::Responder(responder))
                         .await
                         .expect("impossible to connect");
@@ -794,8 +794,6 @@ pub async fn listen_for_downstream_mining(
                         n.task_collector
                             .safe_lock(|c| {
                                 c.push(main_task.abort_handle());
-                                c.push(recv_task_abort_handler);
-                                c.push(send_task_abort_handler);
                             })
                             .unwrap()
                     })

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -82,7 +82,7 @@ impl JobDeclarator {
     ) -> Result<Arc<Mutex<Self>>, Error<'static>> {
         let stream = tokio::net::TcpStream::connect(address).await?;
         let initiator = Initiator::from_raw_k(authority_public_key)?;
-        let (mut receiver, mut sender, _, _) =
+        let (mut receiver, mut sender) =
             Connection::new(stream, HandshakeRole::Initiator(initiator))
                 .await
                 .expect("impossible to connect");

--- a/roles/jd-client/src/lib/template_receiver/mod.rs
+++ b/roles/jd-client/src/lib/template_receiver/mod.rs
@@ -76,7 +76,7 @@ impl TemplateRx {
             None => Initiator::without_pk(),
         }
         .unwrap();
-        let (mut receiver, mut sender, _, _) =
+        let (mut receiver, mut sender) =
             Connection::new(stream, HandshakeRole::Initiator(initiator))
                 .await
                 .unwrap();

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -178,7 +178,7 @@ impl Upstream {
         );
 
         // Channel to send and receive messages to the SV2 Upstream role
-        let (receiver, sender, _, _) = Connection::new(socket, HandshakeRole::Initiator(initiator))
+        let (receiver, sender) = Connection::new(socket, HandshakeRole::Initiator(initiator))
             .await
             .expect("Failed to create connection");
 

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -474,7 +474,7 @@ impl JobDeclarator {
 
             let addr = stream.peer_addr();
 
-            if let Ok((receiver, sender, _, _)) =
+            if let Ok((receiver, sender)) =
                 Connection::new(stream, HandshakeRole::Responder(responder)).await
             {
                 match receiver.recv().await {

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -370,7 +370,7 @@ impl UpstreamMiningNode {
                 );
 
                 let initiator = Initiator::from_raw_k(authority_public_key).unwrap();
-                let (receiver, sender, _, _) =
+                let (receiver, sender) =
                     Connection::new(socket, HandshakeRole::Initiator(initiator))
                         .await
                         .expect("impossible to conenct");

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -293,7 +293,7 @@ impl Pool {
 
                                 match responder {
                                     Ok(resp) => {
-                                        if let Ok((receiver, sender, _, _)) = Connection::new(stream, HandshakeRole::Responder(resp)).await {
+                                        if let Ok((receiver, sender)) = Connection::new(stream, HandshakeRole::Responder(resp)).await {
                                             handle_result!(
                                                 status_tx,
                                                 Self::accept_incoming_connection_(

--- a/roles/pool/src/lib/template_receiver/mod.rs
+++ b/roles/pool/src/lib/template_receiver/mod.rs
@@ -63,7 +63,7 @@ impl TemplateRx {
             }
             None => Initiator::without_pk(),
         }?;
-        let (mut receiver, mut sender, _, _) =
+        let (mut receiver, mut sender) =
             Connection::new(stream, HandshakeRole::Initiator(initiator))
                 .await
                 .unwrap();

--- a/roles/test-utils/mining-device/src/lib/mod.rs
+++ b/roles/test-utils/mining-device/src/lib/mod.rs
@@ -71,7 +71,7 @@ pub async fn connect(
     info!("Pool tcp connection established at {}", address);
     let address = socket.peer_addr().unwrap();
     let initiator = Initiator::new(pub_key.map(|e| e.0));
-    let (receiver, sender, _, _): (Receiver<EitherFrame>, Sender<EitherFrame>, _, _) =
+    let (receiver, sender) =
         Connection::new(socket, codec_sv2::HandshakeRole::Initiator(initiator))
             .await
             .unwrap();

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -156,7 +156,7 @@ impl Upstream {
         );
 
         // Channel to send and receive messages to the SV2 Upstream role
-        let (receiver, sender, _, _) = Connection::new(socket, HandshakeRole::Initiator(initiator))
+        let (receiver, sender) = Connection::new(socket, HandshakeRole::Initiator(initiator))
             .await
             .unwrap();
         // Initialize `UpstreamConnection` with channel for SV2 Upstream role communication and

--- a/test/integration-tests/lib/sniffer.rs
+++ b/test/integration-tests/lib/sniffer.rs
@@ -250,7 +250,7 @@ impl Sniffer {
         let responder =
             Responder::from_authority_kp(&pub_key, &prv_key, std::time::Duration::from_secs(10000))
                 .unwrap();
-        if let Ok((receiver_from_client, sender_to_client, _, _)) =
+        if let Ok((receiver_from_client, sender_to_client)) =
             Connection::new::<'static, AnyMessage<'static>>(
                 stream,
                 HandshakeRole::Responder(responder),
@@ -267,7 +267,7 @@ impl Sniffer {
         stream: TcpStream,
     ) -> Option<(Receiver<MessageFrame>, Sender<MessageFrame>)> {
         let initiator = Initiator::without_pk().expect("This fn call can not fail");
-        if let Ok((receiver_from_server, sender_to_server, _, _)) =
+        if let Ok((receiver_from_server, sender_to_server)) =
             Connection::new::<'static, AnyMessage<'static>>(
                 stream,
                 HandshakeRole::Initiator(initiator),


### PR DESCRIPTION
As those handles are mostly not used and they might cause ghost processes because tokio would not drop unneeded tasks if the handle is still in scope/explicitly returned.

resolves #1594 