### PR TITLE
introduce simplified APIs for channel and job logic (server side)

### DIFF
--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -33,6 +33,7 @@ quickcheck_macros = "1"
 rand = "0.8.5"
 toml =  {git = "https://github.com/diondokter/toml-rs", default-features = false, rev="c4161aa"}
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false}
+tracing-subscriber = "0.3"
 
 [features]
 prop_test = ["template_distribution_sv2/prop_test"]

--- a/protocols/v2/roles-logic-sv2/src/channels/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/mod.rs
@@ -1,0 +1,2 @@
+// pub mod client;
+pub mod server;

--- a/protocols/v2/roles-logic-sv2/src/channels/server/error.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/error.rs
@@ -1,0 +1,27 @@
+use crate::channels::server::jobs::error::ExtendedJobFactoryError;
+
+#[derive(Debug)]
+pub enum ExtendedChannelError {
+    JobFactoryError(ExtendedJobFactoryError),
+    InvalidNominalHashrate,
+    RequestedMaxTargetOutOfRange,
+    ChainTipNotSet,
+    TemplateIdNotFound,
+    JobIdNotFound,
+    RequestedMinExtranonceSizeTooLarge,
+    NewExtranoncePrefixTooLarge,
+}
+
+#[derive(Debug)]
+pub enum GroupChannelError {
+    ChainTipNotSet,
+    TemplateIdNotFound,
+    JobFactoryError(ExtendedJobFactoryError),
+}
+
+#[derive(Debug)]
+pub enum StandardChannelError {
+    TemplateIdNotFound,
+    InvalidNominalHashrate,
+    RequestedMaxTargetOutOfRange,
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
@@ -1,0 +1,1417 @@
+//! Mining Server abstraction over the state of a Sv2 Extended Channel
+
+use crate::{
+    channels::server::{
+        error::ExtendedChannelError,
+        jobs::{
+            chain_tip::ChainTip, extended::ExtendedJob, factory::ExtendedJobFactory, JobOrigin,
+        },
+        share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
+    },
+    utils::{
+        bytes_to_hex, hash_rate_to_target, merkle_root_from_path, target_to_difficulty,
+        u256_to_block_hash,
+    },
+};
+use mining_sv2::{SetCustomMiningJob, SubmitSharesExtended, Target, MAX_EXTRANONCE_LEN};
+use std::{collections::HashMap, convert::TryInto};
+use stratum_common::bitcoin::{
+    blockdata::block::{Header, Version},
+    hashes::sha256d::Hash,
+    transaction::TxOut,
+    CompactTarget, Target as BitcoinTarget,
+};
+use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
+use tracing::debug;
+
+/// Mining Server abstraction of a Sv2 Extended Channel.
+///
+/// It keeps track of:
+/// - the channel's unique `channel_id`
+/// - the channel's `user_identity`
+/// - the channel's unique `extranonce_prefix`
+/// - the channel's rollable extranonce size
+/// - the channel's target
+/// - the channel's nominal hashrate
+/// - the channels' mapping between `template_id`s and `job_id`s
+/// - the channel's future jobs (indexed by `template_id`, to be activated upon receipt of a
+///   `SetNewPrevHash` message)
+/// - the channel's active job
+/// - the channel's past jobs (which were active jobs under the current chain tip, indexed by
+///   `job_id`)
+/// - the channel's stale jobs (which were past and active jobs under the previous chain tip,
+///   indexed by `job_id`)
+/// - the channel's share validation state
+/// - the channel's job factory
+#[derive(Clone, Debug)]
+pub struct ExtendedChannel<'a> {
+    channel_id: u32,
+    user_identity: String,
+    extranonce_prefix: Vec<u8>,
+    rollable_extranonce_size: u16,
+    target: Target, // todo: try to use Target from rust-bitcoin
+    nominal_hashrate: f32,
+    // maps template_id to job_id on future jobs
+    future_template_to_job_id: HashMap<u64, u32>,
+    // future jobs are indexed with job_id (u32)
+    future_jobs: HashMap<u32, ExtendedJob<'a>>,
+    active_job: Option<ExtendedJob<'a>>,
+    // past jobs are indexed with job_id (u32)
+    past_jobs: HashMap<u32, ExtendedJob<'a>>,
+    // stale jobs are indexed with job_id (u32)
+    stale_jobs: HashMap<u32, ExtendedJob<'a>>,
+    job_factory: ExtendedJobFactory,
+    share_accounting: ShareAccounting,
+    expected_share_per_minute: f32,
+}
+
+impl<'a> ExtendedChannel<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        channel_id: u32,
+        user_identity: String,
+        extranonce_prefix: Vec<u8>,
+        max_target: Target,
+        nominal_hashrate: f32,
+        version_rolling_allowed: bool,
+        requested_min_rollable_extranonce_size: u16,
+        share_batch_size: usize,
+        expected_share_per_minute: f32,
+    ) -> Result<Self, ExtendedChannelError> {
+        let target_u256 =
+            match hash_rate_to_target(nominal_hashrate.into(), expected_share_per_minute.into()) {
+                Ok(target_u256) => target_u256,
+                Err(_) => {
+                    return Err(ExtendedChannelError::InvalidNominalHashrate);
+                }
+            };
+
+        let target: Target = target_u256.clone().into();
+        let max_target_value: Target = max_target;
+
+        if target > max_target_value {
+            return Err(ExtendedChannelError::RequestedMaxTargetOutOfRange);
+        }
+
+        let available_rollable_extranonce_size =
+            (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        if requested_min_rollable_extranonce_size > available_rollable_extranonce_size {
+            return Err(ExtendedChannelError::RequestedMinExtranonceSizeTooLarge);
+        }
+
+        Ok(Self {
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            rollable_extranonce_size: available_rollable_extranonce_size,
+            target,
+            nominal_hashrate,
+            future_template_to_job_id: HashMap::new(),
+            future_jobs: HashMap::new(),
+            active_job: None,
+            past_jobs: HashMap::new(),
+            stale_jobs: HashMap::new(),
+            job_factory: ExtendedJobFactory::new(version_rolling_allowed),
+            share_accounting: ShareAccounting::new(share_batch_size),
+            expected_share_per_minute,
+        })
+    }
+
+    pub fn get_channel_id(&self) -> u32 {
+        self.channel_id
+    }
+
+    pub fn get_user_identity(&self) -> &String {
+        &self.user_identity
+    }
+
+    pub fn get_extranonce_prefix(&self) -> &Vec<u8> {
+        &self.extranonce_prefix
+    }
+
+    /// Sets the extranonce prefix.
+    ///
+    /// Note: after this, all new jobs will be associated with the new extranonce prefix.
+    /// Jobs created before this call will remain associated with the previous extranonce prefix,
+    /// and share validation will be done accordingly.
+    pub fn set_extranonce_prefix(
+        &mut self,
+        extranonce_prefix: Vec<u8>,
+    ) -> Result<(), ExtendedChannelError> {
+        let new_rollable_extranonce_size =
+            MAX_EXTRANONCE_LEN as u16 - extranonce_prefix.len() as u16;
+
+        // there's no message for informing the mining client about the new rollable_extranonce_size
+        // so we do not update the self.rollable_extranonce_size
+        // we only return an error if the new extranonce_prefix would violate
+        // rollable_extranonce_size that was already established with the client when the channel
+        // was created
+        if new_rollable_extranonce_size < self.rollable_extranonce_size {
+            return Err(ExtendedChannelError::NewExtranoncePrefixTooLarge);
+        }
+
+        self.extranonce_prefix = extranonce_prefix;
+
+        Ok(())
+    }
+
+    pub fn get_rollable_extranonce_size(&self) -> u16 {
+        self.rollable_extranonce_size
+    }
+
+    pub fn get_target(&self) -> &Target {
+        &self.target
+    }
+
+    pub fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32> {
+        &self.future_template_to_job_id
+    }
+
+    pub fn get_nominal_hashrate(&self) -> f32 {
+        self.nominal_hashrate
+    }
+
+    /// Updates the channel's nominal hashrate and target.
+    pub fn update_channel(
+        &mut self,
+        new_nominal_hashrate: f32,
+        max_target: Target,
+    ) -> Result<(), ExtendedChannelError> {
+        let target_u256 = match hash_rate_to_target(
+            new_nominal_hashrate.into(),
+            self.expected_share_per_minute.into(),
+        ) {
+            Ok(target_u256) => target_u256,
+            Err(_) => {
+                return Err(ExtendedChannelError::InvalidNominalHashrate);
+            }
+        };
+
+        // debug hex of target_u256 and max_Target
+        // just like in share validation
+        let mut target_bytes = target_u256.to_vec();
+        target_bytes.reverse(); // Convert to big-endian for display
+        let max_target_u256: binary_sv2::U256 = max_target.clone().into();
+        let mut max_target_bytes = max_target_u256.to_vec();
+        max_target_bytes.reverse(); // Convert to big-endian for display
+
+        // Get the old target for comparison on the debug log
+        // Not really needed for the actual method functionality
+        // But it's useful to have for debugging purposes
+        let old_target_u256: binary_sv2::U256 = self.target.clone().into();
+        let mut old_target_bytes = old_target_u256.to_vec();
+        old_target_bytes.reverse(); // Convert to big-endian for display
+
+        debug!(
+            "updating channel target \nold target:\t{}\nnew target:\t{}\nmax_target:\t{}",
+            bytes_to_hex(&old_target_bytes),
+            bytes_to_hex(&target_bytes),
+            bytes_to_hex(&max_target_bytes)
+        );
+
+        let new_target: Target = target_u256.into();
+
+        if new_target > max_target {
+            return Err(ExtendedChannelError::RequestedMaxTargetOutOfRange);
+        }
+
+        self.nominal_hashrate = new_nominal_hashrate;
+        self.target = new_target;
+
+        Ok(())
+    }
+
+    pub fn get_active_job(&self) -> Option<&ExtendedJob<'a>> {
+        self.active_job.as_ref()
+    }
+
+    pub fn get_future_jobs(&self) -> &HashMap<u32, ExtendedJob<'a>> {
+        &self.future_jobs
+    }
+
+    pub fn get_past_jobs(&self) -> &HashMap<u32, ExtendedJob<'a>> {
+        &self.past_jobs
+    }
+
+    pub fn get_share_accounting(&self) -> &ShareAccounting {
+        &self.share_accounting
+    }
+
+    /// Updates the channel state with a new template.
+    ///
+    /// If the template is a future template, the chain tip is not used.
+    /// If the template is not a future template, the chain tip must be set.
+    ///
+    /// Only meant for usage on a Sv2 Pool Server or a Sv2 Job Declaration Client,
+    /// but not on mining clients such as Mining Devices or Proxies.
+    pub fn on_new_template(
+        &mut self,
+        template: NewTemplate<'a>,
+        coinbase_reward_outputs: Vec<TxOut>,
+        chain_tip: Option<ChainTip>,
+    ) -> Result<(), ExtendedChannelError> {
+        match template.future_template {
+            true => {
+                let new_job = self
+                    .job_factory
+                    .new_job(
+                        self.channel_id,
+                        None,
+                        self.extranonce_prefix.clone(),
+                        template.clone(),
+                        coinbase_reward_outputs,
+                    )
+                    .map_err(ExtendedChannelError::JobFactoryError)?;
+                let new_job_id = new_job.get_job_id();
+                self.future_jobs.insert(new_job_id, new_job);
+                self.future_template_to_job_id
+                    .insert(template.template_id, new_job_id);
+            }
+            false => {
+                match chain_tip {
+                    // we can only create non-future jobs if we have a chain tip
+                    None => return Err(ExtendedChannelError::ChainTipNotSet),
+                    Some(chain_tip) => {
+                        let new_job = self
+                            .job_factory
+                            .new_job(
+                                self.channel_id,
+                                Some(chain_tip),
+                                self.extranonce_prefix.clone(),
+                                template.clone(),
+                                coinbase_reward_outputs,
+                            )
+                            .map_err(ExtendedChannelError::JobFactoryError)?;
+                        // if there's already some active job, move it to the past jobs
+                        // and set the new job as the active job
+                        if let Some(active_job) = self.active_job.take() {
+                            self.past_jobs.insert(active_job.get_job_id(), active_job);
+                            self.active_job = Some(new_job);
+                        } else {
+                            // if there's no active job, simply set the new job as the active job
+                            self.active_job = Some(new_job);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Updates the channel state with a new `SetNewPrevHash` message (Template Distribution
+    /// Protocol variant).
+    ///
+    /// If there are no future jobs, returns an error.
+    /// If there is some future job matching the `template_id`` that `SetNewPrevHash` points to,
+    /// this future job is "activated" and set as the active job.
+    ///
+    /// All past jobs are cleared.
+    ///
+    /// The chain tip information is not kept in the channel state.
+    pub fn on_set_new_prev_hash(
+        &mut self,
+        set_new_prev_hash: SetNewPrevHashTdp<'a>,
+    ) -> Result<(), ExtendedChannelError> {
+        match self.future_jobs.is_empty() {
+            true => {
+                return Err(ExtendedChannelError::TemplateIdNotFound);
+            }
+            false => {
+                // the SetNewPrevHash message was addressed to a specific future template
+                let future_job_id = self
+                    .future_template_to_job_id
+                    .remove(&set_new_prev_hash.template_id)
+                    .ok_or(ExtendedChannelError::TemplateIdNotFound)?;
+
+                // move currently active job to past jobs (so it can be marked as stale)
+                let currently_active_job = self.active_job.take();
+                if let Some(active_job) = currently_active_job {
+                    self.past_jobs.insert(active_job.get_job_id(), active_job);
+                }
+
+                // activate the future job
+                let mut activated_job = self
+                    .future_jobs
+                    .remove(&future_job_id)
+                    .expect("future job must exist");
+
+                activated_job.activate(set_new_prev_hash.header_timestamp);
+
+                self.active_job = Some(activated_job);
+
+                self.future_jobs.clear();
+                self.future_template_to_job_id.clear();
+            }
+        }
+
+        // mark all past jobs as stale, so that shares can be rejected with the appropriate error
+        // code
+        self.stale_jobs = self.past_jobs.clone();
+
+        // clear past jobs, as we're no longer going to validate shares for them
+        self.past_jobs.clear();
+
+        // clear seen shares, as shares for past chain tip will be rejected as stale
+        self.share_accounting.flush_seen_shares();
+
+        Ok(())
+    }
+
+    /// Updates the channel state with a new custom mining job.
+    ///
+    /// If there is an active job, it is moved to the past jobs.
+    /// The new custom mining job is then set as the active job.
+    ///
+    /// Returns the job id of the new custom mining job.
+    ///
+    /// To be used by a Sv2 Pool Server upon receiving a `SetCustomMiningJob` message.
+    pub fn on_set_custom_mining_job(
+        &mut self,
+        set_custom_mining_job: SetCustomMiningJob<'a>,
+    ) -> Result<u32, ExtendedChannelError> {
+        let new_job = self
+            .job_factory
+            .new_custom_job(set_custom_mining_job, self.extranonce_prefix.clone())
+            .map_err(ExtendedChannelError::JobFactoryError)?;
+
+        let job_id = new_job.get_job_id();
+
+        if let Some(active_job) = self.active_job.take() {
+            self.past_jobs.insert(active_job.get_job_id(), active_job);
+        }
+
+        self.active_job = Some(new_job);
+
+        Ok(job_id)
+    }
+
+    /// Validates a share.
+    ///
+    /// Updates the channel state with the result of the share validation.
+    pub fn validate_share(
+        &mut self,
+        share: SubmitSharesExtended,
+        chain_tip: ChainTip,
+    ) -> Result<ShareValidationResult, ShareValidationError> {
+        let job_id = share.job_id;
+
+        // check if job_id is active job
+        let is_active_job = self
+            .active_job
+            .as_ref()
+            .is_some_and(|job| job.get_job_id() == job_id);
+
+        // check if job_id is past job
+        let is_past_job = self.past_jobs.contains_key(&job_id);
+
+        // check if job_id is stale job
+        let is_stale_job = self.stale_jobs.contains_key(&job_id);
+
+        if is_stale_job {
+            return Err(ShareValidationError::Stale);
+        }
+
+        // if job_id is not active, past or stale, return error
+        if !is_active_job && !is_past_job && !is_stale_job {
+            return Err(ShareValidationError::InvalidJobId);
+        }
+
+        let job = if is_active_job {
+            self.active_job.as_ref().expect("active job must exist")
+        } else if is_past_job {
+            self.past_jobs.get(&job_id).expect("past job must exist")
+        } else {
+            self.stale_jobs.get(&job_id).expect("stale job must exist")
+        };
+
+        let extranonce_prefix = job.get_extranonce_prefix();
+        let mut full_extranonce = vec![];
+        full_extranonce.extend(extranonce_prefix.clone());
+        full_extranonce.extend(share.extranonce.inner_as_ref());
+
+        // calculate the merkle root from:
+        // - job coinbase_tx_prefix
+        // - full extranonce
+        // - job coinbase_tx_suffix
+        // - job merkle_path
+        let merkle_root: [u8; 32] = merkle_root_from_path(
+            job.get_coinbase_tx_prefix().inner_as_ref(),
+            job.get_coinbase_tx_suffix().inner_as_ref(),
+            full_extranonce.as_ref(),
+            &job.get_merkle_path().inner_as_ref(),
+        )
+        .ok_or(ShareValidationError::Invalid)?
+        .try_into()
+        .expect("merkle root must be 32 bytes");
+
+        let prev_hash = chain_tip.prev_hash();
+        let nbits = CompactTarget::from_consensus(chain_tip.nbits());
+
+        // validate when version rolling is not allowed
+        if !job.version_rolling_allowed() {
+            // If version rolling is not allowed, ensure bits 13-28 are 0
+            // This is done by checking if the version & 0x1fffe000 == 0
+            // ref: https://github.com/bitcoin/bips/blob/master/bip-0320.mediawiki
+            if (share.version & 0x1fffe000) != 0 {
+                return Err(ShareValidationError::VersionRollingNotAllowed);
+            }
+        }
+
+        // create the header for validation
+        let header = Header {
+            version: Version::from_consensus(share.version as i32),
+            prev_blockhash: u256_to_block_hash(prev_hash.clone()),
+            merkle_root: (*Hash::from_bytes_ref(&merkle_root)).into(),
+            time: share.ntime,
+            bits: nbits,
+            nonce: share.nonce,
+        };
+
+        // convert the header hash to a target type for easy comparison
+        let hash = header.block_hash();
+        let raw_hash: [u8; 32] = *hash.to_raw_hash().as_ref();
+        let hash_as_target: Target = raw_hash.into();
+        let hash_as_diff = target_to_difficulty(hash_as_target.clone());
+
+        let network_target = BitcoinTarget::from_compact(nbits);
+
+        // print hash_as_target and self.target as human readable hex
+        let hash_as_u256: binary_sv2::U256 = hash_as_target.clone().into();
+        let mut hash_bytes = hash_as_u256.to_vec();
+        hash_bytes.reverse(); // Convert to big-endian for display
+        let target_u256: binary_sv2::U256 = self.target.clone().into();
+        let mut target_bytes = target_u256.to_vec();
+        target_bytes.reverse(); // Convert to big-endian for display
+
+        debug!(
+            "share validation \nshare:\t\t{}\nchannel target:\t{}\nnetwork target:\t{}",
+            bytes_to_hex(&hash_bytes),
+            bytes_to_hex(&target_bytes),
+            format!("{:x}", network_target)
+        );
+
+        // check if a block was found
+        if network_target.is_met_by(hash) {
+            self.share_accounting.update_share_accounting(
+                target_to_difficulty(self.target.clone()) as u64,
+                share.sequence_number,
+                hash.to_raw_hash(),
+            );
+
+            let mut coinbase = vec![];
+            coinbase.extend(job.get_coinbase_tx_prefix().inner_as_ref());
+            coinbase.extend(full_extranonce);
+            coinbase.extend(job.get_coinbase_tx_suffix().inner_as_ref());
+
+            match job.get_origin() {
+                JobOrigin::NewTemplate(template) => {
+                    let template_id = template.template_id;
+                    return Ok(ShareValidationResult::BlockFound(
+                        Some(template_id),
+                        coinbase,
+                    ));
+                }
+                JobOrigin::SetCustomMiningJob(_set_custom_mining_job) => {
+                    return Ok(ShareValidationResult::BlockFound(None, coinbase));
+                }
+            }
+        }
+
+        // check if the share hash meets the channel target
+        if hash_as_target <= self.target {
+            if self.share_accounting.is_share_seen(hash.to_raw_hash()) {
+                return Err(ShareValidationError::DuplicateShare);
+            }
+
+            self.share_accounting.update_share_accounting(
+                target_to_difficulty(self.target.clone()) as u64,
+                share.sequence_number,
+                hash.to_raw_hash(),
+            );
+
+            // update the best diff
+            self.share_accounting.update_best_diff(hash_as_diff);
+
+            let last_sequence_number = self.share_accounting.get_last_share_sequence_number();
+            let new_submits_accepted_count = self.share_accounting.get_shares_accepted();
+            let new_shares_sum = self.share_accounting.get_share_work_sum();
+
+            // if sequence number is a multiple of share_batch_size
+            // it's time to send a SubmitShares.Success
+            if self.share_accounting.should_acknowledge() {
+                Ok(ShareValidationResult::ValidWithAcknowledgement(
+                    last_sequence_number,
+                    new_submits_accepted_count,
+                    new_shares_sum,
+                ))
+            } else {
+                Ok(ShareValidationResult::Valid)
+            }
+        } else {
+            Err(ShareValidationError::DoesNotMeetTarget)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::channels::server::{
+        error::ExtendedChannelError,
+        extended::ExtendedChannel,
+        jobs::chain_tip::ChainTip,
+        share_accounting::{ShareValidationError, ShareValidationResult},
+    };
+    use binary_sv2::Sv2Option;
+    use mining_sv2::{NewExtendedMiningJob, SubmitSharesExtended, Target, MAX_EXTRANONCE_LEN};
+    use std::convert::TryInto;
+    use stratum_common::bitcoin::{transaction::TxOut, Amount, ScriptBuf};
+    use template_distribution_sv2::{NewTemplate, SetNewPrevHash};
+
+    const SATS_AVAILABLE_IN_TEMPLATE: u64 = 5000000000;
+
+    #[test]
+    fn test_future_job_activation_flow() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 1.0;
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        assert!(channel.get_future_jobs().is_empty());
+        channel
+            .on_new_template(template.clone(), coinbase_reward_outputs, None)
+            .unwrap();
+        assert!(channel.get_active_job().is_none());
+
+        let future_job_id = channel
+            .get_future_template_to_job_id()
+            .get(&template.template_id)
+            .unwrap();
+
+        let future_job = channel
+            .get_future_jobs()
+            .get(future_job_id)
+            .unwrap()
+            .clone();
+
+        // we know that the provided template + coinbase_reward_outputs should generate this future
+        // job
+        let expected_job = NewExtendedMiningJob {
+            channel_id: 1,
+            job_id: 1,
+            min_ntime: Sv2Option::new(None),
+            version: 536870912,
+            version_rolling_allowed: true,
+            coinbase_tx_prefix: vec![
+                2, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 34, 82, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_suffix: vec![
+                255, 255, 255, 255, 2, 0, 242, 5, 42, 1, 0, 0, 0, 22, 0, 20, 235, 225, 183, 220,
+                194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194, 8, 252, 0, 0, 0,
+                0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209, 222,
+                253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180, 139,
+                235, 216, 54, 151, 78, 140, 249, 1, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        assert_eq!(future_job.get_job_message(), &expected_job);
+
+        let ntime = 1746839905;
+        let set_new_prev_hash = SetNewPrevHash {
+            template_id: 1,
+            prev_hash: [
+                200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144,
+                205, 88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+            ]
+            .into(),
+            header_timestamp: ntime,
+            n_bits: 503543726,
+            target: [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                174, 119, 3, 0, 0,
+            ]
+            .into(),
+        };
+
+        channel.on_set_new_prev_hash(set_new_prev_hash).unwrap();
+
+        // we just activated the only future job
+        assert!(channel.get_future_jobs().is_empty());
+
+        let mut previously_future_job = future_job.clone();
+        previously_future_job.activate(ntime);
+
+        let activated_job = channel.get_active_job().unwrap();
+
+        // assert that the activated job is the same as the previously future job
+        assert_eq!(
+            activated_job.get_job_message(),
+            previously_future_job.get_job_message()
+        );
+    }
+
+    #[test]
+    fn test_non_future_job_creation_flow() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 1.0;
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        let ntime = 1746839905;
+        let prev_hash = [
+            200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144, 205,
+            88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+        ]
+        .into();
+        let n_bits = 503543726;
+
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // this is a non-future template, so we must provide a chain_tip
+        assert!(channel
+            .on_new_template(template.clone(), coinbase_reward_outputs.clone(), None)
+            .is_err());
+        channel
+            .on_new_template(template.clone(), coinbase_reward_outputs, Some(chain_tip))
+            .unwrap();
+
+        assert!(channel.get_future_jobs().is_empty());
+
+        let active_job = channel.get_active_job().unwrap().clone();
+
+        // we know that the provided template + coinbase_reward_outputs should generate this
+        // non-future job
+        let expected_job = NewExtendedMiningJob {
+            channel_id: 1,
+            job_id: 1,
+            min_ntime: Sv2Option::new(Some(ntime)),
+            version: 536870912,
+            version_rolling_allowed: true,
+            coinbase_tx_prefix: vec![
+                2, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 34, 82, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_suffix: vec![
+                255, 255, 255, 255, 2, 0, 242, 5, 42, 1, 0, 0, 0, 22, 0, 20, 235, 225, 183, 220,
+                194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194, 8, 252, 0, 0, 0,
+                0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209, 222,
+                253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180, 139,
+                235, 216, 54, 151, 78, 140, 249, 1, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        assert_eq!(active_job.get_job_message(), &expected_job);
+    }
+
+    #[test]
+    fn test_custom_job_creation_flow() {
+        // todo: assert that a SetCustomMiningJob leads to
+        // the correct NewExtendedMiningJob message
+        // we should wait until the following spec cleanup is finished
+        // https://github.com/stratum-mining/sv2-spec/issues/133
+    }
+
+    #[test]
+    fn test_coinbase_reward_outputs_sum_above_template_value() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 1.0;
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+
+        let invalid_coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE + 1), /* oops: one too many extra
+                                                                      * sats */
+            script_pubkey: script,
+        }];
+
+        let res = channel.on_new_template(template.clone(), invalid_coinbase_reward_outputs, None);
+
+        assert!(res.is_err());
+        assert!(channel.get_future_jobs().is_empty());
+    }
+
+    #[test]
+    fn test_share_validation_block_found() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation and share
+        // validation
+
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 1.0;
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // channel target: 04325c53ef368eb04325c53ef368eb04325c53ef368eb04325c53ef368eb0431
+
+        let template_id = 1;
+        let template = NewTemplate {
+            template_id,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // network target: 7fffff0000000000000000000000000000000000000000000000000000000000
+        let ntime = 1745596910;
+        let prev_hash = [
+            251, 175, 106, 40, 35, 87, 122, 90, 58, 51, 78, 32, 202, 236, 228, 36, 154, 174, 206,
+            144, 147, 195, 21, 224, 195, 103, 214, 189, 51, 190, 24, 98,
+        ]
+        .into();
+        let n_bits = 545259519;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        // prepare channel with non-future job
+        channel
+            .on_new_template(
+                template.clone(),
+                coinbase_reward_outputs,
+                Some(chain_tip.clone()),
+            )
+            .unwrap();
+
+        // this share has hash 00009a270ad03f1256312c7f196ab1a66bf8951f282fc75d9c81393cbb6427a8
+        // which satisfies network target
+        // 7fffff0000000000000000000000000000000000000000000000000000000000
+        let share_valid_block = SubmitSharesExtended {
+            channel_id,
+            sequence_number: 0,
+            job_id: 1,
+            nonce: 741057,
+            ntime: 1745596971,
+            version: 536870912,
+            extranonce: vec![1, 0, 0, 0, 0].try_into().unwrap(),
+        };
+
+        let res = channel.validate_share(share_valid_block, chain_tip);
+
+        assert!(matches!(res, Ok(ShareValidationResult::BlockFound(_, _))));
+    }
+
+    #[test]
+    fn test_share_validation_does_not_meet_target() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation and share
+        // validation
+
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 100.0; // bigger hashrate to get higher difficulty
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // channel target: 000aebbc990fff5144366f000aebbc990fff5144366f000aebbc990fff514435
+
+        let template_id = 1;
+        let template = NewTemplate {
+            template_id,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // network target: 000000000000d7c0000000000000000000000000000000000000000000000000
+        let ntime = 1745596910;
+        let prev_hash = [
+            154, 124, 239, 231, 221, 122, 160, 173, 164, 175, 87, 33, 74, 214, 191, 107, 73, 34, 0,
+            162, 227, 16, 44, 40, 33, 73, 0, 0, 0, 0, 0, 0,
+        ]
+        .into();
+        let n_bits = 453040064;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        // prepare channel with non-future job
+        channel
+            .on_new_template(
+                template.clone(),
+                coinbase_reward_outputs,
+                Some(chain_tip.clone()),
+            )
+            .unwrap();
+
+        // this share has hash 6f33ea329093baa13e37d11b3afa91960f8d84f0ec064c1376522548c0852d79
+        // which does not meet the channel target
+        // 000aebbc990fff5144366f000aebbc990fff5144366f000aebbc990fff514435
+        let share_low_diff = SubmitSharesExtended {
+            channel_id,
+            sequence_number: 0,
+            job_id: 1,
+            nonce: 741057,
+            ntime: 1745596971,
+            version: 536870912,
+            extranonce: vec![1, 0, 0, 0, 0].try_into().unwrap(),
+        };
+
+        let res = channel.validate_share(share_low_diff, chain_tip);
+
+        assert!(matches!(
+            res.unwrap_err(),
+            ShareValidationError::DoesNotMeetTarget
+        ));
+    }
+
+    #[test]
+    fn test_share_validation_valid_share() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation and share
+        // validation
+
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 1_000.0; // bigger hashrate to get higher difficulty
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // channel target is:
+        // 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205
+
+        let template_id = 1;
+        let template = NewTemplate {
+            template_id,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // network tarkget is: 000000000000d7c0000000000000000000000000000000000000000000000000
+        let n_bits = 453040064;
+        let ntime = 1745611105;
+        let prev_hash = [
+            23, 205, 72, 134, 153, 86, 220, 153, 224, 28, 216, 146, 228, 120, 227, 157, 213, 99,
+            160, 163, 128, 59, 139, 190, 158, 62, 0, 0, 0, 0, 0, 0,
+        ]
+        .into();
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        // prepare channel with non-future job
+        channel
+            .on_new_template(
+                template.clone(),
+                coinbase_reward_outputs,
+                Some(chain_tip.clone()),
+            )
+            .unwrap();
+
+        // this share has hash 0001099d7c957a0502952177aada0254921f04306a174543389263d1dd487cce
+        // which does meet the channel target
+        // 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205
+        // but does not meet network target
+        // 000000000000d7c0000000000000000000000000000000000000000000000000
+        let valid_share = SubmitSharesExtended {
+            channel_id,
+            sequence_number: 1,
+            job_id: 1,
+            nonce: 159386,
+            ntime: 1745611105,
+            version: 536870912,
+            extranonce: vec![1, 0, 0, 0, 0].try_into().unwrap(),
+        };
+
+        let res = channel.validate_share(valid_share, chain_tip.clone());
+        assert!(matches!(res, Ok(ShareValidationResult::Valid)));
+
+        // try to cheat by re-submitting the same share
+        // with a different sequence number
+        let repeated_share = SubmitSharesExtended {
+            channel_id,
+            sequence_number: 2,
+            job_id: 1,
+            nonce: 159386,
+            ntime: 1745611105,
+            version: 536870912,
+            extranonce: vec![1, 0, 0, 0, 0].try_into().unwrap(),
+        };
+
+        let res = channel.validate_share(repeated_share, chain_tip.clone());
+
+        // assert duplicate share is rejected
+        assert!(matches!(res, Err(ShareValidationError::DuplicateShare)));
+    }
+
+    #[test]
+    fn test_update_channel() {
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let expected_share_per_minute = 1.0;
+        let initial_hashrate = 10.0;
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        // this is the most permissive possible max_target
+        let max_target: Target = [0xff; 32].into();
+
+        // Create a channel with initial hashrate
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target.clone(),
+            initial_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // Get the initial target
+        let initial_target = channel.get_target().clone();
+
+        // Update the channel with a new hashrate (higher)
+        let new_hashrate = 100.0;
+        channel
+            .update_channel(new_hashrate, max_target.clone())
+            .unwrap();
+
+        // Get the new target after update
+        let new_target = channel.get_target().clone();
+
+        // The target should be different after updating with a different hashrate
+        // old target: 006d0b803685c01b42e00da17006d0b803685c01b42e00da17006d0b803685bf
+        // new target: 000aebbc990fff5144366f000aebbc990fff5144366f000aebbc990fff514435
+        assert_ne!(initial_target, new_target);
+
+        // The nominal hashrate should be updated
+        assert_eq!(channel.get_nominal_hashrate(), new_hashrate);
+
+        // Test invalid hashrate (negative)
+        let result = channel.update_channel(-1.0, max_target.clone());
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(ExtendedChannelError::InvalidNominalHashrate)
+        ));
+
+        // Create a not so permissive max_target so we can test a target that exceeds it
+        let not_so_permissive_max_target: Target = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0x00,
+        ]
+        .into();
+
+        // Try to update with a hashrate that would result in a target exceeding the max_target
+        // new target: 2492492492492492492492492492492492492492492492492492492492492491
+        // max target: 00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        let very_small_hashrate = 0.1;
+        let result =
+            channel.update_channel(very_small_hashrate, not_so_permissive_max_target.clone());
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(ExtendedChannelError::RequestedMaxTargetOutOfRange)
+        ));
+
+        // Test successful update with not_so_permissive_max_target
+        // new target: 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205
+        // max target: 00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        let sufficiently_big_hashrate = 1000.0;
+        let result =
+            channel.update_channel(sufficiently_big_hashrate, not_so_permissive_max_target);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_update_extranonce_prefix() {
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 1_000.0;
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
+        let share_batch_size = 100;
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix.clone(),
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        let current_extranonce_prefix = channel.get_extranonce_prefix();
+        assert_eq!(current_extranonce_prefix, &extranonce_prefix);
+
+        let new_extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 2,
+        ]
+        .to_vec();
+
+        channel
+            .set_extranonce_prefix(new_extranonce_prefix.clone())
+            .unwrap();
+        let current_extranonce_prefix = channel.get_extranonce_prefix();
+        assert_eq!(current_extranonce_prefix, &new_extranonce_prefix);
+
+        let new_extranonce_prefix_too_large = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 2, 0,
+        ]
+        .to_vec();
+
+        // try to set a new extranonce_prefix that is too large
+        let result = channel.set_extranonce_prefix(new_extranonce_prefix_too_large.clone());
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(ExtendedChannelError::NewExtranoncePrefixTooLarge)
+        ));
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/group.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/group.rs
@@ -1,0 +1,452 @@
+//! Abstraction over the state of a Sv2 Group Channel, as seen by a Mining Server
+use crate::channels::server::{
+    error::GroupChannelError,
+    jobs::{chain_tip::ChainTip, extended::ExtendedJob, factory::ExtendedJobFactory},
+};
+use stratum_common::bitcoin::transaction::TxOut;
+use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
+
+use std::collections::{HashMap, HashSet};
+
+/// Abstraction of a Group Channel.
+///
+/// It keeps track of:
+/// - the group channel's unique `group_channel_id`
+/// - the group channel's `standard_channels` (indexed by `channel_id`)
+/// - the group channel's job factory
+/// - the group channel's future jobs (indexed by `template_id`, to be activated upon receipt of a
+///   `SetNewPrevHash` message)
+/// - the group channel's active job
+///
+/// Since share validation happens at the Standard Channel level, we don't really keep track of:
+/// - the group channel's past jobs
+/// - the group channel's stale jobs
+/// - the group channel's share validation state
+#[derive(Debug, Clone)]
+pub struct GroupChannel<'a> {
+    group_channel_id: u32,
+    standard_channel_ids: HashSet<u32>,
+    job_factory: ExtendedJobFactory,
+    // maps template_id to job_id on future jobs
+    future_template_to_job_id: HashMap<u64, u32>,
+    // future jobs are indexed with job_id (u32)
+    future_jobs: HashMap<u32, ExtendedJob<'a>>,
+    active_job: Option<ExtendedJob<'a>>,
+}
+
+impl<'a> GroupChannel<'a> {
+    pub fn new(group_channel_id: u32) -> Self {
+        Self {
+            group_channel_id,
+            standard_channel_ids: HashSet::new(),
+            job_factory: ExtendedJobFactory::new(true),
+            future_template_to_job_id: HashMap::new(),
+            future_jobs: HashMap::new(),
+            active_job: None,
+        }
+    }
+
+    pub fn add_standard_channel_id(&mut self, standard_channel_id: u32) {
+        self.standard_channel_ids.insert(standard_channel_id);
+    }
+
+    pub fn remove_standard_channel_id(&mut self, standard_channel_id: u32) {
+        self.standard_channel_ids.remove(&standard_channel_id);
+    }
+
+    pub fn get_group_channel_id(&self) -> u32 {
+        self.group_channel_id
+    }
+
+    pub fn get_standard_channel_ids(&self) -> &HashSet<u32> {
+        &self.standard_channel_ids
+    }
+
+    pub fn get_active_job(&self) -> Option<&ExtendedJob<'a>> {
+        self.active_job.as_ref()
+    }
+
+    pub fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32> {
+        &self.future_template_to_job_id
+    }
+
+    pub fn get_future_jobs(&self) -> &HashMap<u32, ExtendedJob<'a>> {
+        &self.future_jobs
+    }
+
+    /// Updates the group channel state with a new template.
+    ///
+    /// If the template is a future template, the chain tip is not used.
+    /// If the template is not a future template, the chain tip must be set.
+    pub fn on_new_template(
+        &mut self,
+        template: NewTemplate<'a>,
+        coinbase_reward_outputs: Vec<TxOut>,
+        chain_tip: Option<ChainTip>,
+    ) -> Result<(), GroupChannelError> {
+        match template.future_template {
+            true => {
+                let new_job = self
+                    .job_factory
+                    .new_job(
+                        self.group_channel_id,
+                        None,
+                        vec![], /* empty extranonce prefix, as it will be replaced by the
+                                 * standard channel's extranonce
+                                 * prefix */
+                        template.clone(),
+                        coinbase_reward_outputs,
+                    )
+                    .map_err(GroupChannelError::JobFactoryError)?;
+                let new_job_id = new_job.get_job_id();
+                self.future_jobs.insert(new_job_id, new_job);
+                self.future_template_to_job_id
+                    .insert(template.template_id, new_job_id);
+            }
+            false => {
+                match chain_tip {
+                    // we can only create non-future jobs if we have a chain tip
+                    None => return Err(GroupChannelError::ChainTipNotSet),
+                    Some(chain_tip) => {
+                        let new_job = self
+                            .job_factory
+                            .new_job(
+                                self.group_channel_id,
+                                Some(chain_tip),
+                                vec![], /* empty extranonce prefix, as it will be replaced by
+                                         * the standard
+                                         * channel's extranonce prefix */
+                                template.clone(),
+                                coinbase_reward_outputs,
+                            )
+                            .map_err(GroupChannelError::JobFactoryError)?;
+                        self.active_job = Some(new_job);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Updates the channel state with a new `SetNewPrevHash` message (Template Distribution
+    /// Protocol variant).
+    ///
+    /// If there is some future job matching the `template_id`` that `SetNewPrevHash` points to,
+    /// this future job is "activated" and set as the active job.
+    ///
+    /// The chain tip information is not kept in the channel state.
+    pub fn on_set_new_prev_hash(
+        &mut self,
+        set_new_prev_hash: SetNewPrevHashTdp<'a>,
+    ) -> Result<(), GroupChannelError> {
+        match self.future_jobs.is_empty() {
+            true => {
+                return Err(GroupChannelError::TemplateIdNotFound);
+            }
+            false => {
+                // the SetNewPrevHash message was addressed to a specific future template
+                let future_job_id = self
+                    .future_template_to_job_id
+                    .remove(&set_new_prev_hash.template_id)
+                    .ok_or(GroupChannelError::TemplateIdNotFound)?;
+
+                // activate the future job
+                let mut activated_job = self
+                    .future_jobs
+                    .remove(&future_job_id)
+                    .expect("future job must exist");
+
+                activated_job.activate(set_new_prev_hash.header_timestamp);
+
+                self.active_job = Some(activated_job);
+
+                self.future_jobs.clear();
+                self.future_template_to_job_id.clear();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::channels::server::{group::GroupChannel, jobs::chain_tip::ChainTip};
+    use binary_sv2::Sv2Option;
+    use mining_sv2::NewExtendedMiningJob;
+    use std::convert::TryInto;
+    use stratum_common::bitcoin::{transaction::TxOut, Amount, ScriptBuf};
+    use template_distribution_sv2::{NewTemplate, SetNewPrevHash};
+
+    const SATS_AVAILABLE_IN_TEMPLATE: u64 = 5000000000;
+
+    #[test]
+    fn test_future_job_activation_flow() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        assert!(group_channel.get_future_jobs().is_empty());
+        group_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs, None)
+            .unwrap();
+        assert!(group_channel.get_active_job().is_none());
+
+        let future_job_id = group_channel
+            .get_future_template_to_job_id()
+            .get(&template.template_id)
+            .unwrap();
+
+        let future_job = group_channel
+            .get_future_jobs()
+            .get(future_job_id)
+            .unwrap()
+            .clone();
+
+        // we know that the provided template + coinbase_reward_outputs should generate this future
+        // job
+        let expected_job = NewExtendedMiningJob {
+            channel_id: 1,
+            job_id: 1,
+            min_ntime: Sv2Option::new(None),
+            version: 536870912,
+            version_rolling_allowed: true,
+            coinbase_tx_prefix: vec![
+                2, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 34, 82, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_suffix: vec![
+                255, 255, 255, 255, 2, 0, 242, 5, 42, 1, 0, 0, 0, 22, 0, 20, 235, 225, 183, 220,
+                194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194, 8, 252, 0, 0, 0,
+                0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209, 222,
+                253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180, 139,
+                235, 216, 54, 151, 78, 140, 249, 1, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        assert_eq!(future_job.get_job_message(), &expected_job);
+
+        let ntime = 1746839905;
+
+        let set_new_prev_hash = SetNewPrevHash {
+            template_id: 1,
+            prev_hash: [
+                200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144,
+                205, 88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+            ]
+            .into(),
+            header_timestamp: ntime,
+            n_bits: 503543726,
+            target: [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                174, 119, 3, 0, 0,
+            ]
+            .into(),
+        };
+
+        group_channel
+            .on_set_new_prev_hash(set_new_prev_hash)
+            .unwrap();
+
+        // we just activated the only future job
+        assert!(group_channel.get_active_job().is_some());
+
+        let mut previously_future_job = future_job.clone();
+        previously_future_job.activate(ntime);
+
+        let activated_job = group_channel.get_active_job().unwrap();
+
+        // assert that the activated job is the same as the previously future job
+        assert_eq!(
+            activated_job.get_job_message(),
+            previously_future_job.get_job_message()
+        );
+    }
+
+    #[test]
+    fn test_non_future_job_creation_flow() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let ntime = 1746839905;
+        let prev_hash = [
+            200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144, 205,
+            88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+        ]
+        .into();
+        let n_bits = 503543726;
+
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // this is a non-future template, so we must provide a chain_tip
+        assert!(group_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs.clone(), None)
+            .is_err());
+        group_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs, Some(chain_tip))
+            .unwrap();
+
+        let active_job = group_channel.get_active_job().unwrap();
+
+        // we know that the provided template + coinbase_reward_outputs should generate this
+        // non-future job
+        let expected_job = NewExtendedMiningJob {
+            channel_id: 1,
+            job_id: 1,
+            min_ntime: Sv2Option::new(Some(ntime)),
+            version: 536870912,
+            version_rolling_allowed: true,
+            coinbase_tx_prefix: vec![
+                2, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 34, 82, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_suffix: vec![
+                255, 255, 255, 255, 2, 0, 242, 5, 42, 1, 0, 0, 0, 22, 0, 20, 235, 225, 183, 220,
+                194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194, 8, 252, 0, 0, 0,
+                0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209, 222,
+                253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180, 139,
+                235, 216, 54, 151, 78, 140, 249, 1, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        assert_eq!(active_job.get_job_message(), &expected_job);
+    }
+
+    #[test]
+    fn test_coinbase_reward_outputs_sum_above_template_value() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+
+        let invalid_coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE + 1), /* oops: one too many extra
+                                                                      * sats */
+            script_pubkey: script,
+        }];
+
+        assert!(group_channel
+            .on_new_template(template.clone(), invalid_coinbase_reward_outputs, None)
+            .is_err());
+        assert!(group_channel.get_future_jobs().is_empty());
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/chain_tip.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/chain_tip.rs
@@ -1,0 +1,34 @@
+//! # Chain Tip
+use binary_sv2::U256;
+
+/// An abstraction over the chain tip, carrying information from `SetNewPrevHash` messages.
+///
+/// Used while creating non-future jobs.
+#[derive(Debug, Clone)]
+pub struct ChainTip {
+    prev_hash: U256<'static>,
+    nbits: u32,
+    min_ntime: u32,
+}
+
+impl ChainTip {
+    pub fn new(prev_hash: U256<'static>, nbits: u32, min_ntime: u32) -> Self {
+        Self {
+            prev_hash,
+            nbits,
+            min_ntime,
+        }
+    }
+
+    pub fn prev_hash(&self) -> U256<'static> {
+        self.prev_hash.clone()
+    }
+
+    pub fn nbits(&self) -> u32 {
+        self.nbits
+    }
+
+    pub fn min_ntime(&self) -> u32 {
+        self.min_ntime
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/error.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/error.rs
@@ -1,0 +1,16 @@
+pub enum ExtendedJobError {
+    CoinbaseOutputsSumOverflow,
+    InvalidCoinbaseOutputsSum,
+}
+
+pub enum StandardJobError {}
+
+#[derive(Debug)]
+pub enum ExtendedJobFactoryError {
+    InvalidTemplate(String),
+    CoinbaseTxPrefixError,
+    CoinbaseTxSuffixError,
+    CoinbaseOutputsSumOverflow,
+    InvalidCoinbaseOutputsSum,
+    ChainTipRequired,
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
@@ -1,0 +1,153 @@
+use crate::{
+    channels::server::jobs::{standard::StandardJob, JobOrigin},
+    template_distribution_sv2::NewTemplate,
+    utils::{deserialize_outputs, merkle_root_from_path},
+};
+use binary_sv2::{Seq0255, Sv2Option, B064K, U256};
+use mining_sv2::{NewExtendedMiningJob, NewMiningJob, SetCustomMiningJob};
+use std::convert::TryInto;
+use stratum_common::bitcoin::transaction::TxOut;
+
+/// Abstraction of an extended mining job with:
+/// - the `NewTemplate` OR `SetCustomMiningJob` message that originated it
+/// - the extranonce prefix associated with the channel at the time of job creation
+/// - all coinbase outputs (spendable + unspendable) associated with the job
+/// - the `NewExtendedMiningJob` message to be sent across the wire
+#[derive(Debug, Clone)]
+pub struct ExtendedJob<'a> {
+    origin: JobOrigin<'a>,
+    extranonce_prefix: Vec<u8>,
+    coinbase_outputs: Vec<TxOut>,
+    job_message: NewExtendedMiningJob<'a>,
+}
+
+impl<'a> ExtendedJob<'a> {
+    /// Creates a new job from a template.
+    ///
+    /// `additional_coinbase_outputs` are added to the coinbase outputs coming from the template.
+    pub fn from_template(
+        template: NewTemplate<'a>,
+        extranonce_prefix: Vec<u8>,
+        additional_coinbase_outputs: Vec<TxOut>,
+        job_message: NewExtendedMiningJob<'a>,
+    ) -> Self {
+        let mut coinbase_outputs = vec![];
+        coinbase_outputs.extend(additional_coinbase_outputs);
+        coinbase_outputs.extend(deserialize_outputs(
+            template.coinbase_tx_outputs.inner_as_ref().to_vec(),
+        ));
+
+        Self {
+            origin: JobOrigin::NewTemplate(template),
+            extranonce_prefix,
+            coinbase_outputs,
+            job_message,
+        }
+    }
+
+    pub fn from_custom_job(
+        custom_job: SetCustomMiningJob<'a>,
+        extranonce_prefix: Vec<u8>,
+        coinbase_outputs: Vec<TxOut>,
+        job_message: NewExtendedMiningJob<'a>,
+    ) -> Self {
+        Self {
+            origin: JobOrigin::SetCustomMiningJob(custom_job),
+            extranonce_prefix,
+            coinbase_outputs,
+            job_message,
+        }
+    }
+
+    /// Converts the `ExtendedJob` into a `SetCustomMiningJob` message.
+    ///
+    /// To be used by a Sv2 Job Declaration Client after:
+    /// - creating a non-future extended job from a non-future template
+    /// - activating a future extended job (that was created from a future template)
+    pub fn into_custom_job(self) -> SetCustomMiningJob<'a> {
+        // we need to wait for the outcome of the discussions around
+        // https://github.com/stratum-mining/sv2-spec/issues/133
+        // before implementing this
+        todo!()
+    }
+
+    pub fn into_standard_job(self, channel_id: u32, extranonce_prefix: Vec<u8>) -> StandardJob<'a> {
+        let merkle_root = merkle_root_from_path(
+            self.get_coinbase_tx_prefix().inner_as_ref(),
+            self.get_coinbase_tx_suffix().inner_as_ref(),
+            &extranonce_prefix,
+            &self.get_merkle_path().inner_as_ref(),
+        )
+        .expect("merkle root must be valid")
+        .try_into()
+        .expect("merkle root must be 32 bytes");
+
+        let standard_job_message = NewMiningJob {
+            channel_id,
+            job_id: self.get_job_id(),
+            merkle_root,
+            version: self.get_version(),
+            min_ntime: self.get_min_ntime(),
+        };
+
+        let standard_job = StandardJob::new(
+            self.get_origin().clone(),
+            extranonce_prefix,
+            self.get_coinbase_outputs().clone(),
+            standard_job_message,
+        );
+
+        standard_job
+    }
+
+    pub fn get_job_id(&self) -> u32 {
+        self.job_message.job_id
+    }
+
+    pub fn get_origin(&self) -> &JobOrigin<'a> {
+        &self.origin
+    }
+
+    pub fn get_coinbase_tx_prefix(&self) -> &B064K<'a> {
+        &self.job_message.coinbase_tx_prefix
+    }
+
+    pub fn get_coinbase_tx_suffix(&self) -> &B064K<'a> {
+        &self.job_message.coinbase_tx_suffix
+    }
+
+    pub fn get_extranonce_prefix(&self) -> &Vec<u8> {
+        &self.extranonce_prefix
+    }
+
+    pub fn get_coinbase_outputs(&self) -> &Vec<TxOut> {
+        &self.coinbase_outputs
+    }
+
+    pub fn get_job_message(&self) -> &NewExtendedMiningJob<'a> {
+        &self.job_message
+    }
+
+    pub fn get_merkle_path(&self) -> &Seq0255<'a, U256<'a>> {
+        &self.job_message.merkle_path
+    }
+
+    pub fn get_min_ntime(&self) -> Sv2Option<'a, u32> {
+        self.job_message.min_ntime.clone()
+    }
+
+    pub fn get_version(&self) -> u32 {
+        self.job_message.version
+    }
+
+    pub fn version_rolling_allowed(&self) -> bool {
+        self.job_message.version_rolling_allowed
+    }
+
+    /// Activates the job, setting the `min_ntime` field of the `NewExtendedMiningJob` message.
+    ///
+    /// To be used while activating future jobs upon updating channel `ChainTip` state.
+    pub fn activate(&mut self, min_ntime: u32) {
+        self.job_message.min_ntime = Sv2Option::new(Some(min_ntime));
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/factory.rs
@@ -1,0 +1,455 @@
+//! Abstraction of a factory for creating Sv2 Extended Jobs.
+use crate::{
+    channels::server::jobs::{chain_tip::ChainTip, error::*, extended::ExtendedJob},
+    template_distribution_sv2::NewTemplate,
+    utils::{deserialize_outputs, Id as JobIdFactory},
+};
+use binary_sv2::{Sv2Option, B064K};
+use mining_sv2::{NewExtendedMiningJob, SetCustomMiningJob, MAX_EXTRANONCE_LEN};
+use std::convert::TryInto;
+use stratum_common::bitcoin::{
+    absolute::LockTime,
+    blockdata::witness::Witness,
+    consensus::{serialize, Decodable},
+    transaction::{OutPoint, Transaction, TxIn, TxOut, Version},
+    Amount, Sequence,
+};
+
+/// A Factory for creating Extended Jobs.
+///
+/// Enables creation of new Extended Jobs from NewTemplate and SetCustomMiningJob messages.
+/// Ensures unique job ids.
+///
+/// Please note that there is no `StandardJobFactory` counterpart. Since every Standard Channel
+/// belongs to some Group Channel, all Standard Channels keep track of Standard Jobs that are
+/// actually conversions from the Extended Job created on the Group Channel level.
+#[derive(Debug, Clone)]
+pub struct ExtendedJobFactory {
+    job_id_factory: JobIdFactory,
+    version_rolling_allowed: bool,
+}
+
+impl ExtendedJobFactory {
+    pub fn new(version_rolling_allowed: bool) -> Self {
+        Self {
+            job_id_factory: JobIdFactory::new(),
+            version_rolling_allowed,
+        }
+    }
+
+    /// Creates a new job from a template.
+    ///
+    /// This job (and related shares) is fully committed to:
+    /// - The template
+    /// - The additional coinbase outputs (added to the outputs coming from the template)
+    /// - The extranonce prefix of the channel at the time of job creation
+    ///
+    /// The optional `ChainTip` defines whether the job will be future or not.
+    pub fn new_job<'a>(
+        &mut self,
+        channel_id: u32,
+        chain_tip: Option<ChainTip>,
+        extranonce_prefix: Vec<u8>,
+        template: NewTemplate<'a>,
+        additional_coinbase_outputs: Vec<TxOut>,
+    ) -> Result<ExtendedJob<'a>, ExtendedJobFactoryError> {
+        let job_id = self.job_id_factory.next();
+
+        let version = template.version;
+
+        let coinbase_tx_prefix =
+            self.coinbase_tx_prefix(template.clone(), additional_coinbase_outputs.clone())?;
+        let coinbase_tx_suffix =
+            self.coinbase_tx_suffix(template.clone(), additional_coinbase_outputs.clone())?;
+        let merkle_path = template.merkle_path.clone();
+
+        let job_message = match template.future_template {
+            true => NewExtendedMiningJob {
+                channel_id,
+                job_id,
+                min_ntime: Sv2Option::new(None),
+                version,
+                version_rolling_allowed: self.version_rolling_allowed,
+                merkle_path,
+                coinbase_tx_prefix,
+                coinbase_tx_suffix,
+            },
+            false => {
+                let min_ntime = match chain_tip {
+                    Some(chain_tip) => Some(chain_tip.min_ntime()),
+                    None => return Err(ExtendedJobFactoryError::ChainTipRequired),
+                };
+                NewExtendedMiningJob {
+                    channel_id,
+                    job_id,
+                    min_ntime: Sv2Option::new(min_ntime),
+                    version,
+                    version_rolling_allowed: self.version_rolling_allowed,
+                    merkle_path,
+                    coinbase_tx_prefix,
+                    coinbase_tx_suffix,
+                }
+            }
+        };
+
+        let job = ExtendedJob::from_template(
+            template,
+            extranonce_prefix,
+            additional_coinbase_outputs,
+            job_message,
+        );
+
+        Ok(job)
+    }
+
+    /// Creates a new job from a SetCustomMiningJob message.
+    ///
+    /// Assumes that the SetCustomMiningJob message has already been validated.
+    pub fn new_custom_job<'a>(
+        &mut self,
+        set_custom_mining_job: SetCustomMiningJob<'a>,
+        extranonce_prefix: Vec<u8>,
+    ) -> Result<ExtendedJob<'a>, ExtendedJobFactoryError> {
+        let serialized_outputs = set_custom_mining_job
+            .coinbase_tx_outputs
+            .inner_as_ref()
+            .to_vec();
+
+        let coinbase_outputs = deserialize_outputs(serialized_outputs);
+
+        let job_id = self.job_id_factory.next();
+
+        let version = set_custom_mining_job.version;
+
+        let coinbase_tx_prefix = self.custom_coinbase_tx_prefix(set_custom_mining_job.clone())?;
+        let coinbase_tx_suffix = self.custom_coinbase_tx_suffix(set_custom_mining_job.clone())?;
+
+        let merkle_path = set_custom_mining_job.merkle_path.clone().into_static();
+
+        let job_message = NewExtendedMiningJob {
+            channel_id: set_custom_mining_job.channel_id,
+            job_id,
+            min_ntime: Sv2Option::new(Some(set_custom_mining_job.min_ntime)),
+            version,
+            version_rolling_allowed: self.version_rolling_allowed,
+            coinbase_tx_prefix,
+            coinbase_tx_suffix,
+            merkle_path,
+        };
+
+        let job = ExtendedJob::from_custom_job(
+            set_custom_mining_job,
+            extranonce_prefix,
+            coinbase_outputs,
+            job_message,
+        );
+
+        Ok(job)
+    }
+}
+
+// impl block with private methods
+impl ExtendedJobFactory {
+    // build a coinbase transaction from a SetCustomMiningJob
+    // this is only used to extract coinbase_tx_prefix and coinbase_tx_suffix from the custom
+    // coinbase
+    fn custom_coinbase(
+        &self,
+        m: SetCustomMiningJob<'_>,
+    ) -> Result<Transaction, ExtendedJobFactoryError> {
+        let deserialized_outputs =
+            deserialize_outputs(m.coinbase_tx_outputs.inner_as_ref().to_vec());
+
+        // note: this is assuming there's only one output
+        // where all the sats are added to
+        // hopefully we will clean this once we get a clear outcome from
+        // https://github.com/stratum-mining/sv2-spec/issues/133
+        let mut outputs_with_value_remaining = vec![];
+        for output in deserialized_outputs.iter() {
+            if output.script_pubkey.is_p2pk()
+                || output.script_pubkey.is_p2pkh()
+                || output.script_pubkey.is_p2tr()
+                || output.script_pubkey.is_p2wpkh()
+                || output.script_pubkey.is_p2wsh()
+            {
+                let mut output_with_value_remaining = output.clone();
+                output_with_value_remaining.value = Amount::from_sat(m.coinbase_tx_value_remaining);
+                outputs_with_value_remaining.push(output_with_value_remaining);
+            } else {
+                outputs_with_value_remaining.push(output.clone());
+            }
+        }
+
+        let mut script_sig = vec![];
+        script_sig.extend_from_slice(m.coinbase_prefix.inner_as_ref());
+        script_sig.extend_from_slice(&[0; MAX_EXTRANONCE_LEN]);
+
+        // Create transaction input
+        let tx_in = TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: script_sig.into(),
+            sequence: Sequence(m.coinbase_tx_input_n_sequence),
+            witness: Witness::from(vec![vec![0; 32]]),
+        };
+
+        Ok(Transaction {
+            version: Version::non_standard(m.coinbase_tx_version as i32),
+            lock_time: LockTime::from_consensus(m.coinbase_tx_locktime),
+            input: vec![tx_in],
+            output: outputs_with_value_remaining,
+        })
+    }
+
+    fn custom_coinbase_tx_prefix(
+        &self,
+        m: SetCustomMiningJob<'_>,
+    ) -> Result<B064K<'static>, ExtendedJobFactoryError> {
+        let coinbase = self.custom_coinbase(m.clone())?;
+        let serialized_coinbase = serialize(&coinbase);
+
+        let index = 4 // tx version
+            + 2 // segwit
+            + 1 // number of inputs
+            + 32 // prev OutPoint
+            + 4 // index
+            + 1 // bytes in script
+            + m.coinbase_prefix.inner_as_ref().len(); // script_sig_prefix
+
+        let r = serialized_coinbase[0..index].to_vec();
+
+        r.try_into()
+            .map_err(|_| ExtendedJobFactoryError::CoinbaseTxPrefixError)
+    }
+
+    fn custom_coinbase_tx_suffix(
+        &self,
+        m: SetCustomMiningJob<'_>,
+    ) -> Result<B064K<'static>, ExtendedJobFactoryError> {
+        let coinbase = self.custom_coinbase(m.clone())?;
+        let serialized_coinbase = serialize(&coinbase);
+
+        // Calculate full extranonce size
+        let full_extranonce_size = MAX_EXTRANONCE_LEN;
+
+        let index = 4 // tx version
+            + 2 // segwit
+            + 1 // number of inputs
+            + 32 // prev OutPoint
+            + 4 // index
+            + 1 // bytes in script
+            + m.coinbase_prefix.inner_as_ref().len() // script_sig_prefix
+            + full_extranonce_size;
+
+        let r = serialized_coinbase[index..].to_vec();
+
+        r.try_into()
+            .map_err(|_| ExtendedJobFactoryError::CoinbaseTxSuffixError)
+    }
+
+    // build a coinbase transaction from some template in the JobFactory
+    fn coinbase(
+        &self,
+        template: NewTemplate<'_>,
+        coinbase_reward_outputs: Vec<TxOut>,
+    ) -> Result<Transaction, ExtendedJobFactoryError> {
+        // check that the sum of the additional coinbase outputs is equal to the value remaining in
+        // the active template
+        let mut coinbase_reward_outputs_sum = Amount::from_sat(0);
+        for output in coinbase_reward_outputs.iter() {
+            coinbase_reward_outputs_sum = coinbase_reward_outputs_sum
+                .checked_add(output.value)
+                .ok_or(ExtendedJobFactoryError::CoinbaseOutputsSumOverflow)?;
+        }
+
+        if template.coinbase_tx_value_remaining < coinbase_reward_outputs_sum.to_sat() {
+            return Err(ExtendedJobFactoryError::InvalidCoinbaseOutputsSum);
+        }
+
+        let mut outputs = vec![];
+
+        for output in coinbase_reward_outputs.iter() {
+            outputs.push(output.clone());
+        }
+
+        let serialized_template_outputs = template.coinbase_tx_outputs.to_vec();
+        let mut cursor = 0;
+        let mut txouts = &serialized_template_outputs[cursor..];
+        while let Ok(out) = TxOut::consensus_decode(&mut txouts) {
+            let len = match out.script_pubkey.len() {
+                a @ 0..=252 => 8 + 1 + a,
+                a @ 253..=10000 => 8 + 3 + a,
+                _ => break,
+            };
+            cursor += len;
+            outputs.push(out);
+        }
+
+        let mut script_sig = vec![];
+        script_sig.extend_from_slice(&template.coinbase_prefix.to_vec());
+        script_sig.extend_from_slice(&[0; MAX_EXTRANONCE_LEN]);
+
+        let tx_in = TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: script_sig.into(),
+            sequence: Sequence(template.coinbase_tx_input_sequence),
+            witness: Witness::from(vec![vec![0; 32]]),
+        };
+
+        Ok(Transaction {
+            version: Version::non_standard(template.coinbase_tx_version as i32),
+            lock_time: LockTime::from_consensus(template.coinbase_tx_locktime),
+            input: vec![tx_in],
+            output: outputs,
+        })
+    }
+
+    fn coinbase_tx_prefix(
+        &self,
+        template: NewTemplate<'_>,
+        coinbase_reward_outputs: Vec<TxOut>,
+    ) -> Result<B064K<'static>, ExtendedJobFactoryError> {
+        let coinbase = self.coinbase(template.clone(), coinbase_reward_outputs)?;
+        let serialized_coinbase = serialize(&coinbase);
+
+        let index = 4 // tx version
+            + 2 // segwit bytes
+            + 1 // number of inputs
+            + 32 // prev OutPoint
+            + 4 // index
+            + 1 // bytes in script
+            + template.coinbase_prefix.len(); // script_sig_prefix
+
+        let r = serialized_coinbase[0..index].to_vec();
+
+        r.try_into()
+            .map_err(|_| ExtendedJobFactoryError::CoinbaseTxPrefixError)
+    }
+
+    fn coinbase_tx_suffix(
+        &self,
+        template: NewTemplate<'_>,
+        coinbase_reward_outputs: Vec<TxOut>,
+    ) -> Result<B064K<'static>, ExtendedJobFactoryError> {
+        let coinbase = self.coinbase(template.clone(), coinbase_reward_outputs)?;
+        let serialized_coinbase = serialize(&coinbase);
+
+        let full_extranonce_size = MAX_EXTRANONCE_LEN;
+
+        let r = serialized_coinbase[4 // tx version
+            + 2 // segwit bytes
+            + 1 // number of inputs
+            + 32 // prev OutPoint
+            + 4 // index
+            + 1 // bytes in script
+            + template.coinbase_prefix.len() // script_sig_prefix
+            + full_extranonce_size..]
+            .to_vec();
+
+        r.try_into()
+            .map_err(|_| ExtendedJobFactoryError::CoinbaseTxSuffixError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stratum_common::bitcoin::ScriptBuf;
+    use template_distribution_sv2::NewTemplate;
+
+    #[test]
+    fn test_new_job() {
+        let mut job_factory = ExtendedJobFactory::new(true);
+
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: 5000000000,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(5000000000),
+            script_pubkey: script,
+        }];
+
+        // match the original extranonce_prefix used to generate the expected job
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+
+        let job = job_factory
+            .new_job(
+                1,
+                None,
+                extranonce_prefix,
+                template,
+                coinbase_reward_outputs,
+            )
+            .unwrap();
+
+        // we know that the provided template should generate this job
+        let expected_job = NewExtendedMiningJob {
+            channel_id: 1,
+            job_id: 1,
+            min_ntime: Sv2Option::new(None),
+            version: 536870912,
+            version_rolling_allowed: true,
+            coinbase_tx_prefix: vec![
+                2, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 34, 82, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_suffix: vec![
+                255, 255, 255, 255, 2, 0, 242, 5, 42, 1, 0, 0, 0, 22, 0, 20, 235, 225, 183, 220,
+                194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194, 8, 252, 0, 0, 0,
+                0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209, 222,
+                253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180, 139,
+                235, 216, 54, 151, 78, 140, 249, 1, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        assert_eq!(job.get_job_message(), &expected_job);
+    }
+
+    #[test]
+    fn test_new_custom_job() {
+        // todo: assert that a SetCustomMiningJob leads to
+        // the correct NewExtendedMiningJob message
+        // we should wait until the following spec cleanup is finished
+        // https://github.com/stratum-mining/sv2-spec/issues/133
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/mod.rs
@@ -1,0 +1,14 @@
+pub mod chain_tip;
+pub mod error;
+pub mod extended;
+pub mod factory;
+pub mod standard;
+
+use mining_sv2::SetCustomMiningJob;
+use template_distribution_sv2::NewTemplate;
+
+#[derive(Clone, Debug)]
+pub enum JobOrigin<'a> {
+    NewTemplate(NewTemplate<'a>),
+    SetCustomMiningJob(SetCustomMiningJob<'a>),
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
@@ -1,0 +1,65 @@
+use crate::channels::server::jobs::JobOrigin;
+use binary_sv2::{Sv2Option, U256};
+use mining_sv2::NewMiningJob;
+use stratum_common::bitcoin::transaction::TxOut;
+
+/// Abstraction of a standard mining job with:
+/// - the `NewTemplate` message that originated it
+/// - the extranonce prefix associated with the channel at the time of job creation
+/// - all coinbase outputs (spendable + unspendable) associated with the job
+/// - the `NewMiningJob` message to be sent across the wire
+#[derive(Debug, Clone)]
+pub struct StandardJob<'a> {
+    origin: JobOrigin<'a>,
+    extranonce_prefix: Vec<u8>,
+    coinbase_outputs: Vec<TxOut>,
+    job_message: NewMiningJob<'a>,
+}
+
+impl<'a> StandardJob<'a> {
+    pub fn new(
+        origin: JobOrigin<'a>,
+        extranonce_prefix: Vec<u8>,
+        coinbase_outputs: Vec<TxOut>,
+        job_message: NewMiningJob<'a>,
+    ) -> Self {
+        Self {
+            origin,
+            extranonce_prefix,
+            coinbase_outputs,
+            job_message,
+        }
+    }
+
+    pub fn get_job_id(&self) -> u32 {
+        self.job_message.job_id
+    }
+
+    pub fn get_coinbase_outputs(&self) -> &Vec<TxOut> {
+        &self.coinbase_outputs
+    }
+
+    pub fn get_extranonce_prefix(&self) -> &Vec<u8> {
+        &self.extranonce_prefix
+    }
+
+    pub fn get_job_message(&self) -> &NewMiningJob<'a> {
+        &self.job_message
+    }
+
+    pub fn get_origin(&self) -> &JobOrigin<'a> {
+        &self.origin
+    }
+
+    pub fn get_merkle_root(&self) -> &U256<'a> {
+        &self.job_message.merkle_root
+    }
+
+    pub fn is_future(&self) -> bool {
+        self.job_message.min_ntime.clone().into_inner().is_none()
+    }
+
+    pub fn activate(&mut self, min_ntime: u32) {
+        self.job_message.min_ntime = Sv2Option::new(Some(min_ntime));
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/mod.rs
@@ -1,0 +1,8 @@
+//! Abstractions for channels to be used by mining servers.
+
+pub mod error;
+pub mod extended;
+pub mod group;
+pub mod jobs;
+pub mod share_accounting;
+pub mod standard;

--- a/protocols/v2/roles-logic-sv2/src/channels/server/share_accounting.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/share_accounting.rs
@@ -1,0 +1,122 @@
+//! Abstractions for share validation
+
+use std::collections::HashSet;
+use stratum_common::bitcoin::hashes::sha256d::Hash;
+
+/// The outcome of share validation.
+///
+/// The [`ShareValidationResult::ValidWithAcknowledgement`] variant carries:
+/// - `last_sequence_number` (as `u32`)
+/// - `new_submits_accepted_count` (as `u32`)
+/// - `new_shares_sum` (as `u64`)
+///
+/// which are used to craft `SubmitShares.Success` Sv2 messages.
+///
+/// The [`ShareValidationResult::BlockFound`] variant carries:
+/// - `template_id` (as `Option<u64>`)
+/// - `coinbase` (as `Vec<u8>`)
+///
+/// where `template_id` is `None` if the share is for a custom job.
+#[derive(Debug)]
+pub enum ShareValidationResult {
+    Valid,
+    // last_sequence_number, new_submits_accepted_count, new_shares_sum
+    ValidWithAcknowledgement(u32, u32, u64),
+    // template_id, coinbase
+    // template_id is None if custom job
+    BlockFound(Option<u64>, Vec<u8>),
+}
+
+/// The error variants that can occur during share validation
+#[derive(Debug)]
+pub enum ShareValidationError {
+    Invalid,
+    Stale,
+    InvalidJobId,
+    DoesNotMeetTarget,
+    VersionRollingNotAllowed,
+    DuplicateShare,
+    InvalidCoinbase,
+}
+
+/// The state of share validation on the context of some specific channel (either Extended or
+/// Standard)
+#[derive(Clone, Debug)]
+pub struct ShareAccounting {
+    last_share_sequence_number: u32,
+    shares_accepted: u32,
+    share_work_sum: u64,
+    share_batch_size: usize,
+    seen_shares: HashSet<Hash>,
+    best_diff: f64,
+}
+
+impl ShareAccounting {
+    pub fn new(share_batch_size: usize) -> Self {
+        Self {
+            last_share_sequence_number: 0,
+            shares_accepted: 0,
+            share_work_sum: 0,
+            share_batch_size,
+            seen_shares: HashSet::new(),
+            best_diff: 0.0,
+        }
+    }
+
+    pub fn update_share_accounting(
+        &mut self,
+        share_work: u64,
+        share_sequence_number: u32,
+        share_hash: Hash,
+    ) {
+        self.last_share_sequence_number = share_sequence_number;
+        self.shares_accepted += 1;
+        self.share_work_sum += share_work;
+        self.seen_shares.insert(share_hash);
+    }
+
+    /// clears the hashset of seen shares
+    ///
+    /// should be called on every chain tip update
+    /// to avoid unbounded growth of memory
+    pub fn flush_seen_shares(&mut self) {
+        self.seen_shares.clear();
+    }
+
+    pub fn get_last_share_sequence_number(&self) -> u32 {
+        self.last_share_sequence_number
+    }
+
+    pub fn get_shares_accepted(&self) -> u32 {
+        self.shares_accepted
+    }
+
+    pub fn get_share_work_sum(&self) -> u64 {
+        self.share_work_sum
+    }
+
+    pub fn get_share_batch_size(&self) -> usize {
+        self.share_batch_size
+    }
+
+    pub fn should_acknowledge(&self) -> bool {
+        self.shares_accepted % self.share_batch_size as u32 == 0
+    }
+
+    /// Checks if the share has been seen.
+    /// Useful to avoid duplicate shares.
+    pub fn is_share_seen(&self, share_hash: Hash) -> bool {
+        self.seen_shares.contains(&share_hash)
+    }
+
+    pub fn get_best_diff(&self) -> f64 {
+        self.best_diff
+    }
+
+    /// Updates the best diff if the new diff is higher.
+    pub fn update_best_diff(&mut self, diff: f64) {
+        if diff > self.best_diff {
+            self.best_diff = diff;
+        }
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/standard.rs
@@ -1,0 +1,1225 @@
+//! Abstraction over the state of a Sv2 Standard Channel, as seen by a Mining Server
+use crate::{
+    channels::server::{
+        error::StandardChannelError,
+        jobs::{chain_tip::ChainTip, standard::StandardJob, JobOrigin},
+        share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
+    },
+    utils::{bytes_to_hex, hash_rate_to_target, target_to_difficulty, u256_to_block_hash},
+};
+use mining_sv2::{SubmitSharesStandard, Target};
+use std::{collections::HashMap, convert::TryInto};
+use stratum_common::bitcoin::{
+    absolute::LockTime,
+    blockdata::{
+        block::{Header, Version},
+        witness::Witness,
+    },
+    consensus::Encodable,
+    hashes::sha256d::Hash,
+    transaction::{OutPoint, Transaction, TxIn, Version as TxVersion},
+    CompactTarget, Sequence, Target as BitcoinTarget,
+};
+use template_distribution_sv2::SetNewPrevHash;
+use tracing::debug;
+
+/// Abstraction of a Sv2 Standard Channel.
+///
+/// It keeps track of:
+/// - the channel's unique `channel_id`
+/// - the channel's `user_identity`
+/// - the channel's unique `extranonce_prefix`
+/// - the channel's target
+/// - the channel's nominal hashrate
+/// - the channel's active job
+/// - the channel's future jobs (indexed by `template_id`, to be activated upon receipt of a
+///   `SetNewPrevHash` message)
+/// - the channel's past jobs (which were active jobs under the current chain tip, indexed by
+///   `job_id`)
+/// - the channel's stale jobs (which were past and active jobs under the previous chain tip,
+///   indexed by `job_id`)
+///
+/// Differently from `ExtendedChannel`, there's no reference to:
+/// - a job factory
+///
+/// That's because every Standard Channel always belong to some Group Channel, and it's the Group
+/// Channel's responsability to create jobs.
+///
+/// As the Group Channel creates and activates Extended Jobs, each Standard Channel is updated
+/// with Standard Jobs accordingly.
+#[derive(Debug, Clone)]
+pub struct StandardChannel<'a> {
+    pub channel_id: u32,
+    user_identity: String,
+    extranonce_prefix: Vec<u8>,
+    target: Target,
+    nominal_hashrate: f32,
+    // maps template_id to job_id on future jobs
+    future_template_to_job_id: HashMap<u64, u32>,
+    // future jobs are indexed with job_id (u32)
+    future_jobs: HashMap<u32, StandardJob<'a>>,
+    active_job: Option<StandardJob<'a>>,
+    // past jobs are indexed with job_id (u32)
+    past_jobs: HashMap<u32, StandardJob<'a>>,
+    // stale jobs are indexed with job_id (u32)
+    stale_jobs: HashMap<u32, StandardJob<'a>>,
+    share_accounting: ShareAccounting,
+    expected_share_per_minute: f32,
+}
+
+impl<'a> StandardChannel<'a> {
+    pub fn new(
+        channel_id: u32,
+        user_identity: String,
+        extranonce_prefix: Vec<u8>,
+        requested_max_target: Target,
+        nominal_hashrate: f32,
+        share_batch_size: usize,
+        expected_share_per_minute: f32,
+    ) -> Result<Self, StandardChannelError> {
+        let calculated_target =
+            match hash_rate_to_target(nominal_hashrate.into(), expected_share_per_minute.into()) {
+                Ok(target_u256) => target_u256,
+                Err(_) => {
+                    return Err(StandardChannelError::InvalidNominalHashrate);
+                }
+            };
+
+        let target: Target = calculated_target.into();
+        let requested_max_target_value: Target = requested_max_target;
+
+        if target > requested_max_target_value {
+            return Err(StandardChannelError::RequestedMaxTargetOutOfRange);
+        }
+
+        Ok(Self {
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            target,
+            nominal_hashrate,
+            future_template_to_job_id: HashMap::new(),
+            future_jobs: HashMap::new(),
+            active_job: None,
+            past_jobs: HashMap::new(),
+            stale_jobs: HashMap::new(),
+            share_accounting: ShareAccounting::new(share_batch_size),
+            expected_share_per_minute,
+        })
+    }
+
+    pub fn get_channel_id(&self) -> u32 {
+        self.channel_id
+    }
+
+    pub fn get_user_identity(&self) -> &String {
+        &self.user_identity
+    }
+
+    pub fn get_extranonce_prefix(&self) -> &Vec<u8> {
+        &self.extranonce_prefix
+    }
+
+    pub fn set_extranonce_prefix(&mut self, extranonce_prefix: Vec<u8>) {
+        self.extranonce_prefix = extranonce_prefix;
+    }
+
+    pub fn set_target(&mut self, target: Target) {
+        self.target = target;
+    }
+
+    pub fn set_nominal_hashrate(&mut self, nominal_hashrate: f32) {
+        self.nominal_hashrate = nominal_hashrate;
+    }
+
+    pub fn get_target(&self) -> &Target {
+        &self.target
+    }
+
+    pub fn get_nominal_hashrate(&self) -> f32 {
+        self.nominal_hashrate
+    }
+
+    /// Updates the channel's nominal hashrate and target.
+    pub fn update_channel(
+        &mut self,
+        nominal_hashrate: f32,
+        max_target: Target,
+    ) -> Result<(), StandardChannelError> {
+        let target_u256 = match hash_rate_to_target(
+            nominal_hashrate.into(),
+            self.expected_share_per_minute.into(),
+        ) {
+            Ok(target_u256) => target_u256,
+            Err(_) => {
+                return Err(StandardChannelError::InvalidNominalHashrate);
+            }
+        };
+
+        // debug hex of target_u256 and max_target
+        // just like in share validation
+        let mut target_bytes = target_u256.to_vec();
+        target_bytes.reverse(); // Convert to big-endian for display
+        let max_target_u256: binary_sv2::U256 = max_target.clone().into();
+        let mut max_target_bytes = max_target_u256.to_vec();
+        max_target_bytes.reverse(); // Convert to big-endian for display
+
+        // Get the old target for comparison on the debug log
+        // Not really needed for the actual method functionality
+        // But it's useful to have for debugging purposes
+        let old_target_u256: binary_sv2::U256 = self.target.clone().into();
+        let mut old_target_bytes = old_target_u256.to_vec();
+        old_target_bytes.reverse(); // Convert to big-endian for display
+
+        debug!(
+            "updating channel target \nold target:\t{}\nnew target:\t{}\nmax_target:\t{}",
+            bytes_to_hex(&old_target_bytes),
+            bytes_to_hex(&target_bytes),
+            bytes_to_hex(&max_target_bytes)
+        );
+
+        let new_target: Target = target_u256.into();
+
+        if new_target > max_target {
+            return Err(StandardChannelError::RequestedMaxTargetOutOfRange);
+        }
+
+        self.target = new_target;
+        self.nominal_hashrate = nominal_hashrate;
+        Ok(())
+    }
+
+    pub fn get_active_job(&self) -> Option<&StandardJob<'a>> {
+        self.active_job.as_ref()
+    }
+
+    pub fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32> {
+        &self.future_template_to_job_id
+    }
+
+    pub fn get_future_jobs(&self) -> &HashMap<u32, StandardJob<'a>> {
+        &self.future_jobs
+    }
+
+    pub fn get_past_jobs(&self) -> &HashMap<u32, StandardJob<'a>> {
+        &self.past_jobs
+    }
+
+    pub fn get_stale_jobs(&self) -> &HashMap<u32, StandardJob<'a>> {
+        &self.stale_jobs
+    }
+
+    pub fn get_share_accounting(&self) -> &ShareAccounting {
+        &self.share_accounting
+    }
+
+    /// Updates the channel state with a new job.
+    ///
+    /// Despite the name of this method, the input is not a template (like on [`ExtendedChannel`]).
+    /// That's because Standard Channels don't have a Job Factory, and they don't create jobs by
+    /// themselves.
+    ///
+    /// We expect an Extended Job to be created by a Job Factory for the Group Channel, then
+    /// converted into a Standard Job and passed to this method.
+    pub fn on_new_template(&mut self, new_job: StandardJob<'a>, template_id: u64) {
+        match new_job.is_future() {
+            true => {
+                let job_id = new_job.get_job_id();
+                self.future_jobs.insert(job_id, new_job);
+                self.future_template_to_job_id.insert(template_id, job_id);
+            }
+            false => {
+                // if there's already some active job, move it to the past jobs
+                // and set the new job as the active job
+                if let Some(active_job) = self.active_job.take() {
+                    self.past_jobs.insert(active_job.get_job_id(), active_job);
+                    self.active_job = Some(new_job);
+                } else {
+                    // if there's no active job, simply set the new job as the active job
+                    self.active_job = Some(new_job);
+                }
+            }
+        }
+    }
+
+    /// Updates the channel state with a new `SetNewPrevHash` message.
+    ///
+    /// If there are no future jobs, returns an error.
+    /// If there are future jobs, the active job is set to the job with the given `template_id`.
+    ///
+    /// All past jobs are cleared.
+    ///
+    /// The chain tip information is not kept in the channel state.
+    pub fn on_set_new_prev_hash(
+        &mut self,
+        set_new_prev_hash: SetNewPrevHash<'a>,
+    ) -> Result<(), StandardChannelError> {
+        match self.future_jobs.is_empty() {
+            true => {
+                return Err(StandardChannelError::TemplateIdNotFound);
+            }
+            false => {
+                // the SetNewPrevHash message was addressed to a specific future template
+                if !self
+                    .future_template_to_job_id
+                    .contains_key(&set_new_prev_hash.template_id)
+                {
+                    return Err(StandardChannelError::TemplateIdNotFound);
+                }
+
+                // move currently active job to past jobs (so it can be marked as stale)
+                let currently_active_job = self.active_job.take();
+                if let Some(active_job) = currently_active_job {
+                    self.past_jobs.insert(active_job.get_job_id(), active_job);
+                }
+
+                let future_job_id = self
+                    .future_template_to_job_id
+                    .remove(&set_new_prev_hash.template_id)
+                    .expect("future job must exist");
+
+                // activate the future job
+                let mut activated_job = self
+                    .future_jobs
+                    .remove(&future_job_id)
+                    .expect("future job must exist");
+
+                activated_job.activate(set_new_prev_hash.header_timestamp);
+
+                self.active_job = Some(activated_job);
+            }
+        }
+
+        // mark all past jobs as stale, so that shares can be rejected with the appropriate error
+        // code
+        self.stale_jobs = self.past_jobs.clone();
+
+        // clear past jobs, as we're no longer going to validate shares for them
+        self.past_jobs.clear();
+
+        Ok(())
+    }
+
+    /// Validates a share.
+    ///
+    /// Updates the channel state with the result of the share validation.
+    pub fn validate_share(
+        &mut self,
+        share: SubmitSharesStandard,
+        chain_tip: ChainTip,
+    ) -> Result<ShareValidationResult, ShareValidationError> {
+        let job_id = share.job_id;
+
+        // check if job_id is active job
+        let is_active_job = self
+            .active_job
+            .as_ref()
+            .is_some_and(|job| job.get_job_id() == job_id);
+
+        // check if job_id is past job
+        let is_past_job = self.past_jobs.contains_key(&job_id);
+
+        // check if job_id is stale job
+        let is_stale_job = self.stale_jobs.contains_key(&job_id);
+
+        if is_stale_job {
+            return Err(ShareValidationError::Stale);
+        }
+
+        // if job_id is not active, past or stale, return error
+        if !is_active_job && !is_past_job && !is_stale_job {
+            return Err(ShareValidationError::InvalidJobId);
+        }
+
+        let job = if is_active_job {
+            self.active_job.as_ref().expect("active job must exist")
+        } else if is_past_job {
+            self.past_jobs.get(&job_id).expect("past job must exist")
+        } else {
+            self.stale_jobs.get(&job_id).expect("stale job must exist")
+        };
+
+        let merkle_root: [u8; 32] = job
+            .get_merkle_root()
+            .inner_as_ref()
+            .try_into()
+            .expect("merkle root must be 32 bytes");
+
+        let prev_hash = chain_tip.prev_hash();
+        let nbits = CompactTarget::from_consensus(chain_tip.nbits());
+
+        // create the header for validation
+        let header = Header {
+            version: Version::from_consensus(share.version as i32),
+            prev_blockhash: u256_to_block_hash(prev_hash.clone()),
+            merkle_root: (*Hash::from_bytes_ref(&merkle_root)).into(),
+            time: share.ntime,
+            bits: nbits,
+            nonce: share.nonce,
+        };
+
+        // convert the header hash to a target type for easy comparison
+        let hash = header.block_hash();
+        let raw_hash: [u8; 32] = *hash.to_raw_hash().as_ref();
+        let hash_as_target: Target = raw_hash.into();
+        let hash_as_diff = target_to_difficulty(hash_as_target.clone());
+        let network_target = BitcoinTarget::from_compact(nbits);
+
+        // print hash_as_target and self.target as human readable hex
+        let hash_as_u256: binary_sv2::U256 = hash_as_target.clone().into();
+        let mut hash_bytes = hash_as_u256.to_vec();
+        hash_bytes.reverse(); // Convert to big-endian for display
+        let target_u256: binary_sv2::U256 = self.target.clone().into();
+        let mut target_bytes = target_u256.to_vec();
+        target_bytes.reverse(); // Convert to big-endian for display
+
+        debug!(
+            "share validation \nshare:\t\t{}\nchannel target:\t{}\nnetwork target:\t{}",
+            bytes_to_hex(&hash_bytes),
+            bytes_to_hex(&target_bytes),
+            format!("{:x}", network_target)
+        );
+
+        // check if a block was found
+        if network_target.is_met_by(hash) {
+            self.share_accounting.update_share_accounting(
+                target_to_difficulty(self.target.clone()) as u64,
+                share.sequence_number,
+                hash.to_raw_hash(),
+            );
+
+            match job.get_origin() {
+                JobOrigin::NewTemplate(template) => {
+                    let mut script_sig = template.coinbase_prefix.to_vec();
+                    script_sig.extend(job.get_extranonce_prefix());
+
+                    let tx_in = TxIn {
+                        previous_output: OutPoint::null(),
+                        script_sig: script_sig.into(),
+                        sequence: Sequence(template.coinbase_tx_input_sequence),
+                        witness: Witness::from(vec![vec![0; 32]]),
+                    };
+
+                    let coinbase = Transaction {
+                        version: TxVersion::non_standard(template.coinbase_tx_version as i32),
+                        lock_time: LockTime::from_consensus(template.coinbase_tx_locktime),
+                        input: vec![tx_in],
+                        output: job.get_coinbase_outputs().to_vec(),
+                    };
+                    let mut serialized_coinbase = Vec::new();
+                    coinbase
+                        .consensus_encode(&mut serialized_coinbase)
+                        .map_err(|_| ShareValidationError::InvalidCoinbase)?;
+
+                    return Ok(ShareValidationResult::BlockFound(
+                        Some(template.template_id),
+                        serialized_coinbase,
+                    ));
+                }
+                JobOrigin::SetCustomMiningJob(custom_job) => {
+                    let mut script_sig = custom_job.coinbase_prefix.to_vec();
+                    script_sig.extend(job.get_extranonce_prefix());
+
+                    let tx_in = TxIn {
+                        previous_output: OutPoint::null(),
+                        script_sig: script_sig.into(),
+                        sequence: Sequence(custom_job.coinbase_tx_input_n_sequence),
+                        witness: Witness::from(vec![vec![0; 32]]),
+                    };
+
+                    let coinbase = Transaction {
+                        version: TxVersion::non_standard(custom_job.coinbase_tx_version as i32),
+                        lock_time: LockTime::from_consensus(custom_job.coinbase_tx_locktime),
+                        input: vec![tx_in],
+                        output: job.get_coinbase_outputs().to_vec(),
+                    };
+                    let mut serialized_coinbase = Vec::new();
+                    coinbase
+                        .consensus_encode(&mut serialized_coinbase)
+                        .map_err(|_| ShareValidationError::InvalidCoinbase)?;
+
+                    return Ok(ShareValidationResult::BlockFound(None, serialized_coinbase));
+                }
+            }
+        }
+
+        // check if the share hash meets the channel target
+        if hash_as_target <= self.target {
+            if self.share_accounting.is_share_seen(hash.to_raw_hash()) {
+                return Err(ShareValidationError::DuplicateShare);
+            }
+
+            self.share_accounting.update_share_accounting(
+                target_to_difficulty(self.target.clone()) as u64,
+                share.sequence_number,
+                hash.to_raw_hash(),
+            );
+
+            // update the best diff
+            self.share_accounting.update_best_diff(hash_as_diff);
+
+            let last_sequence_number = self.share_accounting.get_last_share_sequence_number();
+            let new_submits_accepted_count = self.share_accounting.get_shares_accepted();
+            let new_shares_sum = self.share_accounting.get_share_work_sum();
+
+            // if sequence number is a multiple of share_batch_size
+            // it's time to send a SubmitShares.Success
+            if self.share_accounting.should_acknowledge() {
+                Ok(ShareValidationResult::ValidWithAcknowledgement(
+                    last_sequence_number,
+                    new_submits_accepted_count,
+                    new_shares_sum,
+                ))
+            } else {
+                Ok(ShareValidationResult::Valid)
+            }
+        } else {
+            Err(ShareValidationError::DoesNotMeetTarget)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::channels::server::{
+        error::StandardChannelError,
+        group::GroupChannel,
+        jobs::chain_tip::ChainTip,
+        share_accounting::{ShareValidationError, ShareValidationResult},
+        standard::StandardChannel,
+    };
+    use binary_sv2::Sv2Option;
+    use mining_sv2::{NewMiningJob, SubmitSharesStandard, Target};
+    use std::convert::TryInto;
+    use stratum_common::bitcoin::{transaction::TxOut, Amount, ScriptBuf};
+    use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
+
+    const SATS_AVAILABLE_IN_TEMPLATE: u64 = 5000000000;
+
+    #[test]
+    fn test_future_job_activation_flow() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let standard_channel_id = 2;
+        let user_identity = "user_identity".to_string();
+
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+
+        let max_target: Target = [0xff; 32].into();
+        let nominal_hashrate = 10.0;
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+
+        let mut standard_channel = StandardChannel::new(
+            standard_channel_id,
+            user_identity,
+            extranonce_prefix.clone(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967294,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 158,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        assert!(group_channel.get_future_jobs().is_empty());
+        assert!(standard_channel.get_future_jobs().is_empty());
+
+        group_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs, None)
+            .unwrap();
+
+        let future_extended_job_id = group_channel
+            .get_future_template_to_job_id()
+            .get(&template.template_id)
+            .unwrap();
+
+        let future_extended_job = group_channel
+            .get_future_jobs()
+            .get(future_extended_job_id)
+            .unwrap();
+
+        let future_standard_job = future_extended_job
+            .clone()
+            .into_standard_job(standard_channel_id, extranonce_prefix);
+
+        standard_channel.on_new_template(future_standard_job, template.template_id);
+
+        let expected_future_standard_job = NewMiningJob {
+            channel_id: standard_channel_id,
+            job_id: 1,
+            merkle_root: [
+                189, 200, 25, 246, 119, 73, 34, 42, 209, 112, 237, 50, 169, 71, 163, 192, 24, 84,
+                56, 86, 147, 71, 243, 44, 18, 107, 167, 169, 169, 66, 186, 98,
+            ]
+            .into(),
+            version: 536870912,
+            min_ntime: Sv2Option::new(None),
+        };
+
+        let future_standard_job_from_channel =
+            standard_channel.get_future_jobs().get(&1).unwrap().clone();
+        assert_eq!(
+            future_standard_job_from_channel.get_job_message(),
+            &expected_future_standard_job
+        );
+
+        let ntime = 1747092633;
+        let set_new_prev_hash = SetNewPrevHashTdp {
+            template_id: template.template_id,
+            prev_hash: [
+                200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144,
+                205, 88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+            ]
+            .into(),
+            header_timestamp: ntime,
+            n_bits: 503543726,
+            target: [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                174, 119, 3, 0, 0,
+            ]
+            .into(),
+        };
+
+        standard_channel
+            .on_set_new_prev_hash(set_new_prev_hash)
+            .unwrap();
+        let mut previously_future_job = future_standard_job_from_channel.clone();
+        previously_future_job.activate(ntime);
+
+        let activated_job = standard_channel.get_active_job().unwrap();
+
+        // assert that the activated job is the same as the previously future job
+        assert_eq!(
+            activated_job.get_job_message(),
+            previously_future_job.get_job_message()
+        );
+    }
+
+    #[test]
+    fn test_non_future_job_creation_flow() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let standard_channel_id = 2;
+        let user_identity = "user_identity".to_string();
+
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+
+        let max_target: Target = [0xff; 32].into();
+        let nominal_hashrate = 10.0;
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+
+        let mut standard_channel = StandardChannel::new(
+            standard_channel_id,
+            user_identity,
+            extranonce_prefix.clone(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        let ntime = 1747092633;
+        let prev_hash = [
+            200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144, 205,
+            88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+        ]
+        .into();
+        let nbits = 503543726;
+
+        let chain_tip = ChainTip::new(prev_hash, nbits, ntime);
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967294,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 158,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // this is a non-future template, so we must provide a chain_tip
+        assert!(group_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs.clone(), None)
+            .is_err());
+        group_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs, Some(chain_tip))
+            .unwrap();
+
+        assert!(group_channel.get_future_jobs().is_empty());
+
+        let active_extended_job = group_channel.get_active_job().unwrap();
+        let active_standard_job = active_extended_job
+            .clone()
+            .into_standard_job(standard_channel_id, extranonce_prefix);
+
+        standard_channel.on_new_template(active_standard_job.clone(), template.template_id);
+
+        let expected_active_standard_job = NewMiningJob {
+            channel_id: standard_channel_id,
+            job_id: 1,
+            merkle_root: [
+                189, 200, 25, 246, 119, 73, 34, 42, 209, 112, 237, 50, 169, 71, 163, 192, 24, 84,
+                56, 86, 147, 71, 243, 44, 18, 107, 167, 169, 169, 66, 186, 98,
+            ]
+            .into(),
+            version: 536870912,
+            min_ntime: Sv2Option::new(Some(ntime)),
+        };
+
+        let active_standard_job_from_channel = standard_channel.get_active_job().unwrap().clone();
+
+        assert_eq!(
+            active_standard_job_from_channel.get_job_message(),
+            &expected_active_standard_job
+        );
+    }
+
+    #[test]
+    fn test_share_validation_block_found() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let standard_channel_id = 2;
+        let user_identity = "user_identity".to_string();
+
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target: Target = [0xff; 32].into();
+        let nominal_hashrate = 1.0;
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+
+        let mut standard_channel = StandardChannel::new(
+            standard_channel_id,
+            user_identity,
+            extranonce_prefix.clone(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // channel target: 04325c53ef368eb04325c53ef368eb04325c53ef368eb04325c53ef368eb0431
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967294,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 158,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // network target: 7fffff0000000000000000000000000000000000000000000000000000000000
+        let ntime = 1745596910;
+        let prev_hash = [
+            251, 175, 106, 40, 35, 87, 122, 90, 58, 51, 78, 32, 202, 236, 228, 36, 154, 174, 206,
+            144, 147, 195, 21, 224, 195, 103, 214, 189, 51, 190, 24, 98,
+        ]
+        .into();
+        let n_bits = 545259519;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        // prepare group channel with non-future job
+        group_channel
+            .on_new_template(
+                template.clone(),
+                coinbase_reward_outputs,
+                Some(chain_tip.clone()),
+            )
+            .unwrap();
+
+        let active_extended_job = group_channel.get_active_job().unwrap();
+        let active_standard_job = active_extended_job
+            .clone()
+            .into_standard_job(standard_channel_id, extranonce_prefix);
+
+        // prepare standard channel with non-future job
+        standard_channel.on_new_template(active_standard_job.clone(), template.template_id);
+
+        // this share has hash 40b4c57b2c65052bbe1092e556146ad78cdd9e5ffaeff856a0eb54ee7b816da7
+        // which satisfied the network target
+        // 7fffff0000000000000000000000000000000000000000000000000000000000
+        let share_valid_block = SubmitSharesStandard {
+            channel_id: standard_channel_id,
+            sequence_number: 0,
+            job_id: active_standard_job.get_job_id(),
+            nonce: 3,
+            ntime: 1745596932,
+            version: 536870912,
+        };
+
+        let res = standard_channel.validate_share(share_valid_block, chain_tip.clone());
+
+        assert!(matches!(res, Ok(ShareValidationResult::BlockFound(_, _))));
+    }
+
+    #[test]
+    fn test_share_validation_does_not_meet_target() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let standard_channel_id = 2;
+        let user_identity = "user_identity".to_string();
+
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target: Target = [0xff; 32].into();
+        let nominal_hashrate = 100.0; // bigger hashrate to get higher difficulty
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+
+        let mut standard_channel = StandardChannel::new(
+            standard_channel_id,
+            user_identity,
+            extranonce_prefix.clone(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // channel target: 000aebbc990fff5144366f000aebbc990fff5144366f000aebbc990fff514435
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967294,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 158,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // network target: 000000000000d7c0000000000000000000000000000000000000000000000000
+        let ntime = 1745596910;
+        let prev_hash = [
+            154, 124, 239, 231, 221, 122, 160, 173, 164, 175, 87, 33, 74, 214, 191, 107, 73, 34, 0,
+            162, 227, 16, 44, 40, 33, 73, 0, 0, 0, 0, 0, 0,
+        ]
+        .into();
+        let n_bits = 453040064;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        // prepare group channel with non-future job
+        group_channel
+            .on_new_template(
+                template.clone(),
+                coinbase_reward_outputs,
+                Some(chain_tip.clone()),
+            )
+            .unwrap();
+
+        let active_extended_job = group_channel.get_active_job().unwrap();
+        let active_standard_job = active_extended_job
+            .clone()
+            .into_standard_job(standard_channel_id, extranonce_prefix);
+
+        // prepare standard channel with non-future job
+        standard_channel.on_new_template(active_standard_job.clone(), template.template_id);
+
+        // this share has hash a5b65006d89dab9de2b23ececd3b0435f163607f7da1ba2f0bcde62b29e8cd44
+        // which does not meet the channel target
+        // 000aebbc990fff5144366f000aebbc990fff5144366f000aebbc990fff514435
+        let share_low_diff = SubmitSharesStandard {
+            channel_id: standard_channel_id,
+            sequence_number: 0,
+            job_id: active_standard_job.get_job_id(),
+            nonce: 3,
+            ntime: 1745596932,
+            version: 536870912,
+        };
+
+        let res = standard_channel.validate_share(share_low_diff, chain_tip.clone());
+
+        assert!(matches!(
+            res.unwrap_err(),
+            ShareValidationError::DoesNotMeetTarget
+        ));
+    }
+
+    #[test]
+    fn test_share_validation_valid_share() {
+        // note:
+        // the messages on this test were collected from a sane message flow
+        // we use them as test vectors to assert correct behavior of job creation
+        let group_channel_id = 1;
+
+        let mut group_channel = GroupChannel::new(group_channel_id);
+
+        let standard_channel_id = 2;
+        let user_identity = "user_identity".to_string();
+
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target: Target = [0xff; 32].into();
+        let nominal_hashrate = 1_000.0; // bigger hashrate to get higher difficulty
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+
+        let mut standard_channel = StandardChannel::new(
+            standard_channel_id,
+            user_identity,
+            extranonce_prefix.clone(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // channel target is:
+        // 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967294,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 158,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // network target: 000000000000d7c0000000000000000000000000000000000000000000000000
+        let ntime = 1745596910;
+        let prev_hash = [
+            154, 124, 239, 231, 221, 122, 160, 173, 164, 175, 87, 33, 74, 214, 191, 107, 73, 34, 0,
+            162, 227, 16, 44, 40, 33, 73, 0, 0, 0, 0, 0, 0,
+        ]
+        .into();
+        let n_bits = 453040064;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        // prepare group channel with non-future job
+        group_channel
+            .on_new_template(
+                template.clone(),
+                coinbase_reward_outputs,
+                Some(chain_tip.clone()),
+            )
+            .unwrap();
+
+        let active_extended_job = group_channel.get_active_job().unwrap();
+        let active_standard_job = active_extended_job
+            .clone()
+            .into_standard_job(standard_channel_id, extranonce_prefix);
+
+        // prepare standard channel with non-future job
+        standard_channel.on_new_template(active_standard_job.clone(), template.template_id);
+
+        // this share has hash 000010dcb838b589e5b0365350425ea82f368d330616f783d32dadf9b497bd02
+        // which does meet the channel target
+        // 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205
+        // but does not meet network target
+        // 000000000000d7c0000000000000000000000000000000000000000000000000
+        let valid_share = SubmitSharesStandard {
+            channel_id: standard_channel_id,
+            sequence_number: 1,
+            job_id: 1,
+            nonce: 31978,
+            ntime: 1745611105,
+            version: 536870912,
+        };
+        let res = standard_channel.validate_share(valid_share, chain_tip.clone());
+
+        assert!(matches!(res, Ok(ShareValidationResult::Valid)));
+    }
+
+    #[test]
+    fn test_update_channel() {
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let expected_share_per_minute = 1.0;
+        let initial_hashrate = 10.0;
+        let share_batch_size = 100;
+
+        // this is the most permissive possible max_target
+        let max_target: Target = [0xff; 32].into();
+
+        // Create a channel with initial hashrate
+        let mut channel = StandardChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            max_target.clone(),
+            initial_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        // Get the initial target
+        let initial_target = channel.get_target().clone();
+
+        // Update the channel with a new hashrate (higher)
+        let new_hashrate = 100.0;
+        channel
+            .update_channel(new_hashrate, max_target.clone())
+            .unwrap();
+
+        // Get the new target after update
+        let new_target = channel.get_target().clone();
+
+        // The target should be different after updating with a different hashrate
+        // old target: 006d0b803685c01b42e00da17006d0b803685c01b42e00da17006d0b803685bf
+        // new target: 000aebbc990fff5144366f000aebbc990fff5144366f000aebbc990fff514435
+        assert_ne!(initial_target, new_target);
+
+        // The nominal hashrate should be updated
+        assert_eq!(channel.get_nominal_hashrate(), new_hashrate);
+
+        // Test invalid hashrate (negative)
+        let result = channel.update_channel(-1.0, max_target.clone());
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(StandardChannelError::InvalidNominalHashrate)
+        ));
+
+        // Create a not so permissive max_target so we can test a target that exceeds it
+        let not_so_permissive_max_target: Target = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0x00,
+        ]
+        .into();
+
+        // Try to update with a hashrate that would result in a target exceeding the max_target
+        // new target: 2492492492492492492492492492492492492492492492492492492492492491
+        // max target: 00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        let very_small_hashrate = 0.1;
+        let result =
+            channel.update_channel(very_small_hashrate, not_so_permissive_max_target.clone());
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(StandardChannelError::RequestedMaxTargetOutOfRange)
+        ));
+
+        // Test successful update with not_so_permissive_max_target
+        // new target: 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205
+        // max target: 00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        let sufficiently_big_hashrate = 1000.0;
+        let result =
+            channel.update_channel(sufficiently_big_hashrate, not_so_permissive_max_target);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_update_extranonce_prefix() {
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = [0xff; 32].into();
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 1_000.0;
+        let share_batch_size = 100;
+
+        let mut channel = StandardChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix.clone(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+        )
+        .unwrap();
+
+        let current_extranonce_prefix = channel.get_extranonce_prefix();
+        assert_eq!(current_extranonce_prefix, &extranonce_prefix);
+
+        let new_extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+        ]
+        .to_vec();
+
+        channel.set_extranonce_prefix(new_extranonce_prefix.clone());
+        let current_extranonce_prefix = channel.get_extranonce_prefix();
+        assert_eq!(current_extranonce_prefix, &new_extranonce_prefix);
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -4,9 +4,11 @@
 //! module. It includes the [`Error`] enum for representing various errors.
 
 use crate::{
-    common_properties::CommonDownstreamData, parsers::AnyMessage as AllMessages, utils::InputError,
+    channels::server::error::StandardChannelError, common_properties::CommonDownstreamData,
+    parsers::AnyMessage as AllMessages, utils::InputError,
 };
 use binary_sv2::Error as BinarySv2Error;
+use mining_sv2::ExtendedExtranonceError;
 use std::{
     fmt::{self, Display, Formatter},
     sync::{MutexGuard, PoisonError},
@@ -112,6 +114,10 @@ pub enum Error {
     JDSMissingTransactions,
     IoError(std::io::Error),
     FromSliceError(FromSliceError),
+    /// Invalid user identity
+    InvalidUserIdentity(String),
+    ExtranoncePrefixFactoryError(ExtendedExtranonceError),
+    FailedToCreateStandardChannel(StandardChannelError),
 }
 
 impl From<BinarySv2Error> for Error {
@@ -215,6 +221,9 @@ impl Display for Error {
             IoError(e) => write!(f, "IO error: {:?}", e),
             ExtendedExtranonceCreationFailed(e) => write!(f, "Failed to create ExtendedExtranonce: {}", e),
             FromSliceError(e) => write!(f, "Failed to hash from slice: {}", e),
+            InvalidUserIdentity(e) => write!(f, "Invalid user identity: {}", e),
+            ExtranoncePrefixFactoryError(e) => write!(f, "Failed to create ExtranoncePrefixFactory: {:?}", e),
+            FailedToCreateStandardChannel(e) => write!(f, "Failed to create StandardChannel: {:?}", e), 
         }
     }
 }

--- a/protocols/v2/roles-logic-sv2/src/lib.rs
+++ b/protocols/v2/roles-logic-sv2/src/lib.rs
@@ -18,6 +18,7 @@
 //!
 //! - `prop_test`: Enables support for property testing in [`template_distribution_sv2`] crate.
 pub mod channel_logic;
+pub mod channels;
 pub mod common_properties;
 pub mod errors;
 pub mod handlers;

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -206,6 +206,17 @@ pub fn merkle_root_from_path_<T: AsRef<[u8]>>(coinbase_id: [u8; 32], path: &[T])
     }
 }
 
