### PR TITLE
reintroduce versioning for internal crate dependencies

### DIFF
--- a/protocols/v1/Cargo.toml
+++ b/protocols/v1/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4.3"
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 tracing = {version = "0.1"}
-binary_sv2 = { path = "../v2/binary-sv2" }
+binary_sv2 = { path = "../v2/binary-sv2", version = "^2.0.0" }
 
 [dev-dependencies]
 quickcheck = "1"

--- a/protocols/v2/binary-sv2/Cargo.toml
+++ b/protocols/v2/binary-sv2/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-binary_codec_sv2 = { path = "codec" }
-derive_codec_sv2 = { path = "derive_codec" }
+binary_codec_sv2 = { path = "codec", version = "^1.0.0" }
+derive_codec_sv2 = { path = "derive_codec", version = "^1.0.0" }
 
 [features]
 prop_test = ["binary_codec_sv2/prop_test"]

--- a/protocols/v2/binary-sv2/codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/codec/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 quickcheck = { version = "1.0.0", optional = true }
-buffer_sv2 = { path = "../../../../utils/buffer", optional=true }
+buffer_sv2 = { path = "../../../../utils/buffer", optional=true, version = "^2.0.0" }
 
 [features]
 no_std = []

--- a/protocols/v2/binary-sv2/derive_codec/Cargo.toml
+++ b/protocols/v2/binary-sv2/derive_codec/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-binary_codec_sv2 = { path="../codec"}
+binary_codec_sv2 = { path="../codec", version = "^1.0.0" }
 
 [lib]
 proc-macro = true

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -12,16 +12,16 @@ homepage = "https://stratumprotocol.org"
 keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
-framing_sv2 = { path = "../../../protocols/v2/framing-sv2" }
-noise_sv2 = { path = "../../../protocols/v2/noise-sv2", default-features = false, optional = true }
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2" }
-const_sv2 = { path = "../../../protocols/v2/const-sv2"}
-buffer_sv2 = { path = "../../../utils/buffer"}
+framing_sv2 = { path = "../../../protocols/v2/framing-sv2", version = "^4.0.0" }
+noise_sv2 = { path = "../../../protocols/v2/noise-sv2", default-features = false, optional = true, version = "^1.0.0" }
+binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^2.0.0" }
+const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^4.0.0" }
+buffer_sv2 = { path = "../../../utils/buffer", version = "^2.0.0" }
 rand = { version = "0.8.5", default-features = false }
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
-key-utils = { path = "../../../utils/key-utils" }
+key-utils = { path = "../../../utils/key-utils", version = "^1.0.0" }
 
 [features]
 default = ["std"]

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -14,12 +14,12 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-const_sv2 = { path = "../../../protocols/v2/const-sv2" }
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2" }
-buffer_sv2 = { path = "../../../utils/buffer", optional=true }
+const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^4.0.0" }
+binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^2.0.0" }
+buffer_sv2 = { path = "../../../utils/buffer", optional=true, version = "^2.0.0" }
 
 [dev-dependencies]
-noise_sv2 = { path = "../../../protocols/v2/noise-sv2" }
+noise_sv2 = { path = "../../../protocols/v2/noise-sv2", version = "^1.0.0" }
 rand = "0.8.3"
 secp256k1 = { version = "0.28.2", default-features = false, features =["alloc","rand","rand-std"] }
 

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -17,7 +17,7 @@ rand = {version = "0.8.5", default-features = false }
 aes-gcm = { version = "0.10.2", features = ["alloc", "aes"], default-features = false }
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["alloc"]}
 rand_chacha = { version = "0.3.1", default-features = false }
-const_sv2 = { path = "../../../protocols/v2/const-sv2"}
+const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^4.0.0"}
 
 [features]
 default = ["std"]

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", features=["bitcoin"]}
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2" }
-common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages" }
-mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining" }
-template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution" }
-job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration" }
-const_sv2 = { path = "../../../protocols/v2/const-sv2"}
-framing_sv2 = { path = "../../../protocols/v2/framing-sv2" }
+stratum-common = { path = "../../../common", features=["bitcoin"], version = "^1.0.0"}
+binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^2.0.0" }
+common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^4.0.0" }
+mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^3.0.0" }
+template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^3.0.0" }
+job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^3.0.0" }
+const_sv2 = { path = "../../../protocols/v2/const-sv2", version = "^4.0.0" }
+framing_sv2 = { path = "../../../protocols/v2/framing-sv2", version = "^4.0.0" }
 tracing = { version = "0.1"}
 chacha20poly1305 = { version = "0.10.1"}
 nohash-hasher = "0.2.0"
