### PR TITLE
Refactor `IsUpstream` and `IsMiningUpstream` traits to simplify generics used inside handlers

### DIFF
--- a/benches/benches/src/sv2/lib/client.rs
+++ b/benches/benches/src/sv2/lib/client.rs
@@ -142,7 +142,7 @@ impl Device {
     }
 }
 
-impl IsUpstream<(), NullDownstreamMiningSelector> for Device {
+impl IsUpstream for Device {
     fn get_version(&self) -> u16 {
         todo!()
     }
@@ -168,7 +168,7 @@ impl IsUpstream<(), NullDownstreamMiningSelector> for Device {
     }
 }
 
-impl IsMiningUpstream<(), NullDownstreamMiningSelector> for Device {
+impl IsMiningUpstream for Device {
     fn total_hash_rate(&self) -> u64 {
         todo!()
     }

--- a/protocols/v2/roles-logic-sv2/src/common_properties.rs
+++ b/protocols/v2/roles-logic-sv2/src/common_properties.rs
@@ -8,7 +8,7 @@
 use common_messages_sv2::{has_requires_std_job, Protocol, SetupConnection};
 use mining_sv2::{Extranonce, Target};
 use nohash_hasher::BuildNoHashHasher;
-use std::{collections::HashMap, fmt::Debug as D};
+use std::collections::HashMap;
 
 /// Defines a mining downstream node at the most basic level.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
@@ -69,7 +69,7 @@ pub struct PairSettings {
 }
 
 /// Properties defining behaviors common to all Sv2 upstream nodes.
-pub trait IsUpstream<Down: IsDownstream> {
+pub trait IsUpstream {
     /// Returns the protocol version used by the upstream node.
     fn get_version(&self) -> u16;
 
@@ -161,7 +161,7 @@ pub struct StandardChannel {
 ///
 /// This trait extends [`IsUpstream`] with additional functionality specific to mining, such as
 /// hashrate management and channel updates.
-pub trait IsMiningUpstream<Down: IsMiningDownstream>: IsUpstream<Down> {
+pub trait IsMiningUpstream: IsUpstream {
     /// Returns the total hashrate managed by the upstream node.
     fn total_hash_rate(&self) -> u64;
 
@@ -199,7 +199,7 @@ pub trait IsMiningDownstream: IsDownstream {
 }
 
 // Implemented for the `NullDownstreamMiningSelector`.
-impl<Down: IsDownstream + D> IsUpstream<Down> for () {
+impl IsUpstream for () {
     fn get_version(&self) -> u16 {
         unreachable!("Null upstream do not have a version");
     }
@@ -227,7 +227,7 @@ impl IsDownstream for () {
     }
 }
 
-impl<Down: IsMiningDownstream + D> IsMiningUpstream<Down> for () {
+impl IsMiningUpstream for () {
     fn total_hash_rate(&self) -> u64 {
         unreachable!("Null selector do not have hash rate");
     }

--- a/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
@@ -63,9 +63,9 @@ pub enum SupportedChannelTypes {
 ///
 /// This trait defines methods for parsing and routing downstream messages
 /// related to mining operations.
-pub trait ParseMiningMessagesFromDownstream<Up: IsMiningUpstream<Self> + D>
+pub trait ParseMiningMessagesFromDownstream<Up: IsMiningUpstream + D>
 where
-    Self: IsMiningDownstream + Sized + D,
+    Self: Sized + D,
 {
     /// Returns the type of channel supported by the downstream connection.
     fn get_channel_type(&self) -> SupportedChannelTypes;
@@ -238,7 +238,7 @@ where
 /// from the upstream based on the message type and payload.
 pub trait ParseMiningMessagesFromUpstream<Down: IsMiningDownstream + D>
 where
-    Self: IsMiningUpstream<Down> + Sized + D,
+    Self: Sized + D,
 {
     /// Retrieves the type of the channel supported by this upstream parser.
     fn get_channel_type(&self) -> SupportedChannelTypes;

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -444,7 +444,7 @@ impl Upstream {
     }
 }
 
-impl IsUpstream<Downstream> for Upstream {
+impl IsUpstream for Upstream {
     fn get_version(&self) -> u16 {
         todo!()
     }
@@ -466,7 +466,7 @@ impl IsUpstream<Downstream> for Upstream {
     }
 }
 
-impl IsMiningUpstream<Downstream> for Upstream {
+impl IsMiningUpstream for Upstream {
     fn total_hash_rate(&self) -> u64 {
         todo!()
     }

--- a/roles/mining-proxy/src/lib/selectors.rs
+++ b/roles/mining-proxy/src/lib/selectors.rs
@@ -250,7 +250,7 @@ pub trait UpstreamSelector {}
 /// upstream connection setup, failover, and routing logic.
 pub trait UpstreamMiningSelctor<
     Down: IsMiningDownstream,
-    Up: IsMiningUpstream<Down>,
+    Up: IsMiningUpstream,
     Sel: DownstreamMiningSelector<Down>,
 >: UpstreamSelector
 {
@@ -274,7 +274,7 @@ pub trait UpstreamMiningSelctor<
 pub struct GeneralMiningSelector<
     Sel: DownstreamMiningSelector<Down>,
     Down: IsMiningDownstream,
-    Up: IsMiningUpstream<Down>,
+    Up: IsMiningUpstream,
 > {
     /// List of upstream nodes.
     pub upstreams: Vec<Arc<Mutex<Up>>>,
@@ -287,7 +287,7 @@ pub struct GeneralMiningSelector<
     down: std::marker::PhantomData<Down>,
 }
 
-impl<Sel: DownstreamMiningSelector<Down>, Up: IsMiningUpstream<Down>, Down: IsMiningDownstream>
+impl<Sel: DownstreamMiningSelector<Down>, Up: IsMiningUpstream, Down: IsMiningDownstream>
     GeneralMiningSelector<Sel, Down, Up>
 {
     /// Creates a new [`GeneralMiningSelector`] instance with the given upstream nodes.
@@ -310,12 +310,12 @@ impl<Sel: DownstreamMiningSelector<Down>, Up: IsMiningUpstream<Down>, Down: IsMi
     }
 }
 
-impl<Sel: DownstreamMiningSelector<Down>, Down: IsMiningDownstream, Up: IsMiningUpstream<Down>>
+impl<Sel: DownstreamMiningSelector<Down>, Down: IsMiningDownstream, Up: IsMiningUpstream>
     UpstreamSelector for GeneralMiningSelector<Sel, Down, Up>
 {
 }
 
-impl<Sel: DownstreamMiningSelector<Down>, Down: IsMiningDownstream, Up: IsMiningUpstream<Down>>
+impl<Sel: DownstreamMiningSelector<Down>, Down: IsMiningDownstream, Up: IsMiningUpstream>
     UpstreamMiningSelctor<Down, Up, Sel> for GeneralMiningSelector<Sel, Down, Up>
 {
     fn on_setup_connection(

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -1246,7 +1246,7 @@ pub async fn scan(
     res.safe_lock(|r| r.clone()).unwrap()
 }
 
-impl IsUpstream<DownstreamMiningNode> for UpstreamMiningNode {
+impl IsUpstream for UpstreamMiningNode {
     fn get_version(&self) -> u16 {
         self.sv2_connection.unwrap().version
     }
@@ -1267,7 +1267,7 @@ impl IsUpstream<DownstreamMiningNode> for UpstreamMiningNode {
         Some(&mut self.request_id_mapper)
     }
 }
-impl IsMiningUpstream<DownstreamMiningNode> for UpstreamMiningNode {
+impl IsMiningUpstream for UpstreamMiningNode {
     fn total_hash_rate(&self) -> u64 {
         self.total_hash_rate
     }

--- a/roles/test-utils/mining-device/src/lib/mod.rs
+++ b/roles/test-utils/mining-device/src/lib/mod.rs
@@ -8,7 +8,6 @@ use primitive_types::U256;
 use rand::{thread_rng, Rng};
 use roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess},
-    common_properties::{IsMiningUpstream, IsUpstream},
     errors::Error,
     handlers::{
         common::ParseCommonMessagesFromUpstream,
@@ -345,47 +344,6 @@ impl Device {
         let frame: StdFrame = share.try_into().unwrap();
         let sender = self_mutex.safe_lock(|s| s.sender.clone()).unwrap();
         sender.send(frame.into()).await.unwrap();
-    }
-}
-
-impl IsUpstream<()> for Device {
-    fn get_version(&self) -> u16 {
-        todo!()
-    }
-
-    fn get_flags(&self) -> u32 {
-        todo!()
-    }
-
-    fn get_supported_protocols(&self) -> Vec<Protocol> {
-        todo!()
-    }
-
-    fn get_id(&self) -> u32 {
-        todo!()
-    }
-
-    fn get_mapper(&mut self) -> Option<&mut roles_logic_sv2::common_properties::RequestIdMapper> {
-        todo!()
-    }
-}
-
-impl IsMiningUpstream<()> for Device {
-    fn total_hash_rate(&self) -> u64 {
-        todo!()
-    }
-
-    fn add_hash_rate(&mut self, _to_add: u64) {
-        todo!()
-    }
-    fn get_opened_channels(
-        &mut self,
-    ) -> &mut Vec<roles_logic_sv2::common_properties::UpstreamChannel> {
-        todo!()
-    }
-
-    fn update_channels(&mut self, _: roles_logic_sv2::common_properties::UpstreamChannel) {
-        todo!()
     }
 }
 

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -568,7 +568,7 @@ impl Upstream {
     }
 }
 
-impl IsUpstream<Downstream> for Upstream {
+impl IsUpstream for Upstream {
     fn get_version(&self) -> u16 {
         todo!()
     }
@@ -590,7 +590,7 @@ impl IsUpstream<Downstream> for Upstream {
     }
 }
 
-impl IsMiningUpstream<Downstream> for Upstream {
+impl IsMiningUpstream for Upstream {
     fn total_hash_rate(&self) -> u64 {
         todo!()
     }


### PR DESCRIPTION
This PR refactors `IsUpstream` and `IsMiningUpstream` traits inside `common_properties` to simplify generics used inside handlers, simplifying all roles as well.

While it touches `common_properties`, I still think something else is needed to fully tackle this module.
Specifically, the majority of code there is about stuff which should be managed inside the channel_logic module (which is being refactored in https://github.com/stratum-mining/stratum/pull/1624) cc @plebhash 

I'm pretty sure that after the logic is moved there, we could also think about removing `common_properties` entirely.


Partially addresses #1466 