### PR TITLE
fix `hex-conservative` version

### DIFF
--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -26,7 +26,7 @@ chacha20poly1305 = { version = "0.10.1"}
 nohash-hasher = "0.2.0"
 siphasher = "1"
 primitive-types = "0.13.1"
-hex = {package = "hex-conservative", version = "*"}
+hex = {package = "hex-conservative", version = "0.3.0"}
 
 [dev-dependencies]
 codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0" }


### PR DESCRIPTION
it's breaking `cargo publish` for `roles_logic_sv2`

https://github.com/stratum-mining/stratum/actions/runs/14136419713/job/39609107649#step:20:142