@@ -29,7 +29,7 @@ primitive-types = "0.13.1"
 hex = {package = "hex-conservative", version = "*"}
 
 [dev-dependencies]
-codec_sv2 = { path = "../../../protocols/v2/codec-sv2" }
+codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0" }
 quickcheck = "1.0.3"
 quickcheck_macros = "1"
 rand = "0.8.5"

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-binary_sv2 = { path = "../../binary-sv2" }
-const_sv2 = { path = "../../const-sv2" }
+binary_sv2 = { path = "../../binary-sv2", version = "^2.0.0" }
+const_sv2 = { path = "../../const-sv2", version = "^4.0.0" }
 quickcheck = { version = "1.0.3", optional = true }
 quickcheck_macros = { version = "1", optional = true }
 

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 
 [dependencies]
-binary_sv2 = { path = "../../binary-sv2" }
-const_sv2 = { path = "../../const-sv2" }
+binary_sv2 = { path = "../../binary-sv2", version = "^2.0.0" }
+const_sv2 = { path = "../../const-sv2", version = "^4.0.0" }

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-binary_sv2 = { path = "../../binary-sv2" }
-const_sv2 = { path = "../../const-sv2"}
+binary_sv2 = { path = "../../binary-sv2", version = "^2.0.0" }
+const_sv2 = { path = "../../const-sv2", version = "^4.0.0" }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-binary_sv2 = { path = "../../binary-sv2" }
-const_sv2 = { path = "../../const-sv2"}
+binary_sv2 = { path = "../../binary-sv2", version = "^2.0.0" }
+const_sv2 = { path = "../../const-sv2", version = "^4.0.0" }
 quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
 

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 crate-type = ["staticlib"]
 
 [dependencies]
-codec_sv2 = { path = "../../../protocols/v2/codec-sv2" }
-const_sv2 = { path = "../../../protocols/v2/const-sv2" }
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2" }
-common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages" }
-template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution" }
+codec_sv2 = { path = "../codec-sv2", version = "^2.0.0" }
+const_sv2 = { path = "../const-sv2", version = "^4.0.0" }
+binary_sv2 = { path = "../binary-sv2", version = "^2.0.0" }
+common_messages_sv2 = { path = "../subprotocols/common-messages", version = "^4.0.0" }
+template_distribution_sv2 = { path = "../subprotocols/template-distribution", version = "^3.0.0" }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -17,10 +17,10 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 async-std = { version = "1.8.0", optional = true }
 async-channel = { version = "1.8.0", optional = true }
 tokio = { version = "1", features = ["full"] }
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2", optional = true }
-codec_sv2 = { path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"], optional = true }
-const_sv2 = {path = "../../../protocols/v2/const-sv2"}
-sv1_api = { path = "../../../protocols/v1/", optional = true }
+binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^2.0.0", optional = true }
+codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0", features=["noise_sv2"], optional = true }
+const_sv2 = {path = "../../../protocols/v2/const-sv2", version = "^4.0.0"}
+sv1_api = { path = "../../../protocols/v1/", version = "^1.0.0", optional = true }
 tracing = { version = "0.1" }
 futures = "0.3.28"
 tokio-util = { version = "0.7.10", default-features = false, features = ["codec"], optional = true }

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", features=["bitcoin"] }
+stratum-common = { path = "../../../common", features=["bitcoin"], version = "^1.0.0" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc","raw_value"] }
 hex = "0.4.3"

--- a/utils/bip32-key-derivation/Cargo.toml
+++ b/utils/bip32-key-derivation/Cargo.toml
@@ -20,7 +20,7 @@ name = "bip32_derivation-bin"
 path = "src/main.rs"
 
 [dependencies]
-stratum-common = { path = "../../common", features=["bitcoin"] }
+stratum-common = { path = "../../common", features=["bitcoin"], version = "^1.0.0" }
 
 [dev-dependencies]
 toml = { version = "0.5.6", git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }


### PR DESCRIPTION
what was proposed on #1189 broke the execution of `cargo publish`

 https://github.com/stratum-mining/stratum/actions/runs/14129275829/job/39585361550#step:8:12