### PR TITLE
fix integration tests lockfile

### DIFF
--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -23,3 +23,4 @@ jobs:
         run: |
           cargo build --manifest-path=roles/Cargo.toml --locked
           cargo build --manifest-path=utils/Cargo.toml --locked
+          cargo build --manifest-path=test/integration-tests/Cargo.toml --locked

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
 name = "config-helpers"
 version = "0.1.0"
 dependencies = [
+ "miniscript",
  "roles_logic_sv2",
  "serde",
 ]
@@ -1463,6 +1464,16 @@ version = "4.0.0"
 dependencies = [
  "binary_sv2",
  "stratum-common",
+]
+
+[[package]]
+name = "miniscript"
+version = "12.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0760e92feaf4ee26bd2e616f557de64712bf1e75f3b1b218dfb475c0a84c7943"
+dependencies = [
+ "bech32",
+ "bitcoin",
 ]
 
 [[package]]


### PR DESCRIPTION
as a consequence of #1719 the lockfile of `integration_tests_sv2` changed

it wasn't covered in lockfile CI so we missed it