+// Helper function to format bytes as hex string
+// useful for visualizing targets
+pub fn bytes_to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        write!(&mut s, "{:02x}", b)
+            .expect("Writing hex bytes to pre-allocated string should never fail");
+    }
+    s
+}
+
 // Computes the Merkle root by iteratively combining the coinbase transaction hash with each
 // transaction hash in the `path`.
 //

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -13,6 +13,7 @@ use primitive_types::U256 as U256Primitive;
 use std::{
     cmp::max,
     convert::TryInto,
+    fmt::Write,
     ops::Div,
     sync::{Mutex as Mutex_, MutexGuard, PoisonError},
 };
@@ -21,8 +22,10 @@ use stratum_common::{
     bitcoin::{
         blockdata::block::{Header, Version},
         consensus,
+        consensus::Decodable,
         hash_types::{BlockHash, TxMerkleNode},
         hashes::{sha256d::Hash as DHash, Hash},
+        transaction::TxOut,
         CompactTarget, Transaction,
     },
 };
@@ -229,6 +232,36 @@ fn reduce_path<T: AsRef<[u8]>>(coinbase_id: [u8; 32], path: &[T]) -> [u8; 32] {
         root = *hash.as_ref();
     }
     root
+}
+
+/// Deserializes a list of outputs from a serialized format.
+pub fn deserialize_outputs(serialized_outputs: Vec<u8>) -> Vec<TxOut> {
+    let mut deserialized_outputs: Vec<TxOut> = vec![];
+
+    // The serialized outputs are in Bitcoin consensus format
+    // We need to parse them one by one, keeping track of cursor position
+    let mut cursor = 0;
+    let mut txouts = &serialized_outputs[cursor..];
+
+    // Iteratively decode each TxOut until we can't decode any more
+    while let Ok(out) = TxOut::consensus_decode(&mut txouts) {
+        // Calculate the size of this TxOut based on its script_pubkey length
+        // 8 bytes for value + variable bytes for script_pubkey length
+        // For small scripts (0-252 bytes): 1 byte length prefix
+        // For medium scripts (253-1000000 bytes): 3 byte length prefix (1 marker + 2 byte
+        // length)
+        let len = match out.script_pubkey.len() {
+            a @ 0..=252 => 8 + 1 + a,       // 8 (value) + 1 (compact size) + script_len
+            a @ 253..=1000000 => 8 + 3 + a, // 8 (value) + 3 (compact size) + script_len
+            _ => break,                     // Unreasonably large script, likely an error
+        };
+
+        // Move the cursor forward by the size of this TxOut
+        cursor += len;
+        deserialized_outputs.push(out);
+    }
+
+    deserialized_outputs
 }
 
 /// A list of potential errors during conversion between hashrate and target

