### PR TITLE
Reintroduce TProxy-JD integration test

### DIFF
--- a/roles/test-utils/mining-device-sv1/src/client.rs
+++ b/roles/test-utils/mining-device-sv1/src/client.rs
@@ -208,6 +208,8 @@ impl Client {
                     warn!("Share channel is not available");
                     break;
                 }
+                // Introduce a delay of 0.2 seconds after sending a share
+                std::thread::sleep(Duration::from_millis(200));
             }
             miner_cloned
                 .safe_lock(|m| m.header.as_mut().map(|h| h.nonce += 1))

--- a/test/integration-tests/tests/jd_tproxy_integration.rs
+++ b/test/integration-tests/tests/jd_tproxy_integration.rs
@@ -1,0 +1,59 @@
+use const_sv2::{
+    MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB, MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+    MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL_SUCCES, MESSAGE_TYPE_SETUP_CONNECTION,
+    MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS, MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
+    MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
+};
+use integration_tests_sv2::{sniffer::*, *};
+
+#[tokio::test]
+async fn jd_tproxy_integration() {
+    start_tracing();
+    let (tp, tp_addr) = start_template_provider(None);
+    let (_pool, pool_addr) = start_pool(Some(tp_addr)).await;
+    let (jdc_pool_sniffer, jdc_pool_sniffer_addr) =
+        start_sniffer("0".to_string(), pool_addr, false, None);
+    let (_jds, jds_addr) = start_jds(tp.rpc_info());
+    let (_jdc, jdc_addr) = start_jdc(&[(jdc_pool_sniffer_addr, jds_addr)], tp_addr);
+    let (_translator, tproxy_addr) = start_sv2_translator(jdc_addr);
+    let _mining_device = start_mining_device_sv1(tproxy_addr, false, None);
+    jdc_pool_sniffer
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+    jdc_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+    jdc_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+        )
+        .await;
+    jdc_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL_SUCCES,
+        )
+        .await;
+    jdc_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
+        )
+        .await;
+    jdc_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
+        )
+        .await;
+    jdc_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
+        )
+        .await;
+}

--- a/test/integration-tests/tests/translator_integration.rs
+++ b/test/integration-tests/tests/translator_integration.rs
@@ -1,8 +1,5 @@
 // This file contains integration tests for the `TranslatorSv2` module.
-use const_sv2::{
-    MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
-    MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
-};
+use const_sv2::{MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED};
 use integration_tests_sv2::{sniffer::*, *};
 use roles_logic_sv2::parsers::{AnyMessage, CommonMessages, Mining};
 
@@ -46,59 +43,6 @@ async fn translate_sv1_to_sv2_successfully() {
         .wait_for_message_type(
             MessageDirection::ToUpstream,
             MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
-        )
-        .await;
-}
-
-// Test full flow with Translator and Job Declarator. An SV1 mining device is connected to
-// Translator and is successfully submitting a share to the pool.
-//
-// This ignore directive can be removed once this issue is resolved: https://github.com/stratum-mining/stratum/issues/1574.
-#[ignore]
-#[tokio::test]
-async fn translation_proxy_and_jd() {
-    start_tracing();
-    let (tp, tp_addr) = start_template_provider(None);
-    let (_pool, pool_addr) = start_pool(Some(tp_addr)).await;
-    let (jdc_pool_sniffer, jdc_pool_sniffer_addr) =
-        start_sniffer("0".to_string(), pool_addr, false, None);
-    let (_jds, jds_addr) = start_jds(tp.rpc_info());
-    let (_jdc, jdc_addr) = start_jdc(&[(jdc_pool_sniffer_addr, jds_addr)], tp_addr);
-    let (_translator, tproxy_addr) = start_sv2_translator(jdc_addr);
-    let _mining_device = start_mining_device_sv1(tproxy_addr, true, None);
-    jdc_pool_sniffer
-        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
-        .await;
-    assert_common_message!(
-        &jdc_pool_sniffer.next_message_from_downstream(),
-        SetupConnection
-    );
-    assert_common_message!(
-        &jdc_pool_sniffer.next_message_from_upstream(),
-        SetupConnectionSuccess
-    );
-    assert_mining_message!(
-        &jdc_pool_sniffer.next_message_from_downstream(),
-        OpenExtendedMiningChannel
-    );
-    assert_mining_message!(
-        &jdc_pool_sniffer.next_message_from_upstream(),
-        OpenExtendedMiningChannelSuccess
-    );
-    assert_mining_message!(
-        &jdc_pool_sniffer.next_message_from_upstream(),
-        NewExtendedMiningJob
-    );
-    jdc_pool_sniffer
-        .wait_for_message_type(
-            MessageDirection::ToUpstream,
-            MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
-        )
-        .await;
-    jdc_pool_sniffer
-        .wait_for_message_type(
-            MessageDirection::ToDownstream,
-            MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
         )
         .await;
 }


### PR DESCRIPTION
Partially addresses #1574 

This was tested on MacOS with M1 and Linux with AMD using the following script without encountering any failures.

```sh
#!/bin/bash

command_to_run="cargo test --test 'jd_tproxy_integration' -- --nocapture"

num_runs=20
success_count=0
fail_count=0

for i in $(seq 1 "$num_runs"); do
  echo "Running command $i of $num_runs..."
  if eval "$command_to_run"; then
    echo "Run $i: Success"
    ((success_count++))
  else
    echo "Run $i: Fail"
    ((fail_count++))
  fi
done

echo "-------------------------"
echo "Total Runs: $num_runs"
echo "Successful Runs: $success_count"
echo "Failed Runs: $fail_count"
echo "-------------------------"
```