### PR TITLE
Allow specifying descriptors (including `raw` and `addr`) as coinbase outputs

### DIFF
--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -1637,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.2"
+version = "12.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0760e92feaf4ee26bd2e616f557de64712bf1e75f3b1b218dfb475c0a84c7943"
+checksum = "a1eeb3bbebc87062b99fbb8c9067d30dab85469f4cf12248a2667777cc86b282"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/roles/jd-client/config-examples/jdc-config-hosted-example.toml
+++ b/roles/jd-client/config-examples/jdc-config-hosted-example.toml
@@ -26,18 +26,13 @@ tp_authority_public_key = "9bwHCYnjhbHm4AS3pWg9MtAH83mzWohoJJJDELYBqZhDNqszDLc"
 jdc_signature = "JDC"
 
 # Solo Mining config
-# List of coinbase outputs used to build the coinbase tx in case of Solo Mining (as last-resort solution of the pools fallback system)
-# ! Put your Extended Public Key or Script as output_script_value !
-# ! Right now only one output is supported, so comment all the ones you don't need !
-# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.  
-coinbase_outputs = [
-    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-]
+# Coinbase output used to build the coinbase tx in case of Solo Mining (as last-resort solution of the pools fallback system)
+#
+# Coinbase outputs are specified as descriptors. A full list of descriptors is available at
+#     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
+# Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
+# will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+coinbase_output = "addr(tb1qa0sm0hxzj0x25rh8gw5xlzwlsfvvyz8u96w3p8)"
 
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.

--- a/roles/jd-client/config-examples/jdc-config-local-example.toml
+++ b/roles/jd-client/config-examples/jdc-config-local-example.toml
@@ -25,18 +25,13 @@ tp_address = "127.0.0.1:8442"
 jdc_signature = "JDC"
 
 # Solo Mining config
-# List of coinbase outputs used to build the coinbase tx in case of Solo Mining (as last-resort solution of the pools fallback system)
-# ! Put your Extended Public Key or Script as output_script_value !
-# ! Right now only one output is supported, so comment all the ones you don't need !
-# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.  
-coinbase_outputs = [
-    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-]
+# Coinbase output used to build the coinbase tx in case of Solo Mining (as last-resort solution of the pools fallback system)
+#
+# Coinbase outputs are specified as descriptors. A full list of descriptors is available at
+#     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
+# Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
+# will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+coinbase_output = "addr(tb1qa0sm0hxzj0x25rh8gw5xlzwlsfvvyz8u96w3p8)"
 
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.

