### PR TITLE
add verification on `roles_logic_sv2::channels::*::standard::StandardChannel::set_extranonce_prefix`

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/channels/client/error.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/client/error.rs
@@ -7,6 +7,7 @@ pub enum ExtendedChannelError {
 #[derive(Debug)]
 pub enum StandardChannelError {
     JobIdNotFound,
+    NewExtranoncePrefixTooLarge,
 }
 
 #[derive(Debug)]

--- a/protocols/v2/roles-logic-sv2/src/channels/client/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/client/standard.rs
@@ -13,7 +13,7 @@ use crate::{
 use binary_sv2::Sv2Option;
 use mining_sv2::{
     NewExtendedMiningJob, NewMiningJob, SetNewPrevHash as SetNewPrevHashMp, SubmitSharesStandard,
-    Target,
+    Target, MAX_EXTRANONCE_LEN,
 };
 use std::{collections::HashMap, convert::TryInto};
 use stratum_common::bitcoin::{
@@ -86,8 +86,17 @@ impl<'a> StandardChannel<'a> {
         &self.user_identity
     }
 
-    pub fn set_extranonce_prefix(&mut self, extranonce_prefix: Vec<u8>) {
+    pub fn set_extranonce_prefix(
+        &mut self,
+        extranonce_prefix: Vec<u8>,
+    ) -> Result<(), StandardChannelError> {
+        if extranonce_prefix.len() > MAX_EXTRANONCE_LEN {
+            return Err(StandardChannelError::NewExtranoncePrefixTooLarge);
+        }
+
         self.extranonce_prefix = extranonce_prefix;
+
+        Ok(())
     }
 
     pub fn get_extranonce_prefix(&self) -> &Vec<u8> {

--- a/protocols/v2/roles-logic-sv2/src/channels/server/error.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/error.rs
@@ -24,4 +24,5 @@ pub enum StandardChannelError {
     TemplateIdNotFound,
     InvalidNominalHashrate,
     RequestedMaxTargetOutOfRange,
+    NewExtranoncePrefixTooLarge,
 }


### PR DESCRIPTION
otherwise it would be possible to set a new `extranonce_prefix` that's bigger than 32 bytes, which would violate the spec and would not fit a `SetExtranoncePrefix` message