### PR TITLE
bump `stratum-common` MAJOR version

### DIFF
--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "stratum-common"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bitcoin",
  "secp256k1 0.28.2",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratum-common"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2018"
 description = "SV2 pool role"
 license = "MIT OR Apache-2.0"

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", features=["bitcoin"], version = "^1.0.0"}
+stratum-common = { path = "../../../common", features=["bitcoin"], version = "^2.0.0"}
 binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^2.0.0" }
 common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^4.0.0" }
 mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^3.0.0" }

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
 dependencies = [
  "anstream",
  "anstyle",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
@@ -1818,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -2494,7 +2494,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-common"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bitcoin",
  "secp256k1 0.28.2",

--- a/roles/jd-server/Cargo.toml
+++ b/roles/jd-server/Cargo.toml
@@ -17,7 +17,7 @@ name = "jd_server"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-common = { version = "1.0.0", path = "../../common" }
+stratum-common = { version = "2.0.0", path = "../../common" }
 async-channel = "1.5.1"
 binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 buffer_sv2 = { path = "../../utils/buffer" }

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", features=["bitcoin"], version = "^1.0.0" }
+stratum-common = { path = "../../../common", features=["bitcoin"], version = "^2.0.0" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc","raw_value"] }
 hex = "0.4.3"

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -806,7 +806,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "stratum-common"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bitcoin",
  "secp256k1 0.28.2",

--- a/utils/bip32-key-derivation/Cargo.toml
+++ b/utils/bip32-key-derivation/Cargo.toml
@@ -20,7 +20,7 @@ name = "bip32_derivation-bin"
 path = "src/main.rs"
 
 [dependencies]
-stratum-common = { path = "../../common", features=["bitcoin"], version = "^1.0.0" }
+stratum-common = { path = "../../common", features=["bitcoin"], version = "^2.0.0" }
 
 [dev-dependencies]
 toml = { version = "0.5.6", git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }


### PR DESCRIPTION
we forgot to do this on #1487

now this is breaking `cargo publish` for `roles_logic_sv2`

https://github.com/stratum-mining/stratum/actions/runs/14135355408/job/39605674363#step:20:143

close #1345