--- a/roles/jd-client/src/lib/config.rs
+++ b/roles/jd-client/src/lib/config.rs
@@ -159,7 +159,7 @@ impl JobDeclaratorClientConfig {
     pub fn get_txout(&self) -> Result<Vec<TxOut>, config_helpers::CoinbaseOutputError> {
         let mut result = Vec::new();
         for coinbase_output_pool in &self.coinbase_outputs {
-            let output_script = coinbase_output_pool.clone().try_into()?;
+            let output_script = coinbase_output_pool.script_pubkey().to_owned();
             result.push(TxOut {
                 value: Amount::from_sat(0),
                 script_pubkey: output_script,

--- a/roles/jd-client/src/lib/config.rs
+++ b/roles/jd-client/src/lib/config.rs
@@ -56,6 +56,7 @@ pub struct JobDeclaratorClientConfig {
     timeout: Duration,
     /// A list of coinbase outputs to be included in the block templates.
     /// This is only used during solo-mining.
+    #[serde(alias = "coinbase_output")] // only one is allowed, so don't make the user type the plural
     #[serde(deserialize_with = "config_helpers::deserialize_vec_exactly_1")]
     coinbase_outputs: Vec<CoinbaseOutput>,
     /// A signature string identifying this JDC instance.

--- a/roles/jd-client/src/lib/mod.rs
+++ b/roles/jd-client/src/lib/mod.rs
@@ -233,7 +233,7 @@ impl JobDeclaratorClient {
         task_collector: Arc<Mutex<Vec<AbortHandle>>>,
         shutdown: Arc<Notify>,
     ) {
-        let miner_tx_out = config.get_txout().expect("Failed to get txout");
+        let miner_tx_out = config.get_txout();
 
         // Spawn the downstream listener task. In solo mode, `upstream` and `jd` are `None`.
         let downstream_handle = tokio::spawn(downstream::listen_for_downstream_mining(
@@ -245,7 +245,7 @@ impl JobDeclaratorClient {
             config.cert_validity_sec(),
             task_collector.clone(),
             tx_status.clone(),
-            miner_tx_out.clone(),
+            miner_tx_out,
             None,
             config.clone(),
             shutdown,

--- a/roles/jd-server/config-examples/jds-config-hosted-example.toml
+++ b/roles/jd-server/config-examples/jds-config-hosted-example.toml
@@ -6,17 +6,11 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-# List of coinbase outputs used to build the coinbase tx
-# ! Right now only one output is supported, so comment all the ones you don't need !
-# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.  
-coinbase_outputs = [
-    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-]
+# Coinbase outputs are specified as descriptors. A full list of descriptors is available at
+#     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
+# Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
+# will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+coinbase_output = "addr(tb1qa0sm0hxzj0x25rh8gw5xlzwlsfvvyz8u96w3p8)"
 
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.

--- a/roles/jd-server/config-examples/jds-config-local-example.toml
+++ b/roles/jd-server/config-examples/jds-config-local-example.toml
@@ -6,17 +6,11 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-# List of coinbase outputs used to build the coinbase tx
-# ! Right now only one output is supported, so comment all the ones you don't need !
-# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.  
-coinbase_outputs = [
-    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-]
+# Coinbase outputs are specified as descriptors. A full list of descriptors is available at
+#     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
+# Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
+# will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+coinbase_output = "addr(tb1qa0sm0hxzj0x25rh8gw5xlzwlsfvvyz8u96w3p8)"
 
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.

--- a/roles/jd-server/src/lib/config.rs
+++ b/roles/jd-server/src/lib/config.rs
@@ -223,11 +223,10 @@ mod tests {
         let config = load_config("config-examples/jds-config-hosted-example.toml");
         let outputs = config.get_txout().expect("Failed to get coinbase output");
 
-        let expected_output = CoinbaseOutput {
-            output_script_type: "P2WPKH".to_string(),
-            output_script_value:
-                "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
-        };
+        let expected_output = CoinbaseOutput::new(
+            "P2WPKH".to_string(),
+            "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
+        );
         let expected_script: ScriptBuf = expected_output.try_into().unwrap();
         let expected_transaction_output = TxOut {
             value: Amount::from_sat(0),
@@ -296,11 +295,10 @@ mod tests {
     fn get_txout_supported_output_script_types() {
         let config = load_config("config-examples/jds-config-hosted-example.toml");
         let outputs = config.get_txout().expect("Failed to get coinbase output");
-        let expected_output = CoinbaseOutput {
-            output_script_type: "P2WPKH".to_string(),
-            output_script_value:
-                "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
-        };
+        let expected_output = CoinbaseOutput::new(
+            "P2WPKH".to_string(),
+            "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
+        );
         let expected_script: ScriptBuf = expected_output.try_into().unwrap();
         let expected_transaction_output = TxOut {
             value: Amount::from_sat(0),

--- a/roles/jd-server/src/lib/config.rs
+++ b/roles/jd-server/src/lib/config.rs
@@ -28,6 +28,7 @@ pub struct JobDeclaratorServerConfig {
     authority_public_key: Secp256k1PublicKey,
     authority_secret_key: Secp256k1SecretKey,
     cert_validity_sec: u64,
+    #[serde(alias = "coinbase_output")] // only one is allowed, so don't make the user type the plural
     #[serde(deserialize_with = "config_helpers::deserialize_vec_exactly_1")]
     coinbase_outputs: Vec<CoinbaseOutput>,
     core_rpc_url: String,

--- a/roles/jd-server/src/lib/config.rs
+++ b/roles/jd-server/src/lib/config.rs
@@ -28,6 +28,7 @@ pub struct JobDeclaratorServerConfig {
     authority_public_key: Secp256k1PublicKey,
     authority_secret_key: Secp256k1SecretKey,
     cert_validity_sec: u64,
+    #[serde(deserialize_with = "config_helpers::deserialize_vec_exactly_1")]
     coinbase_outputs: Vec<CoinbaseOutput>,
     core_rpc_url: String,
     core_rpc_port: u16,
@@ -40,6 +41,10 @@ pub struct JobDeclaratorServerConfig {
 
 impl JobDeclaratorServerConfig {
     /// Creates a new instance of [`JobDeclaratorServerConfig`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `coinbase_outputs` is empty.
     pub fn new(
         listen_jd_address: String,
         authority_public_key: Secp256k1PublicKey,
@@ -49,6 +54,10 @@ impl JobDeclaratorServerConfig {
         core_rpc: CoreRpc,
         mempool_update_interval: Duration,
     ) -> Self {
+        assert!(
+            !coinbase_outputs.is_empty(),
+            "cannot have empty coinbase outputs array"
+        );
         Self {
             full_template_mode_required: true,
             listen_jd_address,
@@ -134,19 +143,14 @@ impl JobDeclaratorServerConfig {
         self.coinbase_outputs = outputs;
     }
 
-    pub fn get_txout(&self) -> Result<Vec<TxOut>, config_helpers::CoinbaseOutputError> {
-        let mut result = Vec::new();
-        for coinbase_output_pool in &self.coinbase_outputs {
-            let output_script = coinbase_output_pool.script_pubkey().to_owned();
-            result.push(TxOut {
+    pub fn get_txout(&self) -> Vec<TxOut> {
+        self.coinbase_outputs
+            .iter()
+            .map(|out| TxOut {
                 value: Amount::from_sat(0),
-                script_pubkey: output_script,
-            });
-        }
-        match result.is_empty() {
-            true => Err(config_helpers::CoinbaseOutputError::EmptyCoinbaseOutputs),
-            _ => Ok(result),
-        }
+                script_pubkey: out.script_pubkey().to_owned(),
+            })
+            .collect()
     }
     pub fn log_file(&self) -> Option<&Path> {
         self.log_file.as_deref()
@@ -258,7 +262,7 @@ mod tests {
         ))
         .expect("Failed to parse config");
 
-        let outputs = config.get_txout().expect("Failed to get coinbase output");
+        let outputs = config.get_txout();
         let expected_script = ScriptBuf::from_hex(&format!(
             "0014{}",
             pk.wpubkey_hash().expect("compressed key")
@@ -274,36 +278,41 @@ mod tests {
 
     #[test]
     fn test_get_txout_empty() {
-        let config = load_coinbase_config_str("[]").expect("can parse config with empty list");
-
-        let result = config.get_txout();
-        assert!(
-            matches!(
-                result,
-                Err(config_helpers::CoinbaseOutputError::EmptyCoinbaseOutputs)
-            ),
-            "Expected an error for empty coinbase outputs"
+        let error =
+            load_coinbase_config_str("[]").expect_err("cannot parse config with empty list");
+        assert_eq!(
+            error.to_string(),
+            "invalid length 0, expected a list with exactly one coinbase output, or a single descriptor string",
         );
     }
 
     #[test]
     fn test_get_txout_invalid_script_type() {
+        // This error message was introduced in https://github.com/stratum-mining/stratum/pull/1720
+        // as part of a change to allow Vec or non-Vec coinbase output lists to be parsed. We
+        // have https://github.com/stratum-mining/stratum/issues/1793 to track improving it.
         let error = load_coinbase_config_str(&format!(
             "[ {{ output_script_type = \"INVALID\", output_script_value = \"{TEST_PK_HEX}\" }} ]"
         ))
         .expect_err("Cannot parse config with bad script type");
-        assert_eq!(error.to_string(), "Unknown script type in config",);
+        assert_eq!(
+            error.to_string(),
+            "could not parse descriptor string (or old-style list format)",
+        );
     }
 
     #[test]
     fn test_get_txout_invalid_value() {
+        // This error message was introduced in https://github.com/stratum-mining/stratum/pull/1720
+        // as part of a change to allow Vec or non-Vec coinbase output lists to be parsed. We
+        // have https://github.com/stratum-mining/stratum/issues/1793 to track improving it.
         let error = load_coinbase_config_str(&format!(
             "[ {{ output_script_type = \"P2WPKH\", output_script_value = \"{TEST_INVALID_PK_HEX}\" }} ]"
         ))
         .expect_err("Cannot parse config with bad pubkeys");
         assert_eq!(
             error.to_string(),
-            "Invalid output_script_value for your script type. It must be a valid public key/script",
+            "could not parse descriptor string (or old-style list format)",
         );
     }
 }

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -31,10 +31,7 @@ use stratum_common::{
     network_helpers_sv2::noise_connection::Connection,
     roles_logic_sv2::{
         self,
-        bitcoin::{
-            consensus::{encode::serialize, Encodable},
-            Block, Transaction, Txid,
-        },
+        bitcoin::{consensus::encode::serialize, Block, Transaction, Txid},
         codec_sv2::{
             binary_sv2,
             binary_sv2::{B0255, U256},
@@ -121,7 +118,6 @@ impl JobDeclaratorDownstream {
         mempool: Arc<Mutex<JDsMempool>>,
         sender_add_txs_to_mempool: Sender<AddTrasactionsToMempoolInner>,
     ) -> Self {
-        let mut coinbase_output = vec![];
         // TODO: use next variables
         let token_to_job_map = HashMap::with_hasher(BuildNoHashHasher::default());
         let tokens = Id::new();
@@ -129,11 +125,7 @@ impl JobDeclaratorDownstream {
             known_transactions: vec![],
             unknown_transactions: vec![],
         };
-        config
-            .get_txout()
-            .expect("Invalid coinbase output in config")
-            .consensus_encode(&mut coinbase_output)
-            .expect("Invalid coinbase output in config");
+        let coinbase_output = serialize(&config.get_txout());
 
         Self {
             full_template_mode_required,

--- a/roles/pool/config-examples/pool-config-hosted-tp-example.toml
+++ b/roles/pool/config-examples/pool-config-hosted-tp-example.toml
@@ -5,17 +5,11 @@ cert_validity_sec = 3600
 test_only_listen_adress_plain = "0.0.0.0:34250"
 listen_address = "0.0.0.0:34254"
 
-# List of coinbase outputs used to build the coinbase tx
-# ! Right now only one output is supported, so comment all the ones you don't need !
-# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.  
-coinbase_outputs = [
-    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-]
+# Coinbase outputs are specified as descriptors. A full list of descriptors is available at
+#     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
+# Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
+# will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+coinbase_output = "addr(tb1qa0sm0hxzj0x25rh8gw5xlzwlsfvvyz8u96w3p8)"
 
 # Pool signature (string to be included in coinbase tx)
 pool_signature = "Stratum V2 SRI Pool"

--- a/roles/pool/config-examples/pool-config-local-tp-example.toml
+++ b/roles/pool/config-examples/pool-config-local-tp-example.toml
@@ -5,17 +5,11 @@ cert_validity_sec = 3600
 test_only_listen_adress_plain =  "0.0.0.0:34250"
 listen_address = "0.0.0.0:34254"
 
-# List of coinbase outputs used to build the coinbase tx
-# ! Right now only one output is supported, so comment all the ones you don't need !
-# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.  
-coinbase_outputs = [
-    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
-    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
-    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
-]
+# Coinbase outputs are specified as descriptors. A full list of descriptors is available at
+#     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
+# Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
+# will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+coinbase_output = "addr(tb1qa0sm0hxzj0x25rh8gw5xlzwlsfvvyz8u96w3p8)"
 
 # Pool signature (string to be included in coinbase tx)
 pool_signature = "Stratum V2 SRI Pool"

--- a/roles/pool/src/lib/config.rs
+++ b/roles/pool/src/lib/config.rs
@@ -22,6 +22,7 @@ pub struct PoolConfig {
     authority_public_key: Secp256k1PublicKey,
     authority_secret_key: Secp256k1SecretKey,
     cert_validity_sec: u64,
+    #[serde(alias = "coinbase_output")] // only one is allowed, so don't make the user type the plural
     #[serde(deserialize_with = "config_helpers::deserialize_vec_exactly_1")]
     coinbase_outputs: Vec<CoinbaseOutput>,
     pool_signature: String,

--- a/roles/pool/src/lib/config.rs
+++ b/roles/pool/src/lib/config.rs
@@ -22,6 +22,7 @@ pub struct PoolConfig {
     authority_public_key: Secp256k1PublicKey,
     authority_secret_key: Secp256k1SecretKey,
     cert_validity_sec: u64,
+    #[serde(deserialize_with = "config_helpers::deserialize_vec_exactly_1")]
     coinbase_outputs: Vec<CoinbaseOutput>,
     pool_signature: String,
     shares_per_minute: f32,
@@ -31,6 +32,10 @@ pub struct PoolConfig {
 
 impl PoolConfig {
     /// Creates a new instance of the [`PoolConfig`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `coinbase_outputs` is empty.
     pub fn new(
         pool_connection: ConnectionConfig,
         template_provider: TemplateProviderConfig,
@@ -39,6 +44,10 @@ impl PoolConfig {
         shares_per_minute: f32,
         share_batch_size: usize,
     ) -> Self {
+        assert!(
+            !coinbase_outputs.is_empty(),
+            "set of coinbase outputs must be nonempty"
+        );
         Self {
             listen_address: pool_connection.listen_address,
             tp_address: template_provider.address,

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -26,7 +26,6 @@ use super::{
     status,
 };
 use async_channel::{Receiver, Sender};
-use config_helpers::CoinbaseOutputError;
 use error_handling::handle_result;
 use key_utils::SignatureService;
 use nohash_hasher::BuildNoHashHasher;
@@ -42,7 +41,7 @@ use stratum_common::{
     network_helpers_sv2::noise_connection::Connection,
     roles_logic_sv2::{
         self,
-        bitcoin::{Amount, ScriptBuf, TxOut},
+        bitcoin::{Amount, TxOut},
         channels::server::{
             extended::ExtendedChannel, group::GroupChannel, standard::StandardChannel,
         },
@@ -85,19 +84,15 @@ pub type EitherFrame = StandardEitherFrame<Message>;
 /// It iterates through the configured outputs, attempts to convert them into the
 /// internal `CoinbaseOutput_` representation and then into `bitcoin::ScriptBuf`.
 /// Sets the value to 0 sats as per SV2 pool requirements (actual value determined later)
-pub fn get_coinbase_output(config: &PoolConfig) -> Result<Vec<TxOut>, CoinbaseOutputError> {
-    let mut result = Vec::new();
-    for coinbase_output_pool in config.coinbase_outputs() {
-        let output_script: ScriptBuf = coinbase_output_pool.script_pubkey().to_owned();
-        result.push(TxOut {
+pub fn get_coinbase_output(config: &PoolConfig) -> Vec<TxOut> {
+    config
+        .coinbase_outputs()
+        .iter()
+        .map(|out| TxOut {
             value: Amount::from_sat(0),
-            script_pubkey: output_script,
-        });
-    }
-    match result.is_empty() {
-        true => Err(CoinbaseOutputError::EmptyCoinbaseOutputs),
-        _ => Ok(result),
-    }
+            script_pubkey: out.script_pubkey().to_owned(),
+        })
+        .collect()
 }
 
 /// Represents a single connection to a downstream miner.
@@ -1026,7 +1021,7 @@ impl Pool {
             config,
             recv_stop_signal,
             shares_per_minute,
-            pool_coinbase_outputs.expect("Invalid coinbase output in config"),
+            pool_coinbase_outputs,
         )
         .await
         {
@@ -1310,7 +1305,7 @@ mod test {
         let _coinbase_tx_value_remaining: u64 = 625000000;
         let _coinbase_tx_outputs_count = 0;
         let coinbase_tx_locktime = 0;
-        let coinbase_tx_outputs: Vec<bitcoin::TxOut> = super::get_coinbase_output(&config).unwrap();
+        let coinbase_tx_outputs: Vec<bitcoin::TxOut> = super::get_coinbase_output(&config);
         // extranonce len set to max_extranonce_size in `ChannelFactory::new_extended_channel()`
         let extranonce_len = 32;
 

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -88,7 +88,7 @@ pub type EitherFrame = StandardEitherFrame<Message>;
 pub fn get_coinbase_output(config: &PoolConfig) -> Result<Vec<TxOut>, CoinbaseOutputError> {
     let mut result = Vec::new();
     for coinbase_output_pool in config.coinbase_outputs() {
-        let output_script: ScriptBuf = coinbase_output_pool.clone().try_into()?;
+        let output_script: ScriptBuf = coinbase_output_pool.script_pubkey().to_owned();
         result.push(TxOut {
             value: Amount::from_sat(0),
             script_pubkey: output_script,

--- a/roles/pool/src/lib/mod.rs
+++ b/roles/pool/src/lib/mod.rs
@@ -71,7 +71,7 @@ impl PoolSv2 {
         let (s_message_recv_signal, r_message_recv_signal) = bounded(10);
 
         // Prepare coinbase output information required by TemplateRx.
-        let coinbase_output_result = get_coinbase_output(&config)?;
+        let coinbase_output_result = get_coinbase_output(&config);
         let coinbase_output_len = coinbase_output_result
             .iter()
             .map(|output| output.size() as u32)

--- a/roles/pool/src/lib/mod.rs
+++ b/roles/pool/src/lib/mod.rs
@@ -211,35 +211,6 @@ mod tests {
     use ext_config::{Config, File, FileFormat};
 
     #[tokio::test]
-    async fn pool_bad_coinbase_output() {
-        let invalid_coinbase_output = vec![config_helpers::CoinbaseOutput::new(
-            "P2PK".to_string(),
-            "wrong".to_string(),
-        )];
-        let config_path = "config-examples/pool-config-hosted-tp-example.toml";
-        let mut config: PoolConfig = match Config::builder()
-            .add_source(File::new(config_path, FileFormat::Toml))
-            .build()
-        {
-            Ok(settings) => match settings.try_deserialize::<PoolConfig>() {
-                Ok(c) => c,
-                Err(e) => {
-                    error!("Failed to deserialize config: {}", e);
-                    return;
-                }
-            },
-            Err(e) => {
-                error!("Failed to build config: {}", e);
-                return;
-            }
-        };
-        config.set_coinbase_outputs(invalid_coinbase_output);
-        let pool = PoolSv2::new(config);
-        let result = pool.start().await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
     async fn shutdown_pool() {
         let template_provider = integration_tests_sv2::start_template_provider(None);
         let config_path = "config-examples/pool-config-local-tp-example.toml";

--- a/roles/roles-utils/config-helpers/Cargo.toml
+++ b/roles/roles-utils/config-helpers/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 serde = { version = "1.0.89", features = ["derive","alloc"], default-features = false }
-miniscript = { version = "12.3.2", default-features = false, features = [ "no-std" ] }
+miniscript = { version = "12.3.4", default-features = false, features = [ "no-std" ] }
 roles_logic_sv2 = { path = "../../../protocols/v2/roles-logic-sv2" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }

--- a/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use miniscript::bitcoin::address;
+use miniscript::bitcoin::{address, hex};
 
 /// Error enum
 #[derive(Debug)]
@@ -11,8 +11,14 @@ pub enum Error {
     // need to pollute our own error enum with this fiddly stuff
     /// addr() descriptor did not have exactly 1 child
     AddrDescriptorNChildren(usize),
-    /// addr() descriptor child did not have 0 children
+    /// raw() descriptor child did not have 0 children
     AddrDescriptorGrandchild,
+    /// raw() descriptor did not have exactly 1 child
+    RawDescriptorNChildren(usize),
+    /// addr() descriptor child did not have 0 children
+    RawDescriptorGrandchild,
+    /// Error parsing a raw descriptor as hex.
+    Hex(hex::HexToBytesError),
     /// Empty coinbase outputs in config
     EmptyCoinbaseOutputs,
     /// Invalid `output_script_value` for script type. It must be a valid public key/script
@@ -31,6 +37,10 @@ impl fmt::Display for Error {
             AddrDescriptorNChildren(0) => write!(f, "Found addr() descriptor with no address"),
             AddrDescriptorNChildren(n) => write!(f, "Found addr() descriptor with {n} children; must be exactly one valid address"),
             AddrDescriptorGrandchild => write!(f, "Found descriptor of the form addr(X(y)); X must be a valid address and have no subexpression"),
+            RawDescriptorNChildren(0) => write!(f, "Found raw() descriptor with no hex-encoded script"),
+            RawDescriptorNChildren(n) => write!(f, "Found raw() descriptor with {n} children; must be exactly one hex-encoded script"),
+            RawDescriptorGrandchild => write!(f, "Found descriptor of the form raw(X(y)); X must be a hex-encoded script and have no subexpression"),
+            Hex(ref e) => write!(f, "Decoding hex-formatted script: {e}"),
             EmptyCoinbaseOutputs => write!(f, "Empty coinbase outputs in config"),
             UnknownOutputScriptType => write!(f, "Unknown script type in config"),
             InvalidOutputScript => write!(f, "Invalid output_script_value for your script type. It must be a valid public key/script"),
@@ -42,6 +52,12 @@ impl fmt::Display for Error {
 impl From<address::ParseError> for Error {
     fn from(e: address::ParseError) -> Self {
         Error::Address(e)
+    }
+}
+
+impl From<hex::HexToBytesError> for Error {
+    fn from(e: hex::HexToBytesError) -> Self {
+        Error::Hex(e)
     }
 }
 

--- a/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
@@ -19,8 +19,6 @@ pub enum Error {
     RawDescriptorGrandchild,
     /// Error parsing a raw descriptor as hex.
     Hex(hex::HexToBytesError),
-    /// Empty coinbase outputs in config
-    EmptyCoinbaseOutputs,
     /// Invalid `output_script_value` for script type. It must be a valid public key/script
     InvalidOutputScript,
     /// Unknown script type in config
@@ -41,7 +39,6 @@ impl fmt::Display for Error {
             RawDescriptorNChildren(n) => write!(f, "Found raw() descriptor with {n} children; must be exactly one hex-encoded script"),
             RawDescriptorGrandchild => write!(f, "Found descriptor of the form raw(X(y)); X must be a hex-encoded script and have no subexpression"),
             Hex(ref e) => write!(f, "Decoding hex-formatted script: {e}"),
-            EmptyCoinbaseOutputs => write!(f, "Empty coinbase outputs in config"),
             UnknownOutputScriptType => write!(f, "Unknown script type in config"),
             InvalidOutputScript => write!(f, "Invalid output_script_value for your script type. It must be a valid public key/script"),
             Miniscript(ref e) => write!(f, "Miniscript: {e}"),

--- a/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
@@ -1,8 +1,18 @@
 use core::fmt;
 
+use miniscript::bitcoin::address;
+
 /// Error enum
 #[derive(Debug)]
 pub enum Error {
+    /// Error parsing a Bitcoin address
+    Address(address::ParseError),
+    // TODO rust-miniscript 13 will have functions to do these checks for us so we don't
+    // need to pollute our own error enum with this fiddly stuff
+    /// addr() descriptor did not have exactly 1 child
+    AddrDescriptorNChildren(usize),
+    /// addr() descriptor child did not have 0 children
+    AddrDescriptorGrandchild,
     /// Empty coinbase outputs in config
     EmptyCoinbaseOutputs,
     /// Invalid `output_script_value` for script type. It must be a valid public key/script
@@ -17,11 +27,21 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
         match self {
+            Address(ref e) => write!(f, "Bitcoin address: {e}"),
+            AddrDescriptorNChildren(0) => write!(f, "Found addr() descriptor with no address"),
+            AddrDescriptorNChildren(n) => write!(f, "Found addr() descriptor with {n} children; must be exactly one valid address"),
+            AddrDescriptorGrandchild => write!(f, "Found descriptor of the form addr(X(y)); X must be a valid address and have no subexpression"),
             EmptyCoinbaseOutputs => write!(f, "Empty coinbase outputs in config"),
             UnknownOutputScriptType => write!(f, "Unknown script type in config"),
             InvalidOutputScript => write!(f, "Invalid output_script_value for your script type. It must be a valid public key/script"),
             Miniscript(ref e) => write!(f, "Miniscript: {e}"),
         }
+    }
+}
+
+impl From<address::ParseError> for Error {
+    fn from(e: address::ParseError) -> Self {
+        Error::Address(e)
     }
 }
 

--- a/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/errors.rs
@@ -9,6 +9,8 @@ pub enum Error {
     InvalidOutputScript,
     /// Unknown script type in config
     UnknownOutputScriptType,
+    /// Error from the `miniscript` crate.
+    Miniscript(miniscript::Error),
 }
 
 impl fmt::Display for Error {
@@ -18,6 +20,13 @@ impl fmt::Display for Error {
             EmptyCoinbaseOutputs => write!(f, "Empty coinbase outputs in config"),
             UnknownOutputScriptType => write!(f, "Unknown script type in config"),
             InvalidOutputScript => write!(f, "Invalid output_script_value for your script type. It must be a valid public key/script"),
+            Miniscript(ref e) => write!(f, "Miniscript: {e}"),
         }
+    }
+}
+
+impl From<miniscript::Error> for Error {
+    fn from(e: miniscript::Error) -> Self {
+        Error::Miniscript(e)
     }
 }

--- a/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
@@ -1,8 +1,6 @@
 mod errors;
 mod serde_types;
 
-use core::convert::TryFrom;
-
 use miniscript::{
     bitcoin::{Script, ScriptBuf},
     DefiniteDescriptorKey, Descriptor,
@@ -20,14 +18,6 @@ pub struct CoinbaseOutput {
 }
 
 impl CoinbaseOutput {
-    /// Creates a new [`CoinbaseOutput`] from a script type and value.
-    pub fn new(output_script_type: String, output_script_value: String) -> Result<Self, Error> {
-        Self::try_from(serde_types::LegacyCoinbaseOutput {
-            output_script_type,
-            output_script_value,
-        })
-    }
-
     /// Creates a new [`CoinbaseOutput`] from a descriptor string.
     pub fn from_descriptor(s: &str) -> Result<Self, Error> {
         let desc = s.parse::<Descriptor<DefiniteDescriptorKey>>()?;

--- a/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
@@ -2,7 +2,7 @@ mod errors;
 mod serde_types;
 
 use miniscript::{
-    bitcoin::{Script, ScriptBuf},
+    bitcoin::{address::NetworkUnchecked, Address, Network, Script, ScriptBuf},
     DefiniteDescriptorKey, Descriptor,
 };
 
@@ -15,15 +15,74 @@ pub use errors::Error;
 #[serde(try_from = "serde_types::SerdeCoinbaseOutput")]
 pub struct CoinbaseOutput {
     script_pubkey: ScriptBuf,
+    ok_for_mainnet: bool,
 }
 
 impl CoinbaseOutput {
     /// Creates a new [`CoinbaseOutput`] from a descriptor string.
-    pub fn from_descriptor(s: &str) -> Result<Self, Error> {
-        let desc = s.parse::<Descriptor<DefiniteDescriptorKey>>()?;
-        Ok(Self {
-            script_pubkey: desc.script_pubkey(),
-        })
+    pub fn from_descriptor(mut s: &str) -> Result<Self, Error> {
+        // Taproot descriptors cannot be parsed with `expression::Tree::from_str` and
+        // need special handling. So we special-case them early and just pass to
+        // rust-miniscript. In Miniscript 13 we will not need to do this.
+        if s.starts_with("tr") {
+            let desc = s.parse::<Descriptor<DefiniteDescriptorKey>>()?;
+            return Ok(Self {
+                script_pubkey: desc.script_pubkey(),
+                // Descriptors don't have a way to specify a network, so we assume
+                // they are OK to be used on mainnet.
+                ok_for_mainnet: true,
+            });
+        }
+
+        // Manually verify the checksum. FIXME in Miniscript 13 we will not need
+        // to do this, since `expression::Tree::from_str` will do the checksum
+        // validation for us. (And yield a much less horrible error type.)
+        if let Some((desc_str, checksum_str)) = s.rsplit_once('#') {
+            let expected_sum = miniscript::descriptor::checksum::desc_checksum(desc_str)?;
+            if checksum_str != expected_sum {
+                return Err(miniscript::Error::BadDescriptor(format!(
+                    "Invalid checksum '{checksum_str}', expected '{expected_sum}'"
+                ))
+                .into());
+            }
+            s = desc_str;
+        }
+
+        let tree = miniscript::expression::Tree::from_str(s)?;
+        match tree.name {
+            "addr" => {
+                if tree.args.len() != 1 {
+                    return Err(Error::AddrDescriptorNChildren(tree.args.len()));
+                }
+                if !tree.args[0].args.is_empty() {
+                    return Err(Error::AddrDescriptorGrandchild);
+                }
+
+                let addr = tree.args[0].name.parse::<Address<NetworkUnchecked>>()?;
+                Ok(Self {
+                    script_pubkey: addr.assume_checked_ref().script_pubkey(),
+                    ok_for_mainnet: addr.is_valid_for_network(Network::Bitcoin),
+                })
+            }
+            _ => {
+                let desc = s.parse::<Descriptor<DefiniteDescriptorKey>>()?;
+                Ok(Self {
+                    script_pubkey: desc.script_pubkey(),
+                    // Descriptors don't have a way to specify a network, so we assume
+                    // they are OK to be used on mainnet.
+                    ok_for_mainnet: true,
+                })
+            }
+        }
+    }
+
+    /// Whether this coinbase output is okay for use on mainnet.
+    ///
+    /// This is a "best effort" check and currently only returns false if the user
+    /// provides an addr() descriptor in which they specified a testnet or regtest
+    /// address.
+    pub fn ok_for_mainnet(&self) -> bool {
+        self.ok_for_mainnet
     }
 
     /// The `scriptPubKey` associated with the coinbase output

--- a/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
@@ -111,3 +111,263 @@ impl CoinbaseOutput {
         &self.script_pubkey
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_vector_addr() {
+        // Valid
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2)#wdnlkpe8")
+                .unwrap()
+                .script_pubkey()
+                .to_hex_string(),
+            "76a91477bff20c60e522dfaa3350c39b030a5d004e839a88ac",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy)#rsjl0crt")
+                .unwrap()
+                .script_pubkey()
+                .to_hex_string(),
+            "a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor(
+                "addr(bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4)#uyjndxcw"
+            )
+            .unwrap()
+            .script_pubkey()
+            .to_hex_string(),
+            "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor(
+                "addr(bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3)#8kzm8txf"
+            )
+            .unwrap()
+            .script_pubkey()
+            .to_hex_string(),
+            "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+        );
+        // no checksum is ok
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2)")
+                .unwrap()
+                .script_pubkey()
+                .to_hex_string(),
+            "76a91477bff20c60e522dfaa3350c39b030a5d004e839a88ac",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2,)")
+                .unwrap_err()
+                .to_string(),
+            "Found addr() descriptor with 2 children; must be exactly one valid address",
+        );
+
+        // Invalid
+        // But empty checksum is not (in Miniscript 13 these error messages will be cleaner)
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2)#")
+                .unwrap_err()
+                .to_string(),
+            "Miniscript: Invalid descriptor: Invalid checksum '', expected 'wdnlkpe8'",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2)#wdnlkpe7")
+                .unwrap_err()
+                .to_string(),
+            "Miniscript: Invalid descriptor: Invalid checksum 'wdnlkpe7', expected 'wdnlkpe8'",
+        );
+        // Bad base58ck checksum even though the descriptor checksum is OK. Note that rust-bitcoin
+        // 0.32 interprets bad bech32 checksums as "base58 errors" because it doessn't know
+        // what encoding an invalid string is supposed to have. See https://github.com/rust-bitcoin/rust-bitcoin/issues/3044
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN3)#5v55uzec")
+                .unwrap_err()
+                .to_string(),
+            "Bitcoin address: base58 error",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor(
+                "addr(bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t3)#wfr7lfxf"
+            )
+            .unwrap_err()
+            .to_string(),
+            "Bitcoin address: base58 error",
+        );
+        // Flagrantly bad stuff -- should probably PR these upstream to rust-miniscript.
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr()")
+                .unwrap_err()
+                .to_string(),
+            "Bitcoin address: base58 error",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(It's a mad mad world!?! 🙃)")
+                .unwrap_err()
+                .to_string(),
+            "Miniscript: unprintable character 0xf0",
+        );
+        // This error is just wrong lol. Fixed in Miniscript 13.
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(It's a mad mad world!?! 🙃)#abcdefg")
+                .unwrap_err()
+                .to_string(),
+            "Miniscript: Invalid descriptor: Invalid character in checksum: '🙃'",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(It's a mad mad world!?!)#hmeprl29")
+                .unwrap_err()
+                .to_string(),
+            "Bitcoin address: base58 error",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("addr(It's a mad mad world!?!)#🙃🙃🙃🙃🙃🙃")
+                .unwrap_err()
+                .to_string(),
+            "Miniscript: Invalid descriptor: Invalid checksum '🙃🙃🙃🙃🙃🙃', expected 'hmeprl29'",
+        );
+    }
+
+    #[test]
+    fn fixed_vector_combo() {
+        // We do not support combo descriptors. Nobody should.
+        assert_eq!(
+            CoinbaseOutput::from_descriptor(
+                "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
+            )
+            .unwrap_err()
+            .to_string(),
+            "Miniscript: unexpected «combo(1 args) while parsing Miniscript»"
+        );
+    }
+
+    #[test]
+    fn fixed_vector_musig() {
+        // We do not support musig descriptors. One day.
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("musig(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556)").unwrap_err().to_string(),
+            "Miniscript: unexpected «musig(2 args) while parsing Miniscript»"
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("tr(musig(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))").unwrap_err().to_string(),
+            "Miniscript: expected )",
+        );
+    }
+
+    #[test]
+    fn fixed_vector_raw() {
+        // Empty raw descriptors are OK; correspond to the empty script.
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("raw()")
+                .unwrap()
+                .script_pubkey()
+                .to_hex_string(),
+            "",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("raw(deadbeef)")
+                .unwrap()
+                .script_pubkey()
+                .to_hex_string(),
+            "deadbeef",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("raw(DEADBEEF)")
+                .unwrap()
+                .script_pubkey()
+                .to_hex_string(),
+            "deadbeef",
+        );
+        // Should we allow this? We do, so I guess we should test it and make sure we don't stop..
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("raw(DEADbeef)")
+                .unwrap()
+                .script_pubkey()
+                .to_hex_string(),
+            "deadbeef",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("raw(0)")
+                .unwrap_err()
+                .to_string(),
+            "Decoding hex-formatted script: odd length, failed to create bytes from hex",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("raw(0,1)")
+                .unwrap_err()
+                .to_string(),
+            "Found raw() descriptor with 2 children; must be exactly one hex-encoded script",
+        );
+    }
+
+    #[test]
+    fn fixed_vector_miniscript() {
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("sh(wsh(multi(2,0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556)))#qpcmf2lu").unwrap().script_pubkey().to_hex_string(),
+            "a9141cb55de50b72c67709ab16307d69557e6bb1a98787",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor(
+                "tr(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
+            )
+            .unwrap()
+            .script_pubkey()
+            .to_hex_string(),
+            "5120da4710964f7852695de2da025290e24af6d8c281de5a0b902b7135fd9fd74d21",
+        );
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("tr(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,{pk(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556),{multi_a(2,026a245bf6dc698504c89a20cfded60853152b695336c28063b61c65cbd269e6b4,0231ecbfac95d972f0b8f81ec6e01e9c621d91a4b48d5f9d12d7e95febe9f34d64),multi_a(2,026a245bf6dc698504c89a20cfded60853152b695336c28063b61c65cbd269e6b4,0231ecbfac95d972f0b8f81ec6e01e9c621d91a4b48d5f9d12d7e95febe9f34d64)}})")
+            .unwrap()
+            .script_pubkey()
+            .to_hex_string(),
+            "5120493bdae0d225af5cb88c4cb2a1e1e89e391153ba7699c91ebee2fd082ed1636c",
+        );
+    }
+
+    #[test]
+    fn fixed_vector_keys() {
+        // xpub
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8)").unwrap().script_pubkey().to_hex_string(),
+            "76a9143442193e1bb70916e914552172cd4e2dbc9df81188ac",
+        );
+        // xpub with non-hardened path
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/1/2/3)").unwrap().script_pubkey().to_hex_string(),
+            "76a914f2d2e1401c88353c2298d1a928d4ed827ff46ff688ac",
+        );
+        // xpub with hardened path (not allowed)
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/1'/2/3)").unwrap_err().to_string(),
+            "Miniscript: unexpected «cannot parse multi-path keys, keys with a wildcard or keys with hardened derivation steps as a DerivedDescriptorKey»",
+        );
+        // no wildcards allowed (at least for now; gmax thinks it would be cool if we would
+        // instantiate it with the blockheight or something, but need to work out UX)
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/*)").unwrap_err().to_string(),
+            "Miniscript: unexpected «cannot parse multi-path keys, keys with a wildcard or keys with hardened derivation steps as a DerivedDescriptorKey»",
+        );
+        // No multipath descriptors allowed; this is not a wallet with change
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/<0;1>)").unwrap_err().to_string(),
+            "Miniscript: unexpected «cannot parse multi-path keys, keys with a wildcard or keys with hardened derivation steps as a DerivedDescriptorKey»",
+        );
+        // Private keys are not allowed, or xprvs.
+        assert_eq!(
+            CoinbaseOutput::from_descriptor(
+                "pkh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)"
+            )
+            .unwrap_err()
+            .to_string(),
+            "Miniscript: unexpected «Key too short (<66 char), doesn't match any format»",
+        );
+        // This is a confusing error message which should be fixed in Miniscript 13.
+        assert_eq!(
+            CoinbaseOutput::from_descriptor("pkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi)").unwrap_err().to_string(),
+            "Miniscript: unexpected «Public keys must be 64/66/130 characters in size»",
+        );
+    }
+}

--- a/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
@@ -3,7 +3,10 @@ mod serde_types;
 
 use core::convert::TryFrom;
 
-use miniscript::bitcoin::{Script, ScriptBuf};
+use miniscript::{
+    bitcoin::{Script, ScriptBuf},
+    DefiniteDescriptorKey, Descriptor,
+};
 
 pub use errors::Error;
 
@@ -19,9 +22,17 @@ pub struct CoinbaseOutput {
 impl CoinbaseOutput {
     /// Creates a new [`CoinbaseOutput`] from a script type and value.
     pub fn new(output_script_type: String, output_script_value: String) -> Result<Self, Error> {
-        Self::try_from(serde_types::SerdeCoinbaseOutput {
+        Self::try_from(serde_types::LegacyCoinbaseOutput {
             output_script_type,
             output_script_value,
+        })
+    }
+
+    /// Creates a new [`CoinbaseOutput`] from a descriptor string.
+    pub fn from_descriptor(s: &str) -> Result<Self, Error> {
+        let desc = s.parse::<Descriptor<DefiniteDescriptorKey>>()?;
+        Ok(Self {
+            script_pubkey: desc.script_pubkey(),
         })
     }
 

--- a/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
@@ -23,7 +23,7 @@ pub struct CoinbaseOutput {
     /// - `"P2WPKH"`: Pay-to-Witness-Public-Key-Hash
     /// - `"P2WSH"`: Pay-to-Witness-Script-Hash
     /// - `"P2TR"`: Pay-to-Taproot
-    pub output_script_type: String,
+    output_script_type: String,
 
     /// Value associated with the script, typically a public key or script hash.
     ///
@@ -34,7 +34,7 @@ pub struct CoinbaseOutput {
     /// - For `"P2SH"`: A script hash.
     /// - For `"P2WSH"`: A witness script hash.
     /// - For `"P2TR"`: An x-only public key.
-    pub output_script_value: String,
+    output_script_value: String,
 }
 
 impl CoinbaseOutput {

--- a/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/mod.rs
@@ -1,11 +1,9 @@
 mod errors;
+mod serde_types;
 
 use core::convert::TryFrom;
 
-use miniscript::bitcoin::{
-    secp256k1::{All, Secp256k1},
-    PublicKey, ScriptBuf, ScriptHash, WScriptHash, XOnlyPublicKey,
-};
+use miniscript::bitcoin::{Script, ScriptBuf};
 
 pub use errors::Error;
 
@@ -13,108 +11,22 @@ pub use errors::Error;
 ///
 /// Typically used for parsing coinbase outputs defined in SRI role configuration files.
 #[derive(Debug, serde::Deserialize, Clone)]
+#[serde(try_from = "serde_types::SerdeCoinbaseOutput")]
 pub struct CoinbaseOutput {
-    /// Specifies type of the script used in the output.
-    ///
-    /// Supported values include:
-    /// - `"P2PK"`: Pay-to-Public-Key
-    /// - `"P2PKH"`: Pay-to-Public-Key-Hash
-    /// - `"P2SH"`: Pay-to-Script-Hash
-    /// - `"P2WPKH"`: Pay-to-Witness-Public-Key-Hash
-    /// - `"P2WSH"`: Pay-to-Witness-Script-Hash
-    /// - `"P2TR"`: Pay-to-Taproot
-    output_script_type: String,
-
-    /// Value associated with the script, typically a public key or script hash.
-    ///
-    /// This field's interpretation depends on the `output_script_type`:
-    /// - For `"P2PK"`: The raw public key.
-    /// - For `"P2PKH"`: A public key hash.
-    /// - For `"P2WPKH"`: A witness public key hash.
-    /// - For `"P2SH"`: A script hash.
-    /// - For `"P2WSH"`: A witness script hash.
-    /// - For `"P2TR"`: An x-only public key.
-    output_script_value: String,
+    script_pubkey: ScriptBuf,
 }
 
 impl CoinbaseOutput {
-    /// Creates a new [`CoinbaseOutput`].
-    pub fn new(output_script_type: String, output_script_value: String) -> Self {
-        Self {
+    /// Creates a new [`CoinbaseOutput`] from a script type and value.
+    pub fn new(output_script_type: String, output_script_value: String) -> Result<Self, Error> {
+        Self::try_from(serde_types::SerdeCoinbaseOutput {
             output_script_type,
             output_script_value,
-        }
+        })
     }
-}
 
-impl TryFrom<CoinbaseOutput> for ScriptBuf {
-    type Error = Error;
-
-    fn try_from(value: CoinbaseOutput) -> Result<Self, Self::Error> {
-        match value.output_script_type.as_str() {
-            "TEST" => {
-                let pub_key_hash = value
-                    .output_script_value
-                    .parse::<PublicKey>()
-                    .map_err(|_| Error::InvalidOutputScript)?
-                    .pubkey_hash();
-                Ok(ScriptBuf::new_p2pkh(&pub_key_hash))
-            }
-            "P2PK" => {
-                let pub_key = value
-                    .output_script_value
-                    .parse::<PublicKey>()
-                    .map_err(|_| Error::InvalidOutputScript)?;
-                Ok(ScriptBuf::new_p2pk(&pub_key))
-            }
-            "P2PKH" => {
-                let pub_key_hash = value
-                    .output_script_value
-                    .parse::<PublicKey>()
-                    .map_err(|_| Error::InvalidOutputScript)?
-                    .pubkey_hash();
-                Ok(ScriptBuf::new_p2pkh(&pub_key_hash))
-            }
-            "P2WPKH" => {
-                let w_pub_key_hash = value
-                    .output_script_value
-                    .parse::<PublicKey>()
-                    .map_err(|_| Error::InvalidOutputScript)?
-                    .wpubkey_hash()
-                    .unwrap();
-                Ok(ScriptBuf::new_p2wpkh(&w_pub_key_hash))
-            }
-            "P2SH" => {
-                let script_hashed = value
-                    .output_script_value
-                    .parse::<ScriptHash>()
-                    .map_err(|_| Error::InvalidOutputScript)?;
-                Ok(ScriptBuf::new_p2sh(&script_hashed))
-            }
-            "P2WSH" => {
-                let w_script_hashed = value
-                    .output_script_value
-                    .parse::<WScriptHash>()
-                    .map_err(|_| Error::InvalidOutputScript)?;
-                Ok(ScriptBuf::new_p2wsh(&w_script_hashed))
-            }
-            "P2TR" => {
-                // From the bip
-                //
-                // Conceptually, every Taproot output corresponds to a combination of
-                // a single public key condition (the internal key),
-                // and zero or more general conditions encoded in scripts organized in a tree.
-                let pub_key = value
-                    .output_script_value
-                    .parse::<XOnlyPublicKey>()
-                    .map_err(|_| Error::InvalidOutputScript)?;
-                Ok(ScriptBuf::new_p2tr::<All>(
-                    &Secp256k1::<All>::new(),
-                    pub_key,
-                    None,
-                ))
-            }
-            _ => Err(Error::UnknownOutputScriptType),
-        }
+    /// The `scriptPubKey` associated with the coinbase output
+    pub fn script_pubkey(&self) -> &Script {
+        &self.script_pubkey
     }
 }

--- a/roles/roles-utils/config-helpers/src/coinbase_output/serde_types.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/serde_types.rs
@@ -1,0 +1,100 @@
+use core::convert::TryFrom;
+use miniscript::bitcoin::{
+    secp256k1::{All, Secp256k1},
+    PublicKey, ScriptBuf, ScriptHash, WScriptHash, XOnlyPublicKey,
+};
+
+use super::Error;
+
+#[derive(serde::Deserialize)]
+pub(super) struct SerdeCoinbaseOutput {
+    /// Specifies type of the script used in the output.
+    ///
+    /// Supported values include:
+    /// - `"P2PK"`: Pay-to-Public-Key
+    /// - `"P2PKH"`: Pay-to-Public-Key-Hash
+    /// - `"P2SH"`: Pay-to-Script-Hash
+    /// - `"P2WPKH"`: Pay-to-Witness-Public-Key-Hash
+    /// - `"P2WSH"`: Pay-to-Witness-Script-Hash
+    /// - `"P2TR"`: Pay-to-Taproot
+    pub(super) output_script_type: String,
+
+    /// Value associated with the script, typically a public key or script hash.
+    ///
+    /// This field's interpretation depends on the `output_script_type`:
+    /// - For `"P2PK"`: The raw public key.
+    /// - For `"P2PKH"`: A public key hash.
+    /// - For `"P2WPKH"`: A witness public key hash.
+    /// - For `"P2SH"`: A script hash.
+    /// - For `"P2WSH"`: A witness script hash.
+    /// - For `"P2TR"`: An x-only public key.
+    pub(super) output_script_value: String,
+}
+
+impl TryFrom<SerdeCoinbaseOutput> for super::CoinbaseOutput {
+    type Error = super::Error;
+    fn try_from(value: SerdeCoinbaseOutput) -> Result<Self, Self::Error> {
+        let script_pubkey = match value.output_script_type.as_str() {
+            "TEST" => {
+                let pub_key_hash = value
+                    .output_script_value
+                    .parse::<PublicKey>()
+                    .map_err(|_| Error::InvalidOutputScript)?
+                    .pubkey_hash();
+                ScriptBuf::new_p2pkh(&pub_key_hash)
+            }
+            "P2PK" => {
+                let pub_key = value
+                    .output_script_value
+                    .parse::<PublicKey>()
+                    .map_err(|_| Error::InvalidOutputScript)?;
+                ScriptBuf::new_p2pk(&pub_key)
+            }
+            "P2PKH" => {
+                let pub_key_hash = value
+                    .output_script_value
+                    .parse::<PublicKey>()
+                    .map_err(|_| Error::InvalidOutputScript)?
+                    .pubkey_hash();
+                ScriptBuf::new_p2pkh(&pub_key_hash)
+            }
+            "P2WPKH" => {
+                let w_pub_key_hash = value
+                    .output_script_value
+                    .parse::<PublicKey>()
+                    .map_err(|_| Error::InvalidOutputScript)?
+                    .wpubkey_hash()
+                    .unwrap();
+                ScriptBuf::new_p2wpkh(&w_pub_key_hash)
+            }
+            "P2SH" => {
+                let script_hashed = value
+                    .output_script_value
+                    .parse::<ScriptHash>()
+                    .map_err(|_| Error::InvalidOutputScript)?;
+                ScriptBuf::new_p2sh(&script_hashed)
+            }
+            "P2WSH" => {
+                let w_script_hashed = value
+                    .output_script_value
+                    .parse::<WScriptHash>()
+                    .map_err(|_| Error::InvalidOutputScript)?;
+                ScriptBuf::new_p2wsh(&w_script_hashed)
+            }
+            "P2TR" => {
+                // From the bip
+                //
+                // Conceptually, every Taproot output corresponds to a combination of
+                // a single public key condition (the internal key),
+                // and zero or more general conditions encoded in scripts organized in a tree.
+                let pub_key = value
+                    .output_script_value
+                    .parse::<XOnlyPublicKey>()
+                    .map_err(|_| Error::InvalidOutputScript)?;
+                ScriptBuf::new_p2tr::<All>(&Secp256k1::<All>::new(), pub_key, None)
+            }
+            _ => return Err(Error::UnknownOutputScriptType),
+        };
+        Ok(Self { script_pubkey })
+    }
+}

--- a/roles/roles-utils/config-helpers/src/coinbase_output/serde_types.rs
+++ b/roles/roles-utils/config-helpers/src/coinbase_output/serde_types.rs
@@ -96,7 +96,11 @@ impl TryFrom<LegacyCoinbaseOutput> for super::CoinbaseOutput {
             }
             _ => return Err(Error::UnknownOutputScriptType),
         };
-        Ok(Self { script_pubkey })
+        Ok(Self {
+            script_pubkey,
+            // legacy encoding gives no way to specify testnet or mainnet
+            ok_for_mainnet: true,
+        })
     }
 }
 

--- a/roles/roles-utils/config-helpers/src/lib.rs
+++ b/roles/roles-utils/config-helpers/src/lib.rs
@@ -1,7 +1,54 @@
+use serde::{Deserialize, Deserializer};
+
 mod coinbase_output;
 pub use coinbase_output::{CoinbaseOutput, Error as CoinbaseOutputError};
+
+pub mod logging;
 
 mod toml;
 pub use toml::duration_from_toml;
 
-pub mod logging;
+/// Deserialize an object, allowing it to be encoded either directly or as
+/// a singleton vector.
+///
+/// Returns a singleton vector in either case.
+///
+/// This function was created as part of https://github.com/stratum-mining/stratum/pull/1720
+/// as a first step in transitioning the `coinbase_outputs` field of various configuration
+/// files away from a vector toward a single object. As part of a larger refactoring, it
+/// should be changed to return a single [`CoinbaseOutput`] directly.
+pub fn deserialize_vec_exactly_1<'de, D>(d: D) -> Result<Vec<CoinbaseOutput>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error as _;
+
+    // Serde will attempt `Single` first, then `Vec` if that fails.
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Helper {
+        Single(CoinbaseOutput),
+        Vec(Vec<CoinbaseOutput>),
+    }
+
+    match Helper::deserialize(d) {
+        Err(_) => {
+            // The errors yielded by serde are meaningless to the user and
+            // expose the name of the private `Helper` type. Override them
+            // with something equally useless but less confusing.
+            Err(D::Error::custom(
+                "could not parse descriptor string (or old-style list format)",
+            ))
+        }
+        Ok(Helper::Single(ret)) => Ok(vec![ret]),
+        Ok(Helper::Vec(ret)) => {
+            if ret.len() != 1 {
+                return Err(D::Error::invalid_length(
+                    ret.len(),
+                    &"a list with exactly one coinbase output, or a single descriptor string",
+                ));
+            }
+            Ok(ret)
+        }
+    }
+}

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.2"
+version = "12.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0760e92feaf4ee26bd2e616f557de64712bf1e75f3b1b218dfb475c0a84c7943"
+checksum = "a1eeb3bbebc87062b99fbb8c9067d30dab85469f4cf12248a2667777cc86b282"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/test/integration-tests/lib/mod.rs
+++ b/test/integration-tests/lib/mod.rs
@@ -70,7 +70,8 @@ pub async fn start_pool(template_provider_address: Option<SocketAddr>) -> (PoolS
     let coinbase_outputs = vec![CoinbaseOutput::new(
         "P2WPKH".to_string(),
         "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
-    )];
+    )
+    .unwrap()];
     let pool_signature = "Stratum V2 SRI Pool".to_string();
     let tp_address = if let Some(tp_add) = template_provider_address {
         tp_add.to_string()
@@ -129,7 +130,8 @@ pub fn start_jdc(
     let coinbase_outputs = vec![CoinbaseOutput::new(
         "P2WPKH".to_string(),
         "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
-    )];
+    )
+    .unwrap()];
     let authority_pubkey = Secp256k1PublicKey::try_from(
         "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72".to_string(),
     )
@@ -183,7 +185,8 @@ pub fn start_jds(tp_rpc_connection: &ConnectParams) -> (JobDeclaratorServer, Soc
     let coinbase_outputs = vec![CoinbaseOutput::new(
         "P2WPKH".to_string(),
         "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
-    )];
+    )
+    .unwrap()];
     if let Ok(Some(CookieValues { user, password })) = tp_rpc_connection.get_cookie_values() {
         let ip = tp_rpc_connection.rpc_socket.ip().to_string();
         let url = jd_server::Uri::builder()

--- a/test/integration-tests/lib/mod.rs
+++ b/test/integration-tests/lib/mod.rs
@@ -67,9 +67,8 @@ pub async fn start_pool(template_provider_address: Option<SocketAddr>) -> (PoolS
     )
     .expect("failed");
     let cert_validity_sec = 3600;
-    let coinbase_outputs = vec![CoinbaseOutput::new(
-        "P2WPKH".to_string(),
-        "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
+    let coinbase_outputs = vec![CoinbaseOutput::from_descriptor(
+        "wpkh(036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075)",
     )
     .unwrap()];
     let pool_signature = "Stratum V2 SRI Pool".to_string();
@@ -127,9 +126,8 @@ pub fn start_jdc(
         "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n".to_string(),
     )
     .unwrap();
-    let coinbase_outputs = vec![CoinbaseOutput::new(
-        "P2WPKH".to_string(),
-        "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
+    let coinbase_outputs = vec![CoinbaseOutput::from_descriptor(
+        "wpkh(036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075)",
     )
     .unwrap()];
     let authority_pubkey = Secp256k1PublicKey::try_from(
@@ -182,9 +180,8 @@ pub fn start_jds(tp_rpc_connection: &ConnectParams) -> (JobDeclaratorServer, Soc
     .unwrap();
     let listen_jd_address = get_available_address();
     let cert_validity_sec = 3600;
-    let coinbase_outputs = vec![CoinbaseOutput::new(
-        "P2WPKH".to_string(),
-        "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075".to_string(),
+    let coinbase_outputs = vec![CoinbaseOutput::from_descriptor(
+        "wpkh(036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075)",
     )
     .unwrap()];
     if let Ok(Some(CookieValues { user, password })) = tp_rpc_connection.get_cookie_values() {


### PR DESCRIPTION
Fixes #1652.

Draft because I need to update the example configuration files and the documentation. But I am using this with my Bitaxes. Tried both the `raw` and the `addr` descriptor and was able to use a vanitygenned address which previously was impossible to specify.