### PR TITLE
TP only to generates one block for integration tests

### DIFF
--- a/test/integration-tests/lib/mod.rs
+++ b/test/integration-tests/lib/mod.rs
@@ -102,7 +102,7 @@ pub fn start_template_provider(sv2_interval: Option<u32>) -> (TemplateProvider, 
     let address = get_available_address();
     let sv2_interval = sv2_interval.unwrap_or(20);
     let template_provider = TemplateProvider::start(address.port(), sv2_interval);
-    template_provider.generate_blocks(16);
+    template_provider.generate_blocks(1);
     (template_provider, address)
 }
 


### PR DESCRIPTION
the old limitation of minimum 16 blocks was removed via https://github.com/stratum-mining/stratum/pull/1461