--- a/protocols/v2/subprotocols/mining/src/lib.rs
+++ b/protocols/v2/subprotocols/mining/src/lib.rs
@@ -62,7 +62,8 @@ pub use submit_shares::{
     SubmitSharesError, SubmitSharesExtended, SubmitSharesStandard, SubmitSharesSuccess,
 };
 pub use update_channel::{UpdateChannel, UpdateChannelError};
-const MAX_EXTRANONCE_LEN: usize = 32;
+
+pub const MAX_EXTRANONCE_LEN: usize = 32;
 
 /// Target is a 256-bit unsigned integer in little-endian
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
partially addresses #1630 

so far, the APIs were designed and tested for server side functionality, namely Sv2 Pool Servers and Sv2 Job Declaration Clients (in other words, roles that actively create jobs from templates and custom jobs)

client side functionality (for Sv2 Mining Devices and Proxies) will require a follow-up PR

---

- [x] extended channel APIs (missing coinbase validation for custom job [#133@sv2-spec](https://github.com/stratum-mining/sv2-spec/issues/133))
- [x] extended job APIs
- [x] extended channel unit tests (missing coinbase validation for custom job [#133@sv2-spec](https://github.com/stratum-mining/sv2-spec/issues/133))
- [x] standard channel APIs
- [x] standard job APIs
- [x] standard channel unit tests
- [x] group channel APIs
- [x] group channel unit tests