### PR TITLE
remove redundant map_err's in translators

### DIFF
--- a/roles/translator/src/lib/error.rs
+++ b/roles/translator/src/lib/error.rs
@@ -8,10 +8,11 @@
 //! - A specific `ChannelSendError` enum for errors occurring during message sending over
 //!   asynchronous channels.
 
+use codec_sv2::Frame;
 use ext_config::ConfigError;
 use roles_logic_sv2::{
     mining_sv2::{ExtendedExtranonce, NewExtendedMiningJob, SetCustomMiningJob},
-    parsers::Mining,
+    parsers::{AnyMessage, Mining},
 };
 use std::{fmt, sync::PoisonError};
 use v1::server_to_client::{Notify, SetDifficulty};
@@ -299,5 +300,15 @@ impl From<std::convert::Infallible> for Error<'_> {
 impl<'a> From<Mining<'a>> for Error<'a> {
     fn from(e: Mining<'a>) -> Self {
         Error::Sv2ProtocolError(e)
+    }
+}
+
+impl From<async_channel::SendError<Frame<AnyMessage<'_>, codec_sv2::buffer_sv2::Slice>>>
+    for Error<'_>
+{
+    fn from(
+        value: async_channel::SendError<Frame<AnyMessage<'_>, codec_sv2::buffer_sv2::Slice>>,
+    ) -> Self {
+        Error::ChannelErrorSender(ChannelSendError::General(value.to_string()))
     }
 }

--- a/roles/translator/src/lib/upstream_sv2/upstream_connection.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream_connection.rs
@@ -25,11 +25,7 @@ impl UpstreamConnection {
     /// Send a SV2 message to the Upstream role
     pub async fn send(&mut self, sv2_frame: StdFrame) -> ProxyResult<'static, ()> {
         let either_frame = sv2_frame.into();
-        self.sender.send(either_frame).await.map_err(|e| {
-            super::super::error::Error::ChannelErrorSender(
-                super::super::error::ChannelSendError::General(e.to_string()),
-            )
-        })?;
+        self.sender.send(either_frame).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Partially Resolves: #736
This PR is part of an effort to improve error handling in the translator. Currently, there are several redundant .map_err calls in the codebase, which make the code harder to read. This PR removes many of them. However, not all instances could be removed due to the use of non-Send types like MutexGuard errors, which cannot be used in Send contexts (e.g., in tokio::spawn). Addressing these cases will require more targeted changes, which we can defer until we work on those parts of the codebase.