### PR TITLE
update imports in `roles` and `tests` to reflect library reorganization

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.1"
 edition = "2021"
 
 [dependencies]
-stratum-common = { path = "../common", features=["bitcoin"]}
+bitcoin = { version = "0.32.5", optional = true }
 async-std={version = "1.10.0", features = ["attributes"]}
 criterion = "0.5.1"
 async-channel = "1.4.0"

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -3,10 +3,92 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "base58ck"
@@ -14,8 +96,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
@@ -25,21 +107,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
+name = "binary_codec_sv2"
+version = "2.0.0"
+dependencies = [
+ "buffer_sv2",
+]
+
+[[package]]
+name = "binary_sv2"
+version = "3.0.0"
+dependencies = [
+ "binary_codec_sv2",
+ "derive_codec_sv2",
+]
+
+[[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
 dependencies = [
  "base58ck",
  "bech32",
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1 0.29.1",
 ]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-internals"
@@ -59,7 +162,26 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
 ]
 
 [[package]]
@@ -69,31 +191,380 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.97"
+name = "bitflags"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "buffer_sv2"
+version = "2.0.0"
+dependencies = [
+ "aes-gcm",
+]
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "codec_sv2"
+version = "2.1.0"
+dependencies = [
+ "binary_sv2",
+ "buffer_sv2",
+ "framing_sv2",
+ "noise_sv2",
+ "rand",
+ "tracing",
+]
+
+[[package]]
+name = "common_messages_sv2"
+version = "5.1.0"
+dependencies = [
+ "binary_sv2",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "derive_codec_sv2"
+version = "1.1.1"
+dependencies = [
+ "binary_codec_sv2",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "framing_sv2"
+version = "5.1.0"
+dependencies = [
+ "binary_sv2",
+ "buffer_sv2",
+ "noise_sv2",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -105,22 +576,311 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
-name = "libc"
-version = "0.2.154"
+name = "impl-codec"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "job_declaration_sv2"
+version = "4.0.0"
+dependencies = [
+ "binary_sv2",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mining_sv2"
+version = "4.0.0"
+dependencies = [
+ "binary_sv2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "network_helpers_sv2"
+version = "4.0.0"
+dependencies = [
+ "async-channel",
+ "codec_sv2",
+ "futures",
+ "serde_json",
+ "sv1_api",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "noise_sv2"
+version = "1.4.0"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "rand",
+ "rand_chacha",
+ "secp256k1 0.28.2",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -153,11 +913,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "roles_logic_sv2"
+version = "3.0.0"
+dependencies = [
+ "bitcoin",
+ "chacha20poly1305",
+ "codec_sv2",
+ "common_messages_sv2",
+ "hex-conservative 0.3.0",
+ "job_declaration_sv2",
+ "mining_sv2",
+ "nohash-hasher",
+ "primitive-types",
+ "template_distribution_sv2",
+ "tracing",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "secp256k1"
 version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
+ "bitcoin_hashes 0.13.0",
  "rand",
  "secp256k1-sys 0.9.2",
 ]
@@ -168,7 +985,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.13.0",
  "secp256k1-sys 0.10.1",
 ]
 
@@ -191,15 +1008,398 @@ dependencies = [
 ]
 
 [[package]]
-name = "stratum-common"
-version = "2.0.0"
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
- "bitcoin",
- "secp256k1 0.28.2",
+ "serde_derive",
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+name = "serde_derive"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stratum-common"
+version = "3.0.0"
+dependencies = [
+ "network_helpers_sv2",
+ "roles_logic_sv2",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sv1_api"
+version = "1.0.1"
+dependencies = [
+ "binary_sv2",
+ "bitcoin_hashes 0.3.2",
+ "byteorder",
+ "hex",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "template_distribution_sv2"
+version = "3.1.0"
+dependencies = [
+ "binary_sv2",
+]
+
+[[package]]
+name = "tokio"
+version = "1.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "stratum-common"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2018"
 description = "SV2 pool role"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/stratum-mining/stratum"
 
 [dependencies]
-bitcoin = {version="0.32.5",optional=true}
-secp256k1 = { version = "0.28.2", default-features = false, features =["alloc","rand","rand-std"] }
+roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2" }
+network_helpers_sv2 = { path = "../roles/roles-utils/network-helpers", features = ["with_buffer_pool"], optional = true }
+
+[features]
+with_network_helpers = ["dep:network_helpers_sv2"]
+sv1 = ["network_helpers_sv2/sv1"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! `stratum_common` is a utility crate designed to centralize
 //! and manage the shared dependencies and utils across stratum crates.
-#[cfg(feature = "bitcoin")]
-pub use bitcoin;
-pub use secp256k1;
+
+#[cfg(feature = "with_network_helpers")]
+pub use network_helpers_sv2;
+pub use roles_logic_sv2;

--- a/examples/ping-pong-encrypted/Cargo.toml
+++ b/examples/ping-pong-encrypted/Cargo.toml
@@ -11,7 +11,7 @@ binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 codec_sv2 = { path = "../../protocols/v2/codec-sv2", features = [ "noise_sv2" ] }
 noise_sv2 = { path = "../../protocols/v2/noise-sv2" }
 key-utils = { version = "^1.0.0", path = "../../utils/key-utils" }
-network_helpers_sv2 = { version = "3.0.0", path = "../../roles/roles-utils/network-helpers" }
+network_helpers_sv2 = { version = "4.0.0", path = "../../roles/roles-utils/network-helpers" }
 rand = "0.8"
 tokio = { version = "1.44.1", features = [ "full" ] }
 async-channel = "1.5.1"

--- a/protocols/v2/codec-sv2/Cargo.toml
+++ b/protocols/v2/codec-sv2/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 framing_sv2 = { path = "../../../protocols/v2/framing-sv2", version = "^5.0.0" }
 noise_sv2 = { path = "../../../protocols/v2/noise-sv2", default-features = false, optional = true, version = "^1.0.0" }
 binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^3.0.0" }
-stratum-common = { version = "2.0.0", path = "../../../common" }
 buffer_sv2 = { path = "../../../utils/buffer", version = "^2.0.0" }
 rand = { version = "0.8.5", default-features = false }
 tracing = { version = "0.1", optional = true }

--- a/protocols/v2/codec-sv2/examples/encrypted.rs
+++ b/protocols/v2/codec-sv2/examples/encrypted.rs
@@ -24,14 +24,16 @@ use codec_sv2::{
 };
 #[cfg(feature = "noise_sv2")]
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
+
+#[cfg(feature = "noise_sv2")]
+use noise_sv2::{ELLSWIFT_ENCODING_SIZE, INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE};
+
 use std::convert::TryInto;
 #[cfg(feature = "noise_sv2")]
 use std::{
     io::{Read, Write},
     net::{TcpListener, TcpStream},
 };
-#[cfg(feature = "noise_sv2")]
-use stratum_common::{ELLSWIFT_ENCODING_SIZE, INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE};
 
 // Arbitrary message type.
 // Supported Sv2 message types are listed in the [Sv2 Spec Message

--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -67,6 +67,8 @@ pub use noise_sv2::{self, Initiator, NoiseCodec, Responder};
 
 pub use buffer_sv2;
 
+pub use binary_sv2;
+
 pub use framing_sv2::{self, framing::handshake_message_to_frame as h2f};
 
 /// Represents the role in the Noise handshake process, either as an initiator or a responder.

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", version = "^2.0.0" }
 binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^3.0.0" }
 buffer_sv2 = { path = "../../../utils/buffer", optional=true, version = "^2.0.0" }
 noise_sv2 = { path = "../../../protocols/v2/noise-sv2", version = "^1.0.0" }

--- a/protocols/v2/noise-sv2/Cargo.toml
+++ b/protocols/v2/noise-sv2/Cargo.toml
@@ -17,7 +17,6 @@ rand = {version = "0.8.5", default-features = false }
 aes-gcm = { version = "0.10.2", features = ["alloc", "aes"], default-features = false }
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["alloc"]}
 rand_chacha = { version = "0.3.1", default-features = false }
-stratum-common = { path = "../../../common", version = "^2.0.0"}
 
 [features]
 default = ["std"]

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -13,21 +13,19 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", features=["bitcoin"], version = "^2.0.0"}
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^3.0.0" }
+bitcoin = { version = "0.32.5" }
 common_messages_sv2 = { path = "../../../protocols/v2/subprotocols/common-messages", version = "^5.0.0" }
 mining_sv2 = { path = "../../../protocols/v2/subprotocols/mining", version = "^4.0.0" }
 template_distribution_sv2 = { path = "../../../protocols/v2/subprotocols/template-distribution", version = "^3.0.0" }
 job_declaration_sv2 = { path = "../../../protocols/v2/subprotocols/job-declaration", version = "^4.0.0" }
-framing_sv2 = { path = "../../../protocols/v2/framing-sv2", version = "^5.0.0" }
 tracing = { version = "0.1"}
 chacha20poly1305 = { version = "0.10.1"}
 nohash-hasher = "0.2.0"
 primitive-types = "0.13.1"
 hex = {package = "hex-conservative", version = "0.3.0"}
+codec_sv2 = { path = "../../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 
 [dev-dependencies]
-codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0" }
 quickcheck = "1.0.3"
 quickcheck_macros = "1"
 rand = "0.8.5"

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -11,6 +11,7 @@ use crate::{
     Error,
 };
 
+use codec_sv2::binary_sv2;
 use mining_sv2::{
     ExtendedExtranonce, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannelSuccess,
     OpenMiningChannelError, OpenStandardMiningChannelSuccess, SetCustomMiningJob,
@@ -25,7 +26,7 @@ use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashFro
 
 use tracing::{debug, error, info, trace, warn};
 
-use stratum_common::bitcoin::{
+use bitcoin::{
     block::{Header, Version},
     hash_types,
     hashes::sha256d::Hash,
@@ -1809,9 +1810,9 @@ impl ExtendedChannelKind {
 #[cfg(test)]
 mod test {
     use super::*;
-    use binary_sv2::{Seq0255, B064K, U256};
+    use bitcoin::{Amount, PublicKey, Target, TxOut, WPubkeyHash};
+    use codec_sv2::binary_sv2::{Seq0255, B064K, U256};
     use mining_sv2::OpenStandardMiningChannel;
-    use stratum_common::bitcoin::{Amount, PublicKey, Target, TxOut, WPubkeyHash};
 
     const BLOCK_REWARD: u64 = 2_000_000_000;
 

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/proxy_group_channel.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/proxy_group_channel.rs
@@ -213,7 +213,7 @@ impl GroupChannel {
 #[cfg(test)]
 mod test {
     use super::*;
-    use binary_sv2::B064K;
+    use codec_sv2::binary_sv2::{self, B064K};
     use std::convert::TryFrom;
 
     #[test]

--- a/protocols/v2/roles-logic-sv2/src/channels/chain_tip.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/chain_tip.rs
@@ -1,5 +1,5 @@
 //! # Chain Tip
-use binary_sv2::U256;
+use codec_sv2::binary_sv2::U256;
 
 /// An abstraction over the chain tip, carrying information from `SetNewPrevHash` messages.
 ///

--- a/protocols/v2/roles-logic-sv2/src/channels/client/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/client/extended.rs
@@ -10,17 +10,17 @@ use crate::{
     },
     utils::{bytes_to_hex, merkle_root_from_path, target_to_difficulty, u256_to_block_hash},
 };
-use binary_sv2::Sv2Option;
+use bitcoin::{
+    blockdata::block::{Header, Version},
+    hashes::sha256d::Hash,
+    CompactTarget, Target as BitcoinTarget,
+};
+use codec_sv2::binary_sv2::{self, Sv2Option};
 use mining_sv2::{
     NewExtendedMiningJob, SetNewPrevHash as SetNewPrevHashMp, SubmitSharesExtended, Target,
     MAX_EXTRANONCE_LEN,
 };
 use std::{collections::HashMap, convert::TryInto};
-use stratum_common::bitcoin::{
-    blockdata::block::{Header, Version},
-    hashes::sha256d::Hash,
-    CompactTarget, Target as BitcoinTarget,
-};
 use tracing::debug;
 
 // ExtendedJob is a tuple of:
@@ -390,7 +390,7 @@ mod tests {
         extended::ExtendedChannel,
         share_accounting::{ShareValidationError, ShareValidationResult},
     };
-    use binary_sv2::Sv2Option;
+    use codec_sv2::binary_sv2::Sv2Option;
     use mining_sv2::{
         NewExtendedMiningJob, SetNewPrevHash as SetNewPrevHashMp, SubmitSharesExtended,
         MAX_EXTRANONCE_LEN,

--- a/protocols/v2/roles-logic-sv2/src/channels/client/share_accounting.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/client/share_accounting.rs
@@ -1,7 +1,7 @@
 //! Abstractions for share validation for a Mining Client
 
+use bitcoin::hashes::sha256d::Hash;
 use std::collections::HashSet;
-use stratum_common::bitcoin::hashes::sha256d::Hash;
 
 /// The outcome of share validation, from the perspective of a Mining Client.
 #[derive(Debug)]

--- a/protocols/v2/roles-logic-sv2/src/channels/client/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/client/standard.rs
@@ -10,17 +10,17 @@ use crate::{
     },
     utils::{bytes_to_hex, merkle_root_from_path, target_to_difficulty, u256_to_block_hash},
 };
-use binary_sv2::Sv2Option;
+use bitcoin::{
+    blockdata::block::{Header, Version},
+    hashes::sha256d::Hash,
+    CompactTarget, Target as BitcoinTarget,
+};
+use codec_sv2::binary_sv2::{self, Sv2Option};
 use mining_sv2::{
     NewExtendedMiningJob, NewMiningJob, SetNewPrevHash as SetNewPrevHashMp, SubmitSharesStandard,
     Target, MAX_EXTRANONCE_LEN,
 };
 use std::{collections::HashMap, convert::TryInto};
-use stratum_common::bitcoin::{
-    blockdata::block::{Header, Version},
-    hashes::sha256d::Hash,
-    CompactTarget, Target as BitcoinTarget,
-};
 use tracing::debug;
 
 /// Mining Client abstraction over the state of a Sv2 Standard Channel.
@@ -350,7 +350,7 @@ mod tests {
         share_accounting::{ShareValidationError, ShareValidationResult},
         standard::StandardChannel,
     };
-    use binary_sv2::Sv2Option;
+    use codec_sv2::binary_sv2::Sv2Option;
     use mining_sv2::{NewMiningJob, SetNewPrevHash as SetNewPrevHashMp, SubmitSharesStandard};
 
     #[test]

--- a/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
@@ -14,14 +14,15 @@ use crate::{
         u256_to_block_hash,
     },
 };
-use mining_sv2::{SetCustomMiningJob, SubmitSharesExtended, Target, MAX_EXTRANONCE_LEN};
-use std::{collections::HashMap, convert::TryInto};
-use stratum_common::bitcoin::{
+use bitcoin::{
     blockdata::block::{Header, Version},
     hashes::sha256d::Hash,
     transaction::TxOut,
     CompactTarget, Target as BitcoinTarget,
 };
+use codec_sv2::binary_sv2;
+use mining_sv2::{SetCustomMiningJob, SubmitSharesExtended, Target, MAX_EXTRANONCE_LEN};
+use std::{collections::HashMap, convert::TryInto};
 use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
 use tracing::debug;
 
@@ -604,10 +605,10 @@ mod tests {
             share_accounting::{ShareValidationError, ShareValidationResult},
         },
     };
-    use binary_sv2::Sv2Option;
+    use bitcoin::{transaction::TxOut, Amount, ScriptBuf};
+    use codec_sv2::binary_sv2::Sv2Option;
     use mining_sv2::{NewExtendedMiningJob, SubmitSharesExtended, Target, MAX_EXTRANONCE_LEN};
     use std::convert::TryInto;
-    use stratum_common::bitcoin::{transaction::TxOut, Amount, ScriptBuf};
     use template_distribution_sv2::{NewTemplate, SetNewPrevHash};
 
     const SATS_AVAILABLE_IN_TEMPLATE: u64 = 5000000000;

--- a/protocols/v2/roles-logic-sv2/src/channels/server/group.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/group.rs
@@ -6,7 +6,7 @@ use crate::channels::{
         jobs::{extended::ExtendedJob, factory::JobFactory},
     },
 };
-use stratum_common::bitcoin::transaction::TxOut;
+use bitcoin::transaction::TxOut;
 use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
 
 use std::collections::{HashMap, HashSet};
@@ -196,10 +196,10 @@ impl<'a> GroupChannel<'a> {
 #[cfg(test)]
 mod tests {
     use crate::channels::{chain_tip::ChainTip, server::group::GroupChannel};
-    use binary_sv2::Sv2Option;
+    use bitcoin::{transaction::TxOut, Amount, ScriptBuf};
+    use codec_sv2::binary_sv2::Sv2Option;
     use mining_sv2::NewExtendedMiningJob;
     use std::convert::TryInto;
-    use stratum_common::bitcoin::{transaction::TxOut, Amount, ScriptBuf};
     use template_distribution_sv2::{NewTemplate, SetNewPrevHash};
 
     const SATS_AVAILABLE_IN_TEMPLATE: u64 = 5000000000;

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
@@ -6,13 +6,13 @@ use crate::{
     template_distribution_sv2::NewTemplate,
     utils::deserialize_outputs,
 };
-use binary_sv2::{Seq0255, Sv2Option, B0255, B064K, U256};
-use mining_sv2::{NewExtendedMiningJob, SetCustomMiningJob, MAX_EXTRANONCE_LEN};
-use std::convert::TryInto;
-use stratum_common::bitcoin::{
+use bitcoin::{
     consensus::{deserialize, serialize},
     transaction::{Transaction, TxOut},
 };
+use codec_sv2::binary_sv2::{Seq0255, Sv2Option, B0255, B064K, U256};
+use mining_sv2::{NewExtendedMiningJob, SetCustomMiningJob, MAX_EXTRANONCE_LEN};
+use std::convert::TryInto;
 
 /// Abstraction of an extended mining job with:
 /// - the `NewTemplate` OR `SetCustomMiningJob` message that originated it

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/factory.rs
@@ -7,16 +7,16 @@ use crate::{
     template_distribution_sv2::NewTemplate,
     utils::{deserialize_outputs, merkle_root_from_path, Id as JobIdFactory},
 };
-use binary_sv2::{Sv2Option, B064K};
-use mining_sv2::{NewExtendedMiningJob, NewMiningJob, SetCustomMiningJob, MAX_EXTRANONCE_LEN};
-use std::convert::TryInto;
-use stratum_common::bitcoin::{
+use bitcoin::{
     absolute::LockTime,
     blockdata::witness::Witness,
     consensus::{serialize, Decodable},
     transaction::{OutPoint, Transaction, TxIn, TxOut, Version},
     Amount, Sequence,
 };
+use codec_sv2::binary_sv2::{Sv2Option, B064K};
+use mining_sv2::{NewExtendedMiningJob, NewMiningJob, SetCustomMiningJob, MAX_EXTRANONCE_LEN};
+use std::convert::TryInto;
 
 /// A Factory for creating Extended or Standard Jobs.
 ///
@@ -404,7 +404,7 @@ impl JobFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stratum_common::bitcoin::ScriptBuf;
+    use bitcoin::ScriptBuf;
     use template_distribution_sv2::NewTemplate;
 
     #[test]

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
@@ -1,7 +1,7 @@
 use crate::utils::deserialize_outputs;
-use binary_sv2::{Sv2Option, U256};
+use bitcoin::transaction::TxOut;
+use codec_sv2::binary_sv2::{Sv2Option, U256};
 use mining_sv2::NewMiningJob;
-use stratum_common::bitcoin::transaction::TxOut;
 use template_distribution_sv2::NewTemplate;
 
 /// Abstraction of a standard mining job with:

--- a/protocols/v2/roles-logic-sv2/src/channels/server/share_accounting.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/share_accounting.rs
@@ -1,7 +1,7 @@
 //! Abstractions for share validation for a Mining Server
 
+use bitcoin::hashes::sha256d::Hash;
 use std::collections::HashSet;
-use stratum_common::bitcoin::hashes::sha256d::Hash;
 
 /// The outcome of share validation, from the perspective of a Mining Server.
 ///

--- a/protocols/v2/roles-logic-sv2/src/channels/server/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/standard.rs
@@ -10,9 +10,7 @@ use crate::{
     },
     utils::{bytes_to_hex, hash_rate_to_target, target_to_difficulty, u256_to_block_hash},
 };
-use mining_sv2::{SubmitSharesStandard, Target, MAX_EXTRANONCE_LEN};
-use std::{collections::HashMap, convert::TryInto};
-use stratum_common::bitcoin::{
+use bitcoin::{
     absolute::LockTime,
     blockdata::{
         block::{Header, Version},
@@ -23,6 +21,9 @@ use stratum_common::bitcoin::{
     transaction::{OutPoint, Transaction, TxIn, TxOut, Version as TxVersion},
     CompactTarget, Sequence, Target as BitcoinTarget,
 };
+use codec_sv2::binary_sv2;
+use mining_sv2::{SubmitSharesStandard, Target, MAX_EXTRANONCE_LEN};
+use std::{collections::HashMap, convert::TryInto};
 use template_distribution_sv2::{NewTemplate, SetNewPrevHash};
 use tracing::debug;
 
@@ -539,10 +540,10 @@ mod tests {
             standard::StandardChannel,
         },
     };
-    use binary_sv2::Sv2Option;
+    use bitcoin::{transaction::TxOut, Amount, ScriptBuf};
+    use codec_sv2::binary_sv2::Sv2Option;
     use mining_sv2::{NewMiningJob, SubmitSharesStandard, Target};
     use std::convert::TryInto;
-    use stratum_common::bitcoin::{transaction::TxOut, Amount, ScriptBuf};
     use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
 
     const SATS_AVAILABLE_IN_TEMPLATE: u64 = 5000000000;

--- a/protocols/v2/roles-logic-sv2/src/errors.rs
+++ b/protocols/v2/roles-logic-sv2/src/errors.rs
@@ -10,13 +10,13 @@ use crate::{
     utils::InputError,
     vardiff::error::VardiffError,
 };
-use binary_sv2::Error as BinarySv2Error;
+use bitcoin::hashes::FromSliceError;
+use codec_sv2::binary_sv2::Error as BinarySv2Error;
 use mining_sv2::ExtendedExtranonceError;
 use std::{
     fmt::{self, Display, Formatter},
     sync::{MutexGuard, PoisonError},
 };
-use stratum_common::bitcoin::hashes::FromSliceError;
 
 /// Error enum
 #[derive(Debug)]

--- a/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
@@ -28,6 +28,7 @@
 //!   handling edge cases and ensuring the correctness of the mining process.
 
 use crate::{errors::Error, parsers::Mining};
+use codec_sv2::binary_sv2;
 use core::convert::TryInto;
 use mining_sv2::{
     CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannel,

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -3,23 +3,20 @@
 //! This module provides logic to create extended mining jobs given a template from
 //! a template provider as well as logic to clean up old templates when new blocks are mined.
 use crate::{errors, utils::Id, Error};
-use binary_sv2::B064K;
+use bitcoin::{
+    absolute::LockTime,
+    blockdata::{
+        transaction::{OutPoint, Transaction, TxIn, TxOut, Version},
+        witness::Witness,
+    },
+    consensus,
+    consensus::Decodable,
+    Amount,
+};
+use codec_sv2::binary_sv2::{self, B064K};
 use mining_sv2::NewExtendedMiningJob;
 use nohash_hasher::BuildNoHashHasher;
 use std::{collections::HashMap, convert::TryInto};
-use stratum_common::{
-    bitcoin,
-    bitcoin::{
-        absolute::LockTime,
-        blockdata::{
-            transaction::{OutPoint, Transaction, TxIn, TxOut, Version},
-            witness::Witness,
-        },
-        consensus,
-        consensus::Decodable,
-        Amount,
-    },
-};
 use template_distribution_sv2::{NewTemplate, SetNewPrevHash};
 use tracing::debug;
 
@@ -435,16 +432,14 @@ pub mod tests {
     use super::*;
     use crate::utils::merkle_root_from_path;
     #[cfg(feature = "prop_test")]
-    use binary_sv2::u256_from_int;
+    use codec_sv2::binary_sv2::u256_from_int;
     use quickcheck::{Arbitrary, Gen};
     use std::{cmp, vec};
 
     #[cfg(feature = "prop_test")]
     use std::borrow::BorrowMut;
 
-    use stratum_common::bitcoin::{
-        consensus::Encodable, secp256k1::Secp256k1, Network, PrivateKey, PublicKey,
-    };
+    use bitcoin::{consensus::Encodable, secp256k1::Secp256k1, Network, PrivateKey, PublicKey};
 
     pub fn template_from_gen(g: &mut Gen) -> NewTemplate<'static> {
         let mut coinbase_prefix_gen = Gen::new(255);
@@ -501,7 +496,7 @@ pub mod tests {
     }
 
     #[cfg(feature = "prop_test")]
-    use stratum_common::bitcoin::ScriptBuf;
+    use bitcoin::ScriptBuf;
 
     // Test job_id_from_template
     #[cfg(feature = "prop_test")]

--- a/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_dispatcher.rs
@@ -18,7 +18,7 @@ use mining_sv2::{
 use nohash_hasher::BuildNoHashHasher;
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
 
-use stratum_common::bitcoin::hashes::{sha256d, Hash, HashEngine};
+use bitcoin::hashes::{sha256d, Hash, HashEngine};
 
 /// Used to convert an extended mining job to a standard mining job. The `extranonce` field must
 /// be exactly 32 bytes.
@@ -239,12 +239,12 @@ mod tests {
             JobsCreators,
         },
     };
-    use binary_sv2::{u256_from_int, U256};
+    use codec_sv2::binary_sv2::{u256_from_int, U256};
     use mining_sv2::Extranonce;
     use quickcheck::{Arbitrary, Gen};
     use std::convert::TryFrom;
 
-    use stratum_common::bitcoin::{Amount, ScriptBuf, TxOut};
+    use bitcoin::{Amount, ScriptBuf, TxOut};
 
     const BLOCK_REWARD: u64 = 625_000_000_000;
 

--- a/protocols/v2/roles-logic-sv2/src/lib.rs
+++ b/protocols/v2/roles-logic-sv2/src/lib.rs
@@ -27,6 +27,8 @@ pub mod job_dispatcher;
 pub mod parsers;
 pub mod utils;
 pub mod vardiff;
+pub use bitcoin;
+pub use codec_sv2;
 pub use common_messages_sv2;
 pub use errors::Error;
 pub use job_declaration_sv2;

--- a/protocols/v2/roles-logic-sv2/src/parsers.rs
+++ b/protocols/v2/roles-logic-sv2/src/parsers.rs
@@ -21,14 +21,17 @@
 //!   submission).
 
 use crate::Error;
-use binary_sv2::{
-    decodable::{DecodableField, FieldMarker},
-    encodable::EncodableField,
-    from_bytes, Deserialize, GetSize,
+use codec_sv2::{
+    binary_sv2::{
+        self,
+        decodable::{DecodableField, FieldMarker},
+        encodable::EncodableField,
+        from_bytes, Deserialize, GetSize,
+    },
+    framing_sv2::framing::Sv2Frame,
 };
 use common_messages_sv2::*;
 use core::convert::{TryFrom, TryInto};
-use framing_sv2::framing::Sv2Frame;
 use job_declaration_sv2::*;
 use mining_sv2::*;
 use template_distribution_sv2::*;
@@ -1215,8 +1218,10 @@ mod test {
         mining_sv2::NewMiningJob,
         parsers::{AnyMessage, Mining},
     };
-    use binary_sv2::{Sv2Option, U256};
-    use codec_sv2::StandardSv2Frame;
+    use codec_sv2::{
+        binary_sv2::{Sv2Option, U256},
+        StandardSv2Frame,
+    };
     use std::convert::{TryFrom, TryInto};
 
     pub type Message = AnyMessage<'static>;

--- a/protocols/v2/roles-logic-sv2/src/utils.rs
+++ b/protocols/v2/roles-logic-sv2/src/utils.rs
@@ -5,8 +5,16 @@
 //! management, mutex management, difficulty target calculations, merkle root calculations, and
 //! more.
 
-use binary_sv2::U256;
-use bitcoin::Block;
+use bitcoin::{
+    blockdata::block::{Header, Version},
+    consensus,
+    consensus::Decodable,
+    hash_types::{BlockHash, TxMerkleNode},
+    hashes::{sha256d::Hash as DHash, Hash},
+    transaction::TxOut,
+    Block, CompactTarget, Transaction,
+};
+use codec_sv2::binary_sv2::U256;
 use job_declaration_sv2::{DeclareMiningJob, PushSolution};
 use mining_sv2::Target;
 use primitive_types::U256 as U256Primitive;
@@ -16,18 +24,6 @@ use std::{
     fmt::Write,
     ops::Div,
     sync::{Mutex as Mutex_, MutexGuard, PoisonError},
-};
-use stratum_common::{
-    bitcoin,
-    bitcoin::{
-        blockdata::block::{Header, Version},
-        consensus,
-        consensus::Decodable,
-        hash_types::{BlockHash, TxMerkleNode},
-        hashes::{sha256d::Hash as DHash, Hash},
-        transaction::TxOut,
-        CompactTarget, Transaction,
-    },
 };
 use tracing::error;
 
@@ -888,7 +884,7 @@ impl<'a> From<BlockCreator<'a>> for bitcoin::Block {
 mod tests {
 
     use super::{hash_rate_from_target, hash_rate_to_target, *};
-    use binary_sv2::{Seq0255, B064K, U256};
+    use codec_sv2::binary_sv2::{Seq0255, B064K, U256};
     use rand::Rng;
     use serde::Deserialize;
     use std::{convert::TryInto, num::ParseIntError};

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 binary_sv2 = { path = "../../binary-sv2", version = "^3.0.0" }
-stratum-common = { version = "^2.0.0", path = "../../../../common" }
 quickcheck = { version = "1.0.3", optional = true }
 quickcheck_macros = { version = "1", optional = true }
 

--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -14,4 +14,3 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 binary_sv2 = { path = "../../binary-sv2", version = "^3.0.0" }
-stratum-common = { version = "^2.0.0", path = "../../../../common" }

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 binary_sv2 = { path = "../../binary-sv2", version = "^3.0.0" }
-stratum-common = { version = "^2.0.0", path = "../../../../common" }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/protocols/v2/subprotocols/template-distribution/Cargo.toml
+++ b/protocols/v2/subprotocols/template-distribution/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 binary_sv2 = { path = "../../binary-sv2", version = "^3.0.0" }
-stratum-common = { version = "^2.0.0", path = "../../../../common" }
 quickcheck = { version = "1.0.3", optional=true }
 quickcheck_macros = { version = "1", optional=true }
 

--- a/protocols/v2/sv2-ffi/Cargo.toml
+++ b/protocols/v2/sv2-ffi/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 codec_sv2 = { path = "../codec-sv2", version = "^2.0.0" }
-stratum-common = { version = "^2.0.0", path = "../../../common" }
 binary_sv2 = { path = "../binary-sv2", version = "^3.0.0" }
 common_messages_sv2 = { path = "../subprotocols/common-messages", version = "^5.0.0" }
 template_distribution_sv2 = { path = "../subprotocols/template-distribution", version = "^3.0.0" }

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -174,14 +174,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -202,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -213,7 +214,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -515,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "byte-slice-cast"
@@ -636,7 +637,6 @@ dependencies = [
  "framing_sv2",
  "noise_sv2",
  "rand 0.8.5",
- "stratum-common",
  "tracing",
 ]
 
@@ -651,7 +651,6 @@ name = "common_messages_sv2"
 version = "5.1.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -973,7 +972,6 @@ dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "noise_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1207,9 +1205,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1377,8 +1375,6 @@ name = "integration_tests_sv2"
 version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
- "binary_sv2",
- "codec_sv2",
  "config-helpers",
  "corepc-node",
  "flate2",
@@ -1389,11 +1385,9 @@ dependencies = [
  "mining_device_sv1",
  "mining_proxy_sv2",
  "minreq",
- "network_helpers_sv2",
  "once_cell",
  "pool_sv2",
  "rand 0.9.0",
- "roles_logic_sv2",
  "stratum-common",
  "tar",
  "tokio",
@@ -1420,20 +1414,16 @@ version = "0.1.4"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "config-helpers",
  "error_handling",
- "framing_sv2",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
  "primitive-types",
- "roles_logic_sv2",
+ "secp256k1 0.28.2",
  "serde",
  "stratum-common",
  "tokio",
@@ -1446,21 +1436,16 @@ name = "jd_server"
 version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "config-helpers",
  "error_handling",
  "hashbrown 0.11.2",
  "hex",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
- "noise_sv2",
  "rand 0.8.5",
- "roles_logic_sv2",
  "rpc_sv2",
  "serde",
  "serde_json",
@@ -1475,7 +1460,6 @@ name = "job_declaration_sv2"
 version = "4.0.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1556,12 +1540,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
@@ -1603,16 +1581,12 @@ version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "primitive-types",
  "rand 0.8.5",
- "roles_logic_sv2",
  "sha2 0.10.8",
  "stratum-common",
  "tokio",
@@ -1628,7 +1602,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "primitive-types",
- "roles_logic_sv2",
  "serde",
  "serde_json",
  "stratum-common",
@@ -1644,17 +1617,13 @@ version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
  "once_cell",
- "roles_logic_sv2",
  "serde",
  "stratum-common",
  "tokio",
@@ -1667,7 +1636,6 @@ name = "mining_sv2"
 version = "4.0.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1717,15 +1685,13 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-std",
- "binary_sv2",
  "codec_sv2",
  "futures",
  "serde_json",
- "stratum-common",
  "sv1_api",
  "tokio",
  "tokio-util",
@@ -1747,7 +1713,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "secp256k1 0.28.2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1968,15 +1933,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2010,21 +1975,17 @@ version = "0.1.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 1.1.1",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "config-helpers",
  "error_handling",
  "hex",
  "integration_tests_sv2",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
- "noise_sv2",
  "rand 0.8.5",
- "roles_logic_sv2",
+ "secp256k1 0.28.2",
  "serde",
  "stratum-common",
  "tokio",
@@ -2178,16 +2139,15 @@ dependencies = [
 name = "roles_logic_sv2"
 version = "3.0.0"
 dependencies = [
- "binary_sv2",
+ "bitcoin",
  "chacha20poly1305",
+ "codec_sv2",
  "common_messages_sv2",
- "framing_sv2",
  "hex-conservative 0.3.0",
  "job_declaration_sv2",
  "mining_sv2",
  "nohash-hasher",
  "primitive-types",
- "stratum-common",
  "template_distribution_sv2",
  "tracing",
 ]
@@ -2242,27 +2202,14 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -2478,10 +2425,10 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-common"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
- "bitcoin",
- "secp256k1 0.28.2",
+ "network_helpers_sv2",
+ "roles_logic_sv2",
 ]
 
 [[package]]
@@ -2555,7 +2502,7 @@ checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
  "once_cell",
- "rustix 1.0.3",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2564,7 +2511,6 @@ name = "template_distribution_sv2"
 version = "3.1.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -2752,20 +2698,15 @@ version = "1.0.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "error_handling",
- "framing_sv2",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "once_cell",
  "primitive-types",
  "rand 0.8.5",
- "roles_logic_sv2",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/roles/Cargo.toml
+++ b/roles/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "test-utils/mining-device-sv1",
     "translator",
     "jd-client",
-    "jd-server"
+    "jd-server",
+    "roles-utils/network-helpers"
 ]
 
 [profile.dev]

--- a/roles/jd-client/Cargo.toml
+++ b/roles/jd-client/Cargo.toml
@@ -16,15 +16,11 @@ name = "jd_client"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-common = { path = "../../common", features=["bitcoin"]}
+secp256k1 = { version = "0.28.2", default-features = false, features = ["alloc", "rand", "rand-std"] }
 async-channel = "1.5.1"
 async-recursion = "0.3.2"
-binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 buffer_sv2 = { path = "../../utils/buffer" }
-codec_sv2 = { path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-framing_sv2 = { path = "../../protocols/v2/framing-sv2" }
-network_helpers_sv2 = { path = "../roles-utils/network-helpers", features=["with_buffer_pool"] }
-roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
+stratum-common = { path = "../../common", features = ["with_network_helpers"] }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 futures = "0.3.25"
 tokio = { version = "1.44.1", features = ["full"] }

--- a/roles/jd-client/src/lib/config.rs
+++ b/roles/jd-client/src/lib/config.rs
@@ -10,7 +10,7 @@ use config_helpers::CoinbaseOutput;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use serde::Deserialize;
 use std::{net::SocketAddr, time::Duration};
-use stratum_common::bitcoin::{Amount, TxOut};
+use stratum_common::roles_logic_sv2::bitcoin::{Amount, TxOut};
 
 /// Represents the configuration of a Job Declarator Client (JDC).
 ///

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -28,8 +28,11 @@ use super::{
     upstream_sv2::Upstream as UpstreamMiningNode,
 };
 use async_channel::{bounded, Receiver, SendError, Sender};
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
+    self,
+    bitcoin::{consensus::Decodable, TxOut},
     channel_logic::channel_factory::{OnNewShare, PoolChannelFactory, Share},
+    codec_sv2,
     common_messages_sv2::{SetupConnection, SetupConnectionSuccess},
     common_properties::{CommonDownstreamData, IsDownstream, IsMiningDownstream},
     errors::Error,
@@ -48,8 +51,6 @@ use tracing::{debug, error, info, warn};
 
 use codec_sv2::{HandshakeRole, Responder, StandardEitherFrame, StandardSv2Frame};
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
-
-use stratum_common::bitcoin::{consensus::Decodable, TxOut};
 
 pub type Message = MiningDeviceMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
@@ -939,9 +940,11 @@ impl ParseCommonMessagesFromDownstream for DownstreamMiningNode {
     }
 }
 
-use binary_sv2::Str0255;
-use network_helpers_sv2::noise_connection::Connection;
 use std::net::SocketAddr;
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::codec_sv2::binary_sv2::Str0255,
+};
 use tokio::{
     net::TcpListener,
     task::AbortHandle,

--- a/roles/jd-client/src/lib/error.rs
+++ b/roles/jd-client/src/lib/error.rs
@@ -12,8 +12,12 @@
 //! This module ensures that all errors can be passed around consistently, including across async
 //! boundaries.
 use ext_config::ConfigError;
-use roles_logic_sv2::mining_sv2::{ExtendedExtranonce, NewExtendedMiningJob, SetCustomMiningJob};
 use std::fmt;
+use stratum_common::roles_logic_sv2::{
+    self,
+    codec_sv2::{self, binary_sv2, framing_sv2},
+    mining_sv2::{ExtendedExtranonce, NewExtendedMiningJob, SetCustomMiningJob},
+};
 
 pub type ProxyResult<'a, T> = core::result::Result<T, Error<'a>>;
 

--- a/roles/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-client/src/lib/job_declarator/message_handler.rs
@@ -3,7 +3,8 @@
 //! Handles upstream Job Declaration Protocol messages by implementing the
 //! `ParseJobDeclarationMessagesFromUpstream` trait.
 use super::JobDeclarator;
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
+    codec_sv2::binary_sv2,
     handlers::{job_declaration::ParseJobDeclarationMessagesFromUpstream, SendTo_},
     job_declaration_sv2::{
         AllocateMiningJobTokenSuccess, DeclareMiningJobError, DeclareMiningJobSuccess,
@@ -13,7 +14,7 @@ use roles_logic_sv2::{
 };
 use tracing::{debug, error, info};
 pub type SendTo = SendTo_<JobDeclaration<'static>, ()>;
-use roles_logic_sv2::errors::Error;
+use stratum_common::roles_logic_sv2::errors::Error;
 
 impl ParseJobDeclarationMessagesFromUpstream for JobDeclarator {
     /// Handles an `AllocateMiningJobTokenSuccess` message received from the JDS.

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -13,31 +13,35 @@
 
 pub mod message_handler;
 use async_channel::{Receiver, Sender};
-use binary_sv2::{Seq0255, Seq064K, B016M, B064K, U256};
-use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
-use network_helpers_sv2::noise_connection::Connection;
-use roles_logic_sv2::{
-    handlers::SendTo_,
-    job_declaration_sv2::{AllocateMiningJobTokenSuccess, PushSolution},
-    mining_sv2::SubmitSharesExtended,
-    parsers::{AnyMessage, JobDeclaration},
-    template_distribution_sv2::SetNewPrevHash,
-    utils::Mutex,
-};
 use std::{collections::HashMap, convert::TryInto};
-use stratum_common::bitcoin::{consensus, hashes::Hash, Transaction};
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        bitcoin::{consensus, hashes::Hash, Transaction},
+        codec_sv2::{
+            binary_sv2::{Seq0255, Seq064K, B016M, B064K, U256},
+            HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame,
+        },
+        handlers::SendTo_,
+        job_declaration_sv2::{AllocateMiningJobTokenSuccess, PushSolution},
+        mining_sv2::SubmitSharesExtended,
+        parsers::{AnyMessage, JobDeclaration},
+        template_distribution_sv2::SetNewPrevHash,
+        utils::Mutex,
+    },
+};
 use tokio::task::AbortHandle;
 use tracing::{debug, error, info};
 
 use async_recursion::async_recursion;
 use nohash_hasher::BuildNoHashHasher;
-use roles_logic_sv2::{
+use std::{net::SocketAddr, sync::Arc};
+use stratum_common::roles_logic_sv2::{
     handlers::job_declaration::ParseJobDeclarationMessagesFromUpstream,
     job_declaration_sv2::{AllocateMiningJobToken, DeclareMiningJob},
     template_distribution_sv2::NewTemplate,
     utils::Id,
 };
-use std::{net::SocketAddr, sync::Arc};
 
 pub type Message = AnyMessage<'static>;
 pub type SendTo = SendTo_<JobDeclaration<'static>, ()>;

--- a/roles/jd-client/src/lib/job_declarator/setup_connection.rs
+++ b/roles/jd-client/src/lib/job_declarator/setup_connection.rs
@@ -6,15 +6,16 @@
 //! and handling common SV2 connection-related messages.
 
 use async_channel::{Receiver, Sender};
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use roles_logic_sv2::{
+use std::{convert::TryInto, net::SocketAddr, sync::Arc};
+use stratum_common::roles_logic_sv2::{
+    self,
+    codec_sv2::{StandardEitherFrame, StandardSv2Frame},
     common_messages_sv2::{Protocol, Reconnect, SetupConnection},
     handlers::common::{ParseCommonMessagesFromUpstream, SendTo},
     parsers::AnyMessage,
     utils::Mutex,
     Error,
 };
-use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 use tracing::info;
 
 pub type Message = AnyMessage<'static>;

--- a/roles/jd-client/src/lib/mod.rs
+++ b/roles/jd-client/src/lib/mod.rs
@@ -19,12 +19,12 @@ use async_channel::unbounded;
 use config::JobDeclaratorClientConfig;
 use futures::{select, FutureExt};
 use job_declarator::JobDeclarator;
-use roles_logic_sv2::utils::Mutex;
 use std::{
     net::{IpAddr, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
+use stratum_common::roles_logic_sv2::utils::Mutex;
 use tokio::{sync::Notify, task::AbortHandle};
 
 use tracing::{error, info};

--- a/roles/jd-client/src/lib/template_receiver/message_handler.rs
+++ b/roles/jd-client/src/lib/template_receiver/message_handler.rs
@@ -6,7 +6,7 @@
 //! template distribution messages received from a server, and how it responds
 //! to each message type accordingly.
 use super::TemplateRx;
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
     errors::Error,
     handlers::template_distribution::{ParseTemplateDistributionMessagesFromServer, SendTo},
     parsers::TemplateDistribution,

--- a/roles/jd-client/src/lib/template_receiver/mod.rs
+++ b/roles/jd-client/src/lib/template_receiver/mod.rs
@@ -7,24 +7,27 @@
 //! and downstream subsystem.
 use super::{job_declarator::JobDeclarator, status, PoolChangerTrigger};
 use async_channel::{Receiver, Sender};
-use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
-use network_helpers_sv2::noise_connection::Connection;
-use roles_logic_sv2::{
-    handlers::{template_distribution::ParseTemplateDistributionMessagesFromServer, SendTo_},
-    job_declaration_sv2::AllocateMiningJobTokenSuccess,
-    parsers::{AnyMessage, TemplateDistribution},
-    template_distribution_sv2::{
-        CoinbaseOutputConstraints, NewTemplate, RequestTransactionData, SubmitSolution,
-    },
-    utils::Mutex,
-};
 use setup_connection::SetupConnectionHandler;
 use std::{convert::TryInto, net::SocketAddr, sync::Arc};
-use stratum_common::bitcoin::{
-    consensus::{deserialize, Encodable},
-    Transaction, TxOut,
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        self,
+        bitcoin::{
+            consensus::{deserialize, Encodable},
+            Transaction, TxOut,
+        },
+        codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame},
+        handlers::{template_distribution::ParseTemplateDistributionMessagesFromServer, SendTo_},
+        job_declaration_sv2::AllocateMiningJobTokenSuccess,
+        parsers::{AnyMessage, TemplateDistribution},
+        template_distribution_sv2::{
+            CoinbaseOutputConstraints, NewTemplate, RequestTransactionData, SubmitSolution,
+        },
+        utils::Mutex,
+    },
 };
 use tokio::task::AbortHandle;
 use tracing::{error, info, warn};

--- a/roles/jd-client/src/lib/template_receiver/setup_connection.rs
+++ b/roles/jd-client/src/lib/template_receiver/setup_connection.rs
@@ -5,15 +5,16 @@
 //! This includes sending a `SetupConnection` message and processing responses from the upstream.
 
 use async_channel::{Receiver, Sender};
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use roles_logic_sv2::{
+use std::{convert::TryInto, net::SocketAddr, sync::Arc};
+use stratum_common::roles_logic_sv2::{
+    self,
+    codec_sv2::{StandardEitherFrame, StandardSv2Frame},
     common_messages_sv2::{Protocol, Reconnect, SetupConnection},
     handlers::common::{ParseCommonMessagesFromUpstream, SendTo},
     parsers::AnyMessage,
     utils::Mutex,
     Error,
 };
-use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 use tracing::info;
 
 pub type Message = AnyMessage<'static>;

--- a/roles/jd-client/src/lib/upstream_sv2/mod.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/mod.rs
@@ -1,5 +1,7 @@
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use roles_logic_sv2::parsers::AnyMessage;
+use stratum_common::roles_logic_sv2::{
+    codec_sv2::{StandardEitherFrame, StandardSv2Frame},
+    parsers::AnyMessage,
+};
 
 pub mod upstream;
 pub use upstream::Upstream;

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -34,31 +34,37 @@ use super::super::{
     PoolChangerTrigger,
 };
 use async_channel::{Receiver, Sender};
-use binary_sv2::{Seq0255, U256};
-use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
-use network_helpers_sv2::noise_connection::Connection;
-use roles_logic_sv2::{
-    channel_logic::channel_factory::PoolChannelFactory,
-    common_messages_sv2::{Protocol, Reconnect, SetupConnection},
-    common_properties::{IsMiningUpstream, IsUpstream},
-    handlers::{
-        common::{ParseCommonMessagesFromUpstream, SendTo as SendToCommon},
-        mining::{ParseMiningMessagesFromUpstream, SendTo, SupportedChannelTypes},
-    },
-    job_declaration_sv2::DeclareMiningJob,
-    mining_sv2::{ExtendedExtranonce, Extranonce, SetCustomMiningJob, SetGroupChannel},
-    parsers::{AnyMessage, Mining, MiningDeviceMessages},
-    utils::{Id, Mutex},
-    Error as RolesLogicError,
-};
 use std::{
     collections::{HashMap, VecDeque},
     net::SocketAddr,
     sync::Arc,
     thread::sleep,
     time::Duration,
+};
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2,
+    roles_logic_sv2::{
+        channel_logic::channel_factory::PoolChannelFactory,
+        codec_sv2::{
+            self, binary_sv2,
+            binary_sv2::{Seq0255, U256},
+            framing_sv2, HandshakeRole, Initiator,
+        },
+        common_messages_sv2::{Protocol, Reconnect, SetupConnection},
+        common_properties::{IsMiningUpstream, IsUpstream},
+        handlers::{
+            common::{ParseCommonMessagesFromUpstream, SendTo as SendToCommon},
+            mining::{ParseMiningMessagesFromUpstream, SendTo, SupportedChannelTypes},
+        },
+        job_declaration_sv2::DeclareMiningJob,
+        mining_sv2::{ExtendedExtranonce, Extranonce, SetCustomMiningJob, SetGroupChannel},
+        parsers::{AnyMessage, Mining, MiningDeviceMessages},
+        utils::{Id, Mutex},
+        Error as RolesLogicError,
+    },
 };
 use tokio::{net::TcpStream, task, task::AbortHandle};
 use tracing::{debug, error, info, warn};

--- a/roles/jd-server/Cargo.toml
+++ b/roles/jd-server/Cargo.toml
@@ -17,15 +17,10 @@ name = "jd_server"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-common = { version = "2.0.0", path = "../../common" }
+stratum-common = { path = "../../common", features = ["with_network_helpers"] }
 async-channel = "1.5.1"
-binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 buffer_sv2 = { path = "../../utils/buffer" }
-codec_sv2 = { path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
-network_helpers_sv2 = { path = "../roles-utils/network-helpers" }
-noise_sv2 = { path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"
-roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 tokio = { version = "1.44.1", features = ["full"] }
 ext-config = { version = "0.14.0", features = ["toml"], package = "config" }
 tracing = { version = "0.1" }

--- a/roles/jd-server/src/lib/config.rs
+++ b/roles/jd-server/src/lib/config.rs
@@ -15,7 +15,7 @@ use config_helpers::CoinbaseOutput;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
 use serde::Deserialize;
 use std::{convert::TryInto, time::Duration};
-use stratum_common::bitcoin::{Amount, TxOut};
+use stratum_common::roles_logic_sv2::bitcoin::{Amount, TxOut};
 
 #[derive(Debug, serde::Deserialize, Clone)]
 pub struct JobDeclaratorServerConfig {
@@ -174,7 +174,7 @@ mod tests {
     use config_helpers::CoinbaseOutput;
     use ext_config::{Config, File, FileFormat};
     use std::{convert::TryInto, path::PathBuf};
-    use stratum_common::bitcoin::{Amount, ScriptBuf, TxOut};
+    use stratum_common::roles_logic_sv2::bitcoin::{Amount, ScriptBuf, TxOut};
 
     use crate::config::JobDeclaratorServerConfig;
 

--- a/roles/jd-server/src/lib/error.rs
+++ b/roles/jd-server/src/lib/error.rs
@@ -19,7 +19,11 @@ use std::{
     sync::{MutexGuard, PoisonError},
 };
 
-use roles_logic_sv2::parsers::Mining;
+use stratum_common::roles_logic_sv2::{
+    self,
+    codec_sv2::{self, binary_sv2, noise_sv2},
+    parsers::Mining,
+};
 
 use crate::mempool::error::JdsMempoolError;
 

--- a/roles/jd-server/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-server/src/lib/job_declarator/message_handler.rs
@@ -1,5 +1,11 @@
-use binary_sv2::{Decodable, Serialize, U256};
-use roles_logic_sv2::{
+use std::{convert::TryInto, io::Cursor, sync::Arc};
+use stratum_common::roles_logic_sv2::{
+    bitcoin::{
+        consensus::Decodable as BitcoinDecodable,
+        hashes::{sha256d, Hash},
+        Transaction, Txid,
+    },
+    codec_sv2::binary_sv2::{Decodable, Serialize, U256},
     handlers::{job_declaration::ParseJobDeclarationMessagesFromDownstream, SendTo_},
     job_declaration_sv2::{
         AllocateMiningJobToken, AllocateMiningJobTokenSuccess, DeclareMiningJob,
@@ -9,17 +15,11 @@ use roles_logic_sv2::{
     parsers::JobDeclaration,
     utils::Mutex,
 };
-use std::{convert::TryInto, io::Cursor, sync::Arc};
-use stratum_common::bitcoin::{
-    hashes::{sha256d, Hash},
-    Transaction, Txid,
-};
 pub type SendTo = SendTo_<JobDeclaration<'static>, ()>;
 use crate::mempool::JDsMempool;
 
 use super::{signed_token, TransactionState};
-use roles_logic_sv2::{errors::Error, parsers::AnyMessage as AllMessages};
-use stratum_common::bitcoin::consensus::Decodable as BitcoinDecodable;
+use stratum_common::roles_logic_sv2::{errors::Error, parsers::AnyMessage as AllMessages};
 use tracing::{debug, info};
 
 use super::JobDeclaratorDownstream;

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -22,30 +22,35 @@ use super::{
     error::JdsError, mempool::JDsMempool, status, EitherFrame, JobDeclaratorServerConfig, StdFrame,
 };
 use async_channel::{Receiver, Sender};
-use binary_sv2::{B0255, U256};
-use codec_sv2::{HandshakeRole, Responder};
 use core::panic;
 use error_handling::handle_result;
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey, SignatureService};
-use network_helpers_sv2::noise_connection::Connection;
 use nohash_hasher::BuildNoHashHasher;
-use roles_logic_sv2::{
-    common_messages_sv2::{
-        Protocol, SetupConnection, SetupConnectionError, SetupConnectionSuccess,
-    },
-    handlers::job_declaration::{ParseJobDeclarationMessagesFromDownstream, SendTo},
-    job_declaration_sv2::{DeclareMiningJob, PushSolution},
-    parsers::{AnyMessage as JdsMessages, JobDeclaration},
-    utils::{Id, Mutex},
-};
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        self,
+        bitcoin::{
+            consensus::{encode::serialize, Encodable},
+            Block, Transaction, Txid,
+        },
+        codec_sv2::{
+            binary_sv2,
+            binary_sv2::{B0255, U256},
+            HandshakeRole, Responder,
+        },
+        common_messages_sv2::{
+            Protocol, SetupConnection, SetupConnectionError, SetupConnectionSuccess,
+        },
+        handlers::job_declaration::{ParseJobDeclarationMessagesFromDownstream, SendTo},
+        job_declaration_sv2::{DeclareMiningJob, PushSolution},
+        parsers::{AnyMessage as JdsMessages, JobDeclaration},
+        utils::{Id, Mutex},
+    },
+};
 use tokio::{net::TcpListener, time::Duration};
 use tracing::{debug, error, info};
-
-use stratum_common::bitcoin::{
-    consensus::{encode::serialize, Encodable},
-    Block, Transaction, Txid,
-};
 
 /// Represents whether a transaction declared in a mining job is known to the JDS mempool
 /// or still missing and needs to be fetched/provided.

--- a/roles/jd-server/src/lib/mempool/mod.rs
+++ b/roles/jd-server/src/lib/mempool/mod.rs
@@ -19,12 +19,13 @@ pub mod error;
 use super::job_declarator::AddTrasactionsToMempoolInner;
 use crate::mempool::error::JdsMempoolError;
 use async_channel::Receiver;
-use bitcoin::blockdata::transaction::Transaction;
 use hashbrown::HashMap;
-use roles_logic_sv2::utils::Mutex;
 use rpc_sv2::{mini_rpc_client, mini_rpc_client::RpcError};
 use std::{str::FromStr, sync::Arc};
-use stratum_common::{bitcoin, bitcoin::hash_types::Txid};
+use stratum_common::roles_logic_sv2::{
+    bitcoin::{blockdata::transaction::Transaction, hash_types::Txid},
+    utils::Mutex,
+};
 
 /// Wrapper around a known transaction and its hash.
 #[derive(Clone, Debug)]

--- a/roles/jd-server/src/lib/mod.rs
+++ b/roles/jd-server/src/lib/mod.rs
@@ -23,15 +23,18 @@ pub mod job_declarator;
 pub mod mempool;
 pub mod status;
 use async_channel::{bounded, unbounded, Receiver, Sender};
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use config::JobDeclaratorServerConfig;
 use error::JdsError;
 use error_handling::handle_result;
 use job_declarator::JobDeclarator;
 use mempool::error::JdsMempoolError;
-use roles_logic_sv2::{parsers::AnyMessage as JdsMessages, utils::Mutex};
 pub use rpc_sv2::Uri;
 use std::{ops::Sub, str::FromStr, sync::Arc};
+use stratum_common::roles_logic_sv2::{
+    codec_sv2::{StandardEitherFrame, StandardSv2Frame},
+    parsers::AnyMessage as JdsMessages,
+    utils::Mutex,
+};
 use tokio::{select, task};
 use tracing::{error, info, warn};
 

--- a/roles/jd-server/src/lib/status.rs
+++ b/roles/jd-server/src/lib/status.rs
@@ -8,7 +8,7 @@
 //!
 //! This allows for centralized, consistent error handling across the application.
 
-use roles_logic_sv2::parsers::Mining;
+use stratum_common::roles_logic_sv2::parsers::Mining;
 
 use super::error::JdsError;
 
@@ -162,7 +162,11 @@ mod tests {
 
     use super::*;
     use async_channel::{bounded, RecvError};
-    use roles_logic_sv2::mining_sv2::OpenMiningChannelError;
+    use stratum_common::roles_logic_sv2::{
+        self,
+        codec_sv2::{self, binary_sv2, noise_sv2},
+        mining_sv2::OpenMiningChannelError,
+    };
 
     #[tokio::test]
     async fn test_send_status_downstream_listener_shutdown() {

--- a/roles/mining-proxy/Cargo.toml
+++ b/roles/mining-proxy/Cargo.toml
@@ -17,17 +17,13 @@ name = "mining_proxy_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
+stratum-common = { path = "../../common" , features = ["with_network_helpers"] }
 async-channel = "1.8.0"
 async-recursion = "0.3.2"
-binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 buffer_sv2 = { path = "../../utils/buffer" }
-codec_sv2 = { path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
 futures = "0.3.19"
-network_helpers_sv2 = { path = "../roles-utils/network-helpers", features = ["with_buffer_pool"] }
 once_cell = "1.12.0"
-roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
-stratum-common = { path = "../../common" }
 tokio = { version = "1.44.1", features = ["full"] }
 ext-config = { version = "0.14.0", features = ["toml"], package = "config" }
 tracing = {version = "0.1"}

--- a/roles/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/mining-proxy/src/lib/downstream_mining.rs
@@ -8,19 +8,22 @@ use super::{
     routing_logic::{CommonRouter, CommonRoutingLogic, MiningRouter, MiningRoutingLogic},
     upstream_mining::{StdFrame as UpstreamFrame, UpstreamMiningNode},
 };
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use network_helpers_sv2::plain_connection::PlainConnection;
-use roles_logic_sv2::{
-    common_messages_sv2::{SetupConnection, SetupConnectionSuccess},
-    common_properties::{CommonDownstreamData, IsDownstream, IsMiningDownstream},
-    errors::Error,
-    handlers::{
-        common::{ParseCommonMessagesFromDownstream, SendTo as SendToCommon},
-        mining::{ParseMiningMessagesFromDownstream, SendTo, SupportedChannelTypes},
+use stratum_common::{
+    network_helpers_sv2::plain_connection::PlainConnection,
+    roles_logic_sv2::{
+        self, codec_sv2,
+        codec_sv2::{binary_sv2, StandardEitherFrame, StandardSv2Frame},
+        common_messages_sv2::{SetupConnection, SetupConnectionSuccess},
+        common_properties::{CommonDownstreamData, IsDownstream, IsMiningDownstream},
+        errors::Error,
+        handlers::{
+            common::{ParseCommonMessagesFromDownstream, SendTo as SendToCommon},
+            mining::{ParseMiningMessagesFromDownstream, SendTo, SupportedChannelTypes},
+        },
+        mining_sv2::*,
+        parsers::{AnyMessage, Mining, MiningDeviceMessages},
+        utils::Mutex,
     },
-    mining_sv2::*,
-    parsers::{AnyMessage, Mining, MiningDeviceMessages},
-    utils::Mutex,
 };
 
 pub type Message = MiningDeviceMessages<'static>;

--- a/roles/mining-proxy/src/lib/error.rs
+++ b/roles/mining-proxy/src/lib/error.rs
@@ -1,8 +1,7 @@
 use async_channel::SendError;
-use codec_sv2::StandardEitherFrame;
 use core::fmt;
-use roles_logic_sv2::parsers::AnyMessage;
 use std::net::SocketAddr;
+use stratum_common::roles_logic_sv2::{codec_sv2::StandardEitherFrame, parsers::AnyMessage};
 
 pub type Message = AnyMessage<'static>;
 pub type EitherFrame = StandardEitherFrame<Message>;

--- a/roles/mining-proxy/src/lib/mod.rs
+++ b/roles/mining-proxy/src/lib/mod.rs
@@ -5,11 +5,11 @@ pub mod selectors;
 pub mod upstream_mining;
 
 use once_cell::sync::OnceCell;
-use roles_logic_sv2::utils::{GroupId, Id, Mutex};
 use routing_logic::{CommonRoutingLogic, MiningProxyRoutingLogic, MiningRoutingLogic};
 use selectors::GeneralMiningSelector;
 use serde::Deserialize;
 use std::{net::SocketAddr, sync::Arc};
+use stratum_common::roles_logic_sv2::utils::{GroupId, Id, Mutex};
 use tokio::{net::TcpListener, sync::oneshot};
 use tracing::info;
 use upstream_mining::UpstreamMiningNode;

--- a/roles/mining-proxy/src/lib/routing_logic.rs
+++ b/roles/mining-proxy/src/lib/routing_logic.rs
@@ -30,7 +30,8 @@ use super::{
     },
     upstream_mining::HasDownstreamSelector,
 };
-use roles_logic_sv2::{
+use std::{collections::HashMap, fmt::Debug as D, marker::PhantomData, sync::Arc};
+use stratum_common::roles_logic_sv2::{
     common_messages_sv2::{
         has_requires_std_job, Protocol, SetupConnection, SetupConnectionSuccess,
     },
@@ -42,7 +43,6 @@ use roles_logic_sv2::{
     utils::{Id, Mutex},
     Error,
 };
-use std::{collections::HashMap, fmt::Debug as D, marker::PhantomData, sync::Arc};
 
 /// Defines routing logic for common protocol messages.
 ///

--- a/roles/mining-proxy/src/lib/selectors.rs
+++ b/roles/mining-proxy/src/lib/selectors.rs
@@ -5,12 +5,12 @@
 //! send messages to.
 
 use nohash_hasher::BuildNoHashHasher;
-use roles_logic_sv2::{
+use std::{collections::HashMap, fmt::Debug as D, sync::Arc};
+use stratum_common::roles_logic_sv2::{
     common_properties::{IsDownstream, IsMiningDownstream, IsMiningUpstream, PairSettings},
     utils::Mutex,
     Error,
 };
-use std::{collections::HashMap, fmt::Debug as D, sync::Arc};
 
 /// Proxy selector for routing messages to downstream mining nodes.
 ///

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -15,26 +15,31 @@ use super::{
     selectors::{DownstreamMiningSelector, ProxyDownstreamMiningSelector as Prs},
     EXTRANONCE_RANGE_1_LENGTH,
 };
-use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
-use network_helpers_sv2::noise_connection::Connection;
-use roles_logic_sv2::{
-    channel_logic::{
-        channel_factory::{ExtendedChannelKind, OnNewShare, ProxyExtendedChannelFactory, Share},
-        proxy_group_channel::GroupChannels,
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        bitcoin::TxOut,
+        channel_logic::{
+            channel_factory::{
+                ExtendedChannelKind, OnNewShare, ProxyExtendedChannelFactory, Share,
+            },
+            proxy_group_channel::GroupChannels,
+        },
+        codec_sv2,
+        codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame},
+        common_messages_sv2::{Protocol, SetupConnection},
+        common_properties::{
+            IsMiningDownstream, IsMiningUpstream, IsUpstream, RequestIdMapper, UpstreamChannel,
+        },
+        errors::Error,
+        handlers::mining::{ParseMiningMessagesFromUpstream, SendTo, SupportedChannelTypes},
+        job_dispatcher::GroupChannelJobDispatcher,
+        mining_sv2::*,
+        parsers::{AnyMessage, CommonMessages, Mining, MiningDeviceMessages},
+        template_distribution_sv2::SubmitSolution,
+        utils::{GroupId, Id, Mutex},
     },
-    common_messages_sv2::{Protocol, SetupConnection},
-    common_properties::{
-        IsMiningDownstream, IsMiningUpstream, IsUpstream, RequestIdMapper, UpstreamChannel,
-    },
-    errors::Error,
-    handlers::mining::{ParseMiningMessagesFromUpstream, SendTo, SupportedChannelTypes},
-    job_dispatcher::GroupChannelJobDispatcher,
-    mining_sv2::*,
-    parsers::{AnyMessage, CommonMessages, Mining, MiningDeviceMessages},
-    template_distribution_sv2::SubmitSolution,
-    utils::{GroupId, Id, Mutex},
 };
-use stratum_common::bitcoin::TxOut;
 
 pub type Message = AnyMessage<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -18,15 +18,11 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 async-channel = "1.5.1"
-binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
+stratum-common = { path = "../../common", features = ["with_network_helpers"] }
 buffer_sv2 = { path = "../../utils/buffer" }
-codec_sv2 = { path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
-network_helpers_sv2 = { path = "../roles-utils/network-helpers", features =["with_buffer_pool"] }
-noise_sv2 = { path = "../../protocols/v2/noise-sv2" }
 rand = "0.8.4"
-roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
-stratum-common = { path = "../../common", features = ["bitcoin"] }
+secp256k1 = { version = "0.28.2", default-features = false, features = ["alloc", "rand", "rand-std"] }
 tokio = { version = "1.44.1", features = ["full"] }
 ext-config = { version = "0.14.0", features = ["toml"], package = "config" }
 tracing = { version = "0.1" }

--- a/roles/pool/src/lib/error.rs
+++ b/roles/pool/src/lib/error.rs
@@ -16,7 +16,11 @@ use std::{
     sync::{MutexGuard, PoisonError},
 };
 
-use roles_logic_sv2::parsers::Mining;
+use stratum_common::roles_logic_sv2::{
+    self,
+    codec_sv2::{self, binary_sv2, noise_sv2},
+    parsers::Mining,
+};
 
 /// Represents various errors that can occur in the pool implementation.
 #[derive(std::fmt::Debug)]

--- a/roles/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/pool/src/lib/mining_pool/message_handler.rs
@@ -6,14 +6,19 @@
 //! reacts to various mining-related messages received from a connected downstream miner.
 
 use super::super::mining_pool::Downstream;
-use binary_sv2::Str0255;
-use roles_logic_sv2::{
+use std::{
+    convert::TryInto,
+    sync::{Arc, RwLock},
+};
+use stratum_common::roles_logic_sv2::{
+    bitcoin::Amount,
     channels::server::{
         error::{ExtendedChannelError, StandardChannelError},
         extended::ExtendedChannel,
         share_accounting::{ShareValidationError, ShareValidationResult},
         standard::StandardChannel,
     },
+    codec_sv2::binary_sv2::Str0255,
     errors::Error,
     handlers::mining::{ParseMiningMessagesFromDownstream, SendTo, SupportedChannelTypes},
     mining_sv2::*,
@@ -21,11 +26,6 @@ use roles_logic_sv2::{
     template_distribution_sv2::SubmitSolution,
     utils::Mutex,
 };
-use std::{
-    convert::TryInto,
-    sync::{Arc, RwLock},
-};
-use stratum_common::bitcoin::Amount;
 use tracing::{error, info};
 
 impl ParseMiningMessagesFromDownstream<()> for Downstream {

--- a/roles/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/pool/src/lib/mining_pool/setup_connection.rs
@@ -9,7 +9,9 @@ use super::super::{
     mining_pool::{EitherFrame, StdFrame},
 };
 use async_channel::{Receiver, Sender};
-use roles_logic_sv2::{
+use std::{convert::TryInto, net::SocketAddr, sync::Arc};
+use stratum_common::roles_logic_sv2::{
+    self,
     common_messages_sv2::{
         has_requires_std_job, has_version_rolling, has_work_selection, SetupConnection,
         SetupConnectionSuccess,
@@ -20,7 +22,6 @@ use roles_logic_sv2::{
     parsers::{AnyMessage, CommonMessages},
     utils::Mutex,
 };
-use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 use tracing::{debug, error, info};
 
 /// Handles the `SetupConnection` message for downstream connections.

--- a/roles/pool/src/lib/status.rs
+++ b/roles/pool/src/lib/status.rs
@@ -6,7 +6,7 @@
 //! Centralizes and simplifies error handling across the system.
 
 /// Identifies which component sent a status update.
-use roles_logic_sv2::parsers::Mining;
+use stratum_common::roles_logic_sv2::{self, parsers::Mining};
 
 use super::error::PoolError;
 

--- a/roles/pool/src/lib/template_receiver/message_handler.rs
+++ b/roles/pool/src/lib/template_receiver/message_handler.rs
@@ -3,14 +3,14 @@
 //! Handles incoming template distribution messages from the Template Provider and forwards them
 //! as needed.
 use super::TemplateRx;
-use roles_logic_sv2::{
+use std::sync::Arc;
+use stratum_common::roles_logic_sv2::{
     errors::Error,
     handlers::template_distribution::{ParseTemplateDistributionMessagesFromServer, SendTo},
     parsers::TemplateDistribution,
     template_distribution_sv2::*,
     utils::Mutex,
 };
-use std::sync::Arc;
 use tracing::{debug, error, info};
 
 impl ParseTemplateDistributionMessagesFromServer for TemplateRx {

--- a/roles/pool/src/lib/template_receiver/mod.rs
+++ b/roles/pool/src/lib/template_receiver/mod.rs
@@ -13,19 +13,22 @@ use super::{
     status,
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
-use network_helpers_sv2::noise_connection::Connection;
-use roles_logic_sv2::{
-    handlers::template_distribution::ParseTemplateDistributionMessagesFromServer,
-    parsers::{AnyMessage, TemplateDistribution},
-    template_distribution_sv2::{
-        CoinbaseOutputConstraints, NewTemplate, SetNewPrevHash, SubmitSolution,
-    },
-    utils::Mutex,
-};
 use std::{convert::TryInto, net::SocketAddr, sync::Arc};
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        self, codec_sv2,
+        codec_sv2::{HandshakeRole, Initiator},
+        handlers::template_distribution::ParseTemplateDistributionMessagesFromServer,
+        parsers::{AnyMessage, TemplateDistribution},
+        template_distribution_sv2::{
+            CoinbaseOutputConstraints, NewTemplate, SetNewPrevHash, SubmitSolution,
+        },
+        utils::Mutex,
+    },
+};
 use tokio::{net::TcpStream, task};
 use tracing::{info, warn};
 

--- a/roles/pool/src/lib/template_receiver/setup_connection.rs
+++ b/roles/pool/src/lib/template_receiver/setup_connection.rs
@@ -8,14 +8,15 @@ use super::super::{
     mining_pool::{EitherFrame, StdFrame},
 };
 use async_channel::{Receiver, Sender};
-use roles_logic_sv2::{
+use std::{convert::TryInto, net::SocketAddr, sync::Arc};
+use stratum_common::roles_logic_sv2::{
+    self, codec_sv2,
     common_messages_sv2::{Protocol, Reconnect, SetupConnection, SetupConnectionError},
     errors::Error,
     handlers::common::{ParseCommonMessagesFromUpstream, SendTo},
     parsers::{AnyMessage, CommonMessages},
     utils::Mutex,
 };
-use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 use tracing::{error, info};
 
 /// Handles the connection setup process with the Template Provider.

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network_helpers_sv2"
-version = "3.1.0"
+version = "4.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 description = "Networking utils for SV2 roles"
@@ -17,9 +17,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 async-std = { version = "1.8.0", optional = true }
 async-channel = { version = "1.8.0", optional = true }
 tokio = { version = "1.44.1", features = ["full"] }
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2", version = "^3.0.0", optional = true }
 codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0", features=["noise_sv2"], optional = true }
-stratum-common = { path = "../../../common" }
 sv1_api = { path = "../../../protocols/v1/", version = "^1.0.0", optional = true }
 tracing = { version = "0.1" }
 futures = "0.3.28"
@@ -27,7 +25,7 @@ tokio-util = { version = "0.7.10", default-features = false, features = ["codec"
 serde_json = { version = "1.0.138", default-features = false, optional = true }
 
 [features]
-default = ["async-channel", "binary_sv2", "codec_sv2"]
+default = ["async-channel", "codec_sv2"]
 with_buffer_pool = ["codec_sv2/with_buffer_pool"]
 sv1 = ["sv1_api", "tokio-util", "serde_json"]
 

--- a/roles/roles-utils/network-helpers/src/lib.rs
+++ b/roles/roles-utils/network-helpers/src/lib.rs
@@ -6,6 +6,8 @@ pub mod sv1_connection;
 use async_channel::{RecvError, SendError};
 use codec_sv2::Error as CodecError;
 
+pub use codec_sv2;
+
 #[derive(Debug)]
 pub enum Error {
     HandshakeRemoteInvalidMessage,

--- a/roles/roles-utils/network-helpers/src/noise_connection.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::new_ret_no_self)]
 use crate::Error;
 use async_channel::{unbounded, Receiver, Sender};
-use binary_sv2::{Deserialize, GetSize, Serialize};
 use codec_sv2::{
+    binary_sv2::{Deserialize, GetSize, Serialize},
     noise_sv2::{ELLSWIFT_ENCODING_SIZE, INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE},
     HandShakeFrame, HandshakeRole, StandardEitherFrame, StandardNoiseDecoder, State,
 };

--- a/roles/roles-utils/network-helpers/src/plain_connection.rs
+++ b/roles/roles-utils/network-helpers/src/plain_connection.rs
@@ -1,5 +1,5 @@
 use async_channel::{bounded, Receiver, Sender};
-use binary_sv2::{Deserialize, Serialize};
+use codec_sv2::binary_sv2::{Deserialize, Serialize};
 use core::convert::TryInto;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -7,8 +7,7 @@ use tokio::{
     task,
 };
 
-use binary_sv2::GetSize;
-use codec_sv2::{Error::MissingBytes, StandardDecoder, StandardEitherFrame};
+use codec_sv2::{binary_sv2::GetSize, Error::MissingBytes, StandardDecoder, StandardEitherFrame};
 use tracing::{error, trace};
 
 #[derive(Debug)]

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", features=["bitcoin"], version = "^2.0.0" }
+stratum-common = { path = "../../../common" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc","raw_value"] }
 hex = "0.4.3"

--- a/roles/roles-utils/rpc/src/mini_rpc_client.rs
+++ b/roles/roles-utils/rpc/src/mini_rpc_client.rs
@@ -14,7 +14,9 @@ use hyper_util::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use stratum_common::bitcoin::{consensus::encode::deserialize as consensus_decode, Transaction};
+use stratum_common::roles_logic_sv2::bitcoin::{
+    consensus::encode::deserialize as consensus_decode, Transaction,
+};
 
 use super::BlockHash;
 

--- a/roles/test-utils/mining-device-sv1/Cargo.toml
+++ b/roles/test-utils/mining-device-sv1/Cargo.toml
@@ -18,9 +18,8 @@ name = "mining_device_sv1"
 path = "src/lib.rs"
 
 [dependencies]
-stratum-common = { path = "../../../common" }
+stratum-common = { path = "../../../common" }    
 async-channel = "1.5.1"
-roles_logic_sv2 = { path = "../../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 v1 = { path="../../../protocols/v1", package="sv1_api" }

--- a/roles/test-utils/mining-device-sv1/src/client.rs
+++ b/roles/test-utils/mining-device-sv1/src/client.rs
@@ -3,7 +3,6 @@ use async_channel::{unbounded, Receiver, Sender};
 use num_bigint::BigUint;
 use num_traits::FromPrimitive;
 use primitive_types::U256;
-use roles_logic_sv2::utils::Mutex;
 use std::{
     convert::TryInto,
     net::SocketAddr,
@@ -11,6 +10,7 @@ use std::{
     sync::Arc,
     time::{self, Duration},
 };
+use stratum_common::roles_logic_sv2::utils::Mutex;
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::TcpStream,

--- a/roles/test-utils/mining-device-sv1/src/job.rs
+++ b/roles/test-utils/mining-device-sv1/src/job.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+use stratum_common::roles_logic_sv2;
 use v1::server_to_client;
 
 /// Represents a new Job built from an incoming `mining.notify` message from the Upstream server.

--- a/roles/test-utils/mining-device-sv1/src/miner.rs
+++ b/roles/test-utils/mining-device-sv1/src/miner.rs
@@ -1,7 +1,7 @@
 use crate::job::Job;
 use primitive_types::U256;
 use std::convert::TryInto;
-use stratum_common::bitcoin::{
+use stratum_common::roles_logic_sv2::bitcoin::{
     blockdata::block::{Header, Version},
     hash_types::{BlockHash, TxMerkleNode},
     hashes::{sha256d::Hash as DHash, Hash},

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -20,13 +20,9 @@ path = "src/lib/mod.rs"
 
 
 [dependencies]
-codec_sv2 = { path = "../../../protocols/v2/codec-sv2", features=["noise_sv2"] }
-roles_logic_sv2 = { path = "../../../protocols/v2/roles-logic-sv2" }
-stratum-common = { path = "../../../common" }
+stratum-common = { path = "../../../common", features = ["with_network_helpers"] }
 async-channel = "1.5.1"
-binary_sv2 = { path = "../../../protocols/v2/binary-sv2" }
-network_helpers_sv2 = { path = "../../roles-utils/network-helpers" }
-buffer_sv2 = { path = "../../../utils/buffer"}
+buffer_sv2 = { path = "../../../utils/buffer" }
 async-recursion = "0.3.2"
 rand = "0.8.4"
 futures = "0.3.5"

--- a/roles/test-utils/mining-device/src/lib/mod.rs
+++ b/roles/test-utils/mining-device/src/lib/mod.rs
@@ -1,21 +1,8 @@
 #![allow(clippy::option_map_unit_fn)]
 use async_channel::{Receiver, Sender};
-use codec_sv2::{Initiator, StandardEitherFrame, StandardSv2Frame};
 use key_utils::Secp256k1PublicKey;
-use network_helpers_sv2::noise_connection::Connection;
 use primitive_types::U256;
 use rand::{thread_rng, Rng};
-use roles_logic_sv2::{
-    common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess},
-    errors::Error,
-    handlers::{
-        common::ParseCommonMessagesFromUpstream,
-        mining::{ParseMiningMessagesFromUpstream, SendTo, SupportedChannelTypes},
-    },
-    mining_sv2::*,
-    parsers::{Mining, MiningDeviceMessages},
-    utils::{Id, Mutex},
-};
 use std::{
     net::{SocketAddr, ToSocketAddrs},
     sync::{
@@ -25,8 +12,23 @@ use std::{
     thread::available_parallelism,
     time::{Duration, Instant},
 };
-use stratum_common::bitcoin::{
-    blockdata::block::Header, hash_types::BlockHash, hashes::Hash, CompactTarget,
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        self,
+        bitcoin::{blockdata::block::Header, hash_types::BlockHash, hashes::Hash, CompactTarget},
+        codec_sv2,
+        codec_sv2::{Initiator, StandardEitherFrame, StandardSv2Frame},
+        common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess},
+        errors::Error,
+        handlers::{
+            common::ParseCommonMessagesFromUpstream,
+            mining::{ParseMiningMessagesFromUpstream, SendTo, SupportedChannelTypes},
+        },
+        mining_sv2::*,
+        parsers::{Mining, MiningDeviceMessages},
+        utils::{Id, Mutex},
+    },
 };
 use tokio::net::TcpStream;
 use tracing::{debug, error, info};
@@ -92,9 +94,8 @@ pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;
 
 struct SetupConnectionHandler {}
-use roles_logic_sv2::common_messages_sv2::Reconnect;
 use std::convert::TryInto;
-use stratum_common::bitcoin::block::Version;
+use stratum_common::roles_logic_sv2::{bitcoin::block::Version, common_messages_sv2::Reconnect};
 
 impl SetupConnectionHandler {
     pub fn new() -> Self {

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -20,16 +20,11 @@ name = "translator_sv2"
 path = "src/main.rs"
 
 [dependencies]
-stratum-common = { path = "../../common" }
+stratum-common = { path = "../../common", features = ["with_network_helpers"] }
 async-channel = "1.5.1"
 async-recursion = "0.3.2"
-binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 buffer_sv2 = { path = "../../utils/buffer" }
-codec_sv2 = { path = "../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
-framing_sv2 = { path = "../../protocols/v2/framing-sv2" }
-network_helpers_sv2 = { path = "../roles-utils/network-helpers", features=["with_buffer_pool"] }
 once_cell = "1.12.0"
-roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 futures = "0.3.25"

--- a/roles/translator/src/lib/downstream_sv1/diff_management.rs
+++ b/roles/translator/src/lib/downstream_sv1/diff_management.rs
@@ -14,11 +14,12 @@ use super::{Downstream, DownstreamMessages, SetDownstreamTarget};
 
 use super::super::error::{Error, ProxyResult};
 use primitive_types::U256;
-use roles_logic_sv2::{
+use std::{ops::Div, sync::Arc};
+use stratum_common::roles_logic_sv2::{
+    codec_sv2::binary_sv2,
     mining_sv2::Target,
     utils::{hash_rate_to_target, Mutex},
 };
-use std::{ops::Div, sync::Arc};
 use tracing::debug;
 use v1::json_rpc;
 
@@ -243,13 +244,17 @@ mod test {
 
     use crate::config::{DownstreamDifficultyConfig, UpstreamDifficultyConfig};
     use async_channel::unbounded;
-    use binary_sv2::U256;
     use rand::{thread_rng, Rng};
-    use roles_logic_sv2::{mining_sv2::Target, utils::Mutex};
     use sha2::{Digest, Sha256};
     use std::{
         sync::Arc,
         time::{Duration, Instant},
+    };
+    use stratum_common::roles_logic_sv2::{
+        self,
+        codec_sv2::binary_sv2::{self, U256},
+        mining_sv2::Target,
+        utils::Mutex,
     };
 
     use crate::downstream_sv1::Downstream;

--- a/roles/translator/src/lib/downstream_sv1/downstream.rs
+++ b/roles/translator/src/lib/downstream_sv1/downstream.rs
@@ -36,7 +36,8 @@ use tokio::{
 
 use super::{kill, DownstreamMessages, SubmitShareWithChannelId, SUBSCRIBE_TIMEOUT_SECS};
 
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
+    self,
     common_properties::{IsDownstream, IsMiningDownstream},
     mining_sv2::Target,
     utils::{hash_rate_to_target, Mutex},
@@ -723,8 +724,8 @@ impl IsDownstream for Downstream {
 
 #[cfg(test)]
 mod tests {
-    use binary_sv2::U256;
     use roles_logic_sv2::mining_sv2::Target;
+    use stratum_common::roles_logic_sv2::codec_sv2::binary_sv2::U256;
 
     use super::*;
 

--- a/roles/translator/src/lib/downstream_sv1/mod.rs
+++ b/roles/translator/src/lib/downstream_sv1/mod.rs
@@ -11,7 +11,7 @@
 //! - [`diff_management`]: (Declared here, likely contains downstream difficulty logic)
 //! - [`downstream`]: Defines the core [`Downstream`] struct and its functionalities.
 
-use roles_logic_sv2::mining_sv2::Target;
+use stratum_common::roles_logic_sv2::mining_sv2::Target;
 use v1::{client_to_server::Submit, utils::HexU32Be};
 pub mod diff_management;
 pub mod downstream;

--- a/roles/translator/src/lib/error.rs
+++ b/roles/translator/src/lib/error.rs
@@ -8,14 +8,15 @@
 //! - A specific `ChannelSendError` enum for errors occurring during message sending over
 //!   asynchronous channels.
 
-use codec_sv2::Frame;
 use ext_config::ConfigError;
-use roles_logic_sv2::{
+use std::{fmt, sync::PoisonError};
+use stratum_common::roles_logic_sv2::{
+    self,
+    codec_sv2::{self, binary_sv2, framing_sv2, Frame},
     mining_sv2::{ExtendedExtranonce, NewExtendedMiningJob, SetCustomMiningJob},
     parsers::{AnyMessage, Mining},
     vardiff::error::VardiffError,
 };
-use std::{fmt, sync::PoisonError};
 use v1::server_to_client::{Notify, SetDifficulty};
 
 pub type ProxyResult<'a, T> = core::result::Result<T, Error<'a>>;

--- a/roles/translator/src/lib/mod.rs
+++ b/roles/translator/src/lib/mod.rs
@@ -13,13 +13,13 @@
 use async_channel::{bounded, unbounded};
 use futures::FutureExt;
 use rand::Rng;
-pub use roles_logic_sv2::utils::Mutex;
 use status::Status;
 use std::{
     net::{IpAddr, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
+pub use stratum_common::roles_logic_sv2::utils::Mutex;
 
 use tokio::{
     select,

--- a/roles/translator/src/lib/proxy/bridge.rs
+++ b/roles/translator/src/lib/proxy/bridge.rs
@@ -27,7 +27,8 @@ use super::super::{
 };
 use async_channel::{Receiver, Sender};
 use error_handling::handle_result;
-use roles_logic_sv2::{
+use std::sync::Arc;
+use stratum_common::roles_logic_sv2::{
     channel_logic::channel_factory::{
         ExtendedChannelKind, OnNewShare, ProxyExtendedChannelFactory, Share,
     },
@@ -38,7 +39,6 @@ use roles_logic_sv2::{
     utils::{GroupId, Mutex},
     Error as RolesLogicError,
 };
-use std::sync::Arc;
 use tokio::{sync::broadcast, task::AbortHandle};
 use tracing::{debug, error, info, warn};
 use v1::{client_to_server::Submit, server_to_client, utils::HexU32Be};
@@ -588,7 +588,10 @@ pub struct OpenSv1Downstream {
 mod test {
     use super::*;
     use async_channel::bounded;
-    use stratum_common::bitcoin::{absolute::LockTime, consensus, transaction::Version};
+    use stratum_common::roles_logic_sv2::{
+        bitcoin::{absolute::LockTime, consensus, transaction::Version},
+        codec_sv2::binary_sv2,
+    };
 
     pub mod test_utils {
         use super::*;
@@ -654,9 +657,8 @@ mod test {
 
     #[test]
     fn test_version_bits_insert() {
-        use stratum_common::{
-            bitcoin,
-            bitcoin::{blockdata::witness::Witness, hashes::Hash},
+        use stratum_common::roles_logic_sv2::bitcoin::{
+            self, blockdata::witness::Witness, hashes::Hash,
         };
 
         let extranonces = ExtendedExtranonce::new(0..6, 6..8, 8..16, None)

--- a/roles/translator/src/lib/proxy/next_mining_notify.rs
+++ b/roles/translator/src/lib/proxy/next_mining_notify.rs
@@ -1,6 +1,6 @@
 //! Provides functionality to convert Stratum V2 job into a
 //! Stratum V1 `mining.notify` message.
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
     job_creator::extended_job_to_non_segwit,
     mining_sv2::{NewExtendedMiningJob, SetNewPrevHash},
 };

--- a/roles/translator/src/lib/status.rs
+++ b/roles/translator/src/lib/status.rs
@@ -8,6 +8,8 @@
 //!
 //! This allows for centralized, consistent error handling across the application.
 
+use stratum_common::roles_logic_sv2;
+
 use crate::error::{self, Error};
 
 /// Identifies the component that originated a [`Status`] update.

--- a/roles/translator/src/lib/upstream_sv2/diff_management.rs
+++ b/roles/translator/src/lib/upstream_sv2/diff_management.rs
@@ -14,11 +14,11 @@ use super::super::{
     error::ProxyResult,
     upstream_sv2::{EitherFrame, Message, StdFrame},
 };
-use binary_sv2::U256;
-use roles_logic_sv2::{
-    mining_sv2::UpdateChannel, parsers::Mining, utils::Mutex, Error as RolesLogicError,
-};
 use std::{sync::Arc, time::Duration};
+use stratum_common::roles_logic_sv2::{
+    codec_sv2::binary_sv2::U256, mining_sv2::UpdateChannel, parsers::Mining, utils::Mutex,
+    Error as RolesLogicError,
+};
 
 impl Upstream {
     /// Attempts to update the upstream channel's nominal hashrate if the configured

--- a/roles/translator/src/lib/upstream_sv2/mod.rs
+++ b/roles/translator/src/lib/upstream_sv2/mod.rs
@@ -8,8 +8,10 @@
 //! - [`upstream_connection`]: Handles the underlying connection details and frame
 //!   sending/receiving.
 
-use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
-use roles_logic_sv2::parsers::AnyMessage;
+use stratum_common::roles_logic_sv2::{
+    codec_sv2::{StandardEitherFrame, StandardSv2Frame},
+    parsers::AnyMessage,
+};
 
 pub mod diff_management;
 pub mod upstream;

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -28,30 +28,32 @@ use crate::{
     upstream_sv2::{EitherFrame, Message, StdFrame, UpstreamConnection},
 };
 use async_channel::{Receiver, Sender};
-use binary_sv2::u256_from_int;
-use codec_sv2::{HandshakeRole, Initiator};
 use error_handling::handle_result;
 use key_utils::Secp256k1PublicKey;
-use network_helpers_sv2::noise_connection::Connection;
-use roles_logic_sv2::{
-    common_messages_sv2::{Protocol, SetupConnection},
-    common_properties::{IsMiningUpstream, IsUpstream},
-    handlers::{
-        common::{ParseCommonMessagesFromUpstream, SendTo as SendToCommon},
-        mining::{ParseMiningMessagesFromUpstream, SendTo},
-    },
-    mining_sv2::{
-        ExtendedExtranonce, Extranonce, NewExtendedMiningJob, OpenExtendedMiningChannel,
-        SetNewPrevHash, SubmitSharesExtended,
-    },
-    parsers::Mining,
-    utils::Mutex,
-    Error as RolesLogicError,
-    Error::NoUpstreamsConnected,
-};
 use std::{
     net::SocketAddr,
     sync::{atomic::AtomicBool, Arc},
+};
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        self,
+        codec_sv2::{self, binary_sv2::u256_from_int, framing_sv2, HandshakeRole, Initiator},
+        common_messages_sv2::{Protocol, SetupConnection},
+        common_properties::{IsMiningUpstream, IsUpstream},
+        handlers::{
+            common::{ParseCommonMessagesFromUpstream, SendTo as SendToCommon},
+            mining::{ParseMiningMessagesFromUpstream, SendTo},
+        },
+        mining_sv2::{
+            ExtendedExtranonce, Extranonce, NewExtendedMiningJob, OpenExtendedMiningChannel,
+            SetNewPrevHash, SubmitSharesExtended,
+        },
+        parsers::Mining,
+        utils::Mutex,
+        Error as RolesLogicError,
+        Error::NoUpstreamsConnected,
+    },
 };
 use tokio::{
     net::TcpStream,
@@ -60,11 +62,10 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
-use roles_logic_sv2::{
-    common_messages_sv2::Reconnect, handlers::mining::SupportedChannelTypes,
+use stratum_common::roles_logic_sv2::{
+    bitcoin::BlockHash, common_messages_sv2::Reconnect, handlers::mining::SupportedChannelTypes,
     mining_sv2::SetGroupChannel,
 };
-use stratum_common::bitcoin::BlockHash;
 
 /// Atomic boolean flag used for synchronization between receiving a new job
 /// and handling a new previous hash. Indicates whether a `NewExtendedMiningJob`

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -515,7 +515,6 @@ dependencies = [
  "framing_sv2",
  "noise_sv2",
  "rand 0.8.5",
- "stratum-common",
  "tracing",
 ]
 
@@ -530,7 +529,6 @@ name = "common_messages_sv2"
 version = "5.1.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -831,7 +829,6 @@ dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "noise_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1204,8 +1201,6 @@ name = "integration_tests_sv2"
 version = "0.1.0"
 dependencies = [
  "async-channel",
- "binary_sv2",
- "codec_sv2",
  "config-helpers",
  "corepc-node",
  "flate2",
@@ -1216,11 +1211,9 @@ dependencies = [
  "mining_device_sv1",
  "mining_proxy_sv2",
  "minreq",
- "network_helpers_sv2",
  "once_cell",
  "pool_sv2",
  "rand 0.9.0",
- "roles_logic_sv2",
  "stratum-common",
  "sv1_api",
  "tar",
@@ -1248,20 +1241,16 @@ version = "0.1.4"
 dependencies = [
  "async-channel",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "config-helpers",
  "error_handling",
- "framing_sv2",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
  "primitive-types",
- "roles_logic_sv2",
+ "secp256k1 0.28.2",
  "serde",
  "stratum-common",
  "tokio",
@@ -1274,21 +1263,16 @@ name = "jd_server"
 version = "0.1.3"
 dependencies = [
  "async-channel",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "config-helpers",
  "error_handling",
  "hashbrown 0.11.2",
  "hex",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
- "noise_sv2",
  "rand 0.8.5",
- "roles_logic_sv2",
  "rpc_sv2",
  "serde",
  "serde_json",
@@ -1303,7 +1287,6 @@ name = "job_declaration_sv2"
 version = "4.0.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1403,16 +1386,12 @@ version = "0.1.3"
 dependencies = [
  "async-channel",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "primitive-types",
  "rand 0.8.5",
- "roles_logic_sv2",
  "sha2 0.10.8",
  "stratum-common",
  "tokio",
@@ -1428,7 +1407,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "primitive-types",
- "roles_logic_sv2",
  "serde",
  "serde_json",
  "stratum-common",
@@ -1444,17 +1422,13 @@ version = "0.1.3"
 dependencies = [
  "async-channel",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
  "once_cell",
- "roles_logic_sv2",
  "serde",
  "stratum-common",
  "tokio",
@@ -1467,7 +1441,6 @@ name = "mining_sv2"
 version = "4.0.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1517,14 +1490,12 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "async-channel",
- "binary_sv2",
  "codec_sv2",
  "futures",
  "serde_json",
- "stratum-common",
  "sv1_api",
  "tokio",
  "tokio-util",
@@ -1546,7 +1517,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "secp256k1 0.28.2",
- "stratum-common",
 ]
 
 [[package]]
@@ -1777,19 +1747,15 @@ version = "0.1.3"
 dependencies = [
  "async-channel",
  "async-recursion 1.1.1",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "config-helpers",
  "error_handling",
  "key-utils",
- "network_helpers_sv2",
  "nohash-hasher",
- "noise_sv2",
  "rand 0.8.5",
- "roles_logic_sv2",
+ "secp256k1 0.28.2",
  "serde",
  "stratum-common",
  "tokio",
@@ -1938,16 +1904,15 @@ dependencies = [
 name = "roles_logic_sv2"
 version = "3.0.0"
 dependencies = [
- "binary_sv2",
+ "bitcoin",
  "chacha20poly1305",
+ "codec_sv2",
  "common_messages_sv2",
- "framing_sv2",
  "hex-conservative 0.3.0",
  "job_declaration_sv2",
  "mining_sv2",
  "nohash-hasher",
  "primitive-types",
- "stratum-common",
  "template_distribution_sv2",
  "tracing",
 ]
@@ -2231,10 +2196,10 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-common"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
- "bitcoin",
- "secp256k1 0.28.2",
+ "network_helpers_sv2",
+ "roles_logic_sv2",
 ]
 
 [[package]]
@@ -2318,7 +2283,6 @@ name = "template_distribution_sv2"
 version = "3.1.0"
 dependencies = [
  "binary_sv2",
- "stratum-common",
 ]
 
 [[package]]
@@ -2506,20 +2470,15 @@ version = "1.0.0"
 dependencies = [
  "async-channel",
  "async-recursion 0.3.2",
- "binary_sv2",
  "buffer_sv2",
  "clap",
- "codec_sv2",
  "config",
  "error_handling",
- "framing_sv2",
  "futures",
  "key-utils",
- "network_helpers_sv2",
  "once_cell",
  "primitive-types",
  "rand 0.8.5",
- "roles_logic_sv2",
  "serde",
  "serde_json",
  "stratum-common",

--- a/test/integration-tests/Cargo.toml
+++ b/test/integration-tests/Cargo.toml
@@ -22,19 +22,15 @@ tokio = { version="1.44.1", default-features = false,  features = ["tracing"] }
 tracing = { version = "0.1.41", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false }
 
-binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
-codec_sv2 = { path = "../../protocols/v2/codec-sv2", features = ["noise_sv2"] }
 jd_client = { path = "../../roles/jd-client" }
 jd_server = { path = "../../roles/jd-server" }
 key-utils = { path = "../../utils/key-utils" }
 mining_device = { path = "../../roles/test-utils/mining-device" }
 mining_device_sv1 = { path = "../../roles/test-utils/mining-device-sv1" }
 mining_proxy_sv2 = { path = "../../roles/mining-proxy" }
-network_helpers_sv2 = { path = "../../roles/roles-utils/network-helpers", features = ["with_buffer_pool"] }
 pool_sv2 = { path = "../../roles/pool" }
-roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
-stratum-common = { path = "../../common" }
 config-helpers = { path = "../../roles/roles-utils/config-helpers" }
+stratum-common = { path = "../../common" , features = ["with_network_helpers", "sv1"]}
 translator_sv2 = { path = "../../roles/translator" }
 sv1_api = { path = "../../protocols/v1", optional = true }
 
@@ -43,4 +39,4 @@ path = "lib/mod.rs"
 
 [features]
 default = []
-sv1 = ["sv1_api", "network_helpers_sv2/sv1"]
+sv1 = ["sv1_api", "stratum-common/sv1"]

--- a/test/integration-tests/lib/interceptor.rs
+++ b/test/integration-tests/lib/interceptor.rs
@@ -1,5 +1,5 @@
 use crate::types::MsgType;
-use roles_logic_sv2::parsers::AnyMessage;
+use stratum_common::roles_logic_sv2::parsers::AnyMessage;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MessageDirection {

--- a/test/integration-tests/lib/message_aggregator.rs
+++ b/test/integration-tests/lib/message_aggregator.rs
@@ -1,5 +1,5 @@
-use roles_logic_sv2::{parsers::AnyMessage, utils::Mutex};
 use std::{collections::VecDeque, sync::Arc};
+use stratum_common::roles_logic_sv2::{parsers::AnyMessage, utils::Mutex};
 
 use crate::types::MsgType;
 

--- a/test/integration-tests/lib/mock_roles.rs
+++ b/test/integration-tests/lib/mock_roles.rs
@@ -4,9 +4,11 @@ use crate::{
     utils::{create_downstream, create_upstream, message_from_frame, wait_for_client},
 };
 use async_channel::Sender;
-use codec_sv2::{StandardEitherFrame, Sv2Frame};
-use roles_logic_sv2::parsers::AnyMessage;
 use std::net::SocketAddr;
+use stratum_common::roles_logic_sv2::{
+    codec_sv2::{StandardEitherFrame, Sv2Frame},
+    parsers::AnyMessage,
+};
 use tokio::net::TcpStream;
 
 pub struct MockDownstream {
@@ -107,12 +109,12 @@ impl MockUpstream {
 mod tests {
     use super::*;
     use crate::start_template_provider;
-    use codec_sv2::{StandardEitherFrame, Sv2Frame};
-    use roles_logic_sv2::{
+    use std::{convert::TryInto, net::TcpListener};
+    use stratum_common::roles_logic_sv2::{
+        codec_sv2::{StandardEitherFrame, Sv2Frame},
         common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess, *},
         parsers::CommonMessages,
     };
-    use std::{convert::TryInto, net::TcpListener};
 
     #[tokio::test]
     async fn test_mock_downstream() {

--- a/test/integration-tests/lib/mod.rs
+++ b/test/integration-tests/lib/mod.rs
@@ -273,7 +273,7 @@ pub fn start_sv2_translator(upstream: SocketAddr) -> (TranslatorSv2, SocketAddr)
 }
 
 pub fn measure_hashrate(duration_secs: u64) -> f64 {
-    use stratum_common::bitcoin::hashes::{sha256d, Hash, HashEngine};
+    use stratum_common::roles_logic_sv2::bitcoin::hashes::{sha256d, Hash, HashEngine};
 
     let mut share = {
         let mut rng = rng();

--- a/test/integration-tests/lib/sniffer.rs
+++ b/test/integration-tests/lib/sniffer.rs
@@ -7,8 +7,8 @@ use crate::{
         wait_for_client,
     },
 };
-use roles_logic_sv2::parsers::AnyMessage;
 use std::net::SocketAddr;
+use stratum_common::roles_logic_sv2::parsers::AnyMessage;
 use tokio::{net::TcpStream, select};
 
 /// Allows to intercept messages sent between two roles.

--- a/test/integration-tests/lib/sv1_sniffer.rs
+++ b/test/integration-tests/lib/sv1_sniffer.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "sv1")]
 use crate::interceptor::MessageDirection;
 use async_channel::{Receiver, Sender};
-use network_helpers_sv2::sv1_connection::ConnectionSV1;
 use std::{collections::VecDeque, net::SocketAddr, sync::Arc};
+use stratum_common::network_helpers_sv2::sv1_connection::ConnectionSV1;
 use tokio::{
     net::{TcpListener, TcpStream},
     select,

--- a/test/integration-tests/lib/template_provider.rs
+++ b/test/integration-tests/lib/template_provider.rs
@@ -1,6 +1,6 @@
 use corepc_node::{Conf, ConnectParams, Node};
 use std::{env, fs::create_dir_all, path::PathBuf};
-use stratum_common::bitcoin::{Address, Amount, Txid};
+use stratum_common::roles_logic_sv2::bitcoin::{Address, Amount, Txid};
 
 use crate::utils::{http, tarball};
 

--- a/test/integration-tests/lib/types.rs
+++ b/test/integration-tests/lib/types.rs
@@ -1,5 +1,4 @@
-use codec_sv2::StandardEitherFrame;
-use roles_logic_sv2::parsers::AnyMessage;
+use stratum_common::roles_logic_sv2::{codec_sv2::StandardEitherFrame, parsers::AnyMessage};
 
 pub type MessageFrame = StandardEitherFrame<AnyMessage<'static>>;
 pub type MsgType = u8;

--- a/test/integration-tests/lib/utils.rs
+++ b/test/integration-tests/lib/utils.rs
@@ -5,27 +5,32 @@ use crate::{
     types::{MessageFrame, MsgType},
 };
 use async_channel::{Receiver, Sender};
-use codec_sv2::{
-    framing_sv2::framing::Frame, HandshakeRole, Initiator, Responder, StandardEitherFrame, Sv2Frame,
-};
 use key_utils::{Secp256k1PublicKey, Secp256k1SecretKey};
-use network_helpers_sv2::noise_connection::Connection;
 use once_cell::sync::Lazy;
-use roles_logic_sv2::parsers::{
-    message_type_to_name, AnyMessage, CommonMessages, IsSv2Message,
-    JobDeclaration::{
-        AllocateMiningJobToken, AllocateMiningJobTokenSuccess, DeclareMiningJob,
-        DeclareMiningJobError, DeclareMiningJobSuccess, ProvideMissingTransactions,
-        ProvideMissingTransactionsSuccess, PushSolution,
-    },
-    TemplateDistribution,
-    TemplateDistribution::CoinbaseOutputConstraints,
-};
 use std::{
     collections::HashSet,
     convert::TryInto,
     net::{SocketAddr, TcpListener},
     sync::Mutex,
+};
+use stratum_common::{
+    network_helpers_sv2::noise_connection::Connection,
+    roles_logic_sv2::{
+        codec_sv2::{
+            framing_sv2::framing::Frame, HandshakeRole, Initiator, Responder, StandardEitherFrame,
+            Sv2Frame,
+        },
+        parsers::{
+            message_type_to_name, AnyMessage, CommonMessages, IsSv2Message,
+            JobDeclaration::{
+                AllocateMiningJobToken, AllocateMiningJobTokenSuccess, DeclareMiningJob,
+                DeclareMiningJobError, DeclareMiningJobSuccess, ProvideMissingTransactions,
+                ProvideMissingTransactionsSuccess, PushSolution,
+            },
+            TemplateDistribution,
+            TemplateDistribution::CoinbaseOutputConstraints,
+        },
+    },
 };
 
 // prevents get_available_port from ever returning the same port twice

--- a/test/integration-tests/tests/jd_integration.rs
+++ b/test/integration-tests/tests/jd_integration.rs
@@ -1,10 +1,11 @@
 // This file contains integration tests for the `JDC/S` module.
-use binary_sv2::{Seq064K, B032, U256};
 use integration_tests_sv2::{
     interceptor::{IgnoreMessage, MessageDirection, ReplaceMessage},
     *,
 };
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
+    self,
+    codec_sv2::binary_sv2::{Seq064K, B032, U256},
     common_messages_sv2::*,
     job_declaration_sv2::{ProvideMissingTransactionsSuccess, PushSolution, *},
     parsers::AnyMessage,

--- a/test/integration-tests/tests/jd_provide_missing_transaction.rs
+++ b/test/integration-tests/tests/jd_provide_missing_transaction.rs
@@ -1,5 +1,5 @@
 use integration_tests_sv2::{interceptor::MessageDirection, *};
-use roles_logic_sv2::job_declaration_sv2::*;
+use stratum_common::roles_logic_sv2::job_declaration_sv2::*;
 
 #[tokio::test]
 async fn jds_ask_for_missing_transactions() {

--- a/test/integration-tests/tests/jd_tproxy_integration.rs
+++ b/test/integration-tests/tests/jd_tproxy_integration.rs
@@ -1,5 +1,5 @@
 use integration_tests_sv2::{interceptor::MessageDirection, *};
-use roles_logic_sv2::{common_messages_sv2::*, mining_sv2::*};
+use stratum_common::roles_logic_sv2::{common_messages_sv2::*, mining_sv2::*};
 
 #[tokio::test]
 async fn jd_tproxy_integration() {

--- a/test/integration-tests/tests/jdc_block_propogation.rs
+++ b/test/integration-tests/tests/jdc_block_propogation.rs
@@ -2,7 +2,7 @@ use integration_tests_sv2::{
     interceptor::{IgnoreMessage, MessageDirection},
     *,
 };
-use roles_logic_sv2::{job_declaration_sv2::*, template_distribution_sv2::*};
+use stratum_common::roles_logic_sv2::{job_declaration_sv2::*, template_distribution_sv2::*};
 
 // Block propogated from JDC to TP
 #[tokio::test]

--- a/test/integration-tests/tests/jdc_fallback.rs
+++ b/test/integration-tests/tests/jdc_fallback.rs
@@ -2,12 +2,12 @@ use integration_tests_sv2::{
     interceptor::{MessageDirection, ReplaceMessage},
     *,
 };
-use roles_logic_sv2::{
+use std::convert::TryInto;
+use stratum_common::roles_logic_sv2::{
     common_messages_sv2::*,
     mining_sv2::{SubmitSharesError, *},
     parsers::{AnyMessage, Mining},
 };
-use std::convert::TryInto;
 
 // Tests whether JDC will switch to a new pool after receiving a `SubmitSharesError` message from
 // the currently connected pool.

--- a/test/integration-tests/tests/jds_block_propogation.rs
+++ b/test/integration-tests/tests/jds_block_propogation.rs
@@ -2,7 +2,7 @@ use integration_tests_sv2::{
     interceptor::{IgnoreMessage, MessageDirection},
     *,
 };
-use roles_logic_sv2::{job_declaration_sv2::*, template_distribution_sv2::*};
+use stratum_common::roles_logic_sv2::{job_declaration_sv2::*, template_distribution_sv2::*};
 
 // Block propogated from JDS to TP
 #[tokio::test]

--- a/test/integration-tests/tests/pool_integration.rs
+++ b/test/integration-tests/tests/pool_integration.rs
@@ -2,7 +2,7 @@
 //
 // `PoolSv2` is a module that implements the Pool role in the Stratum V2 protocol.
 use integration_tests_sv2::{interceptor::MessageDirection, *};
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, *},
     mining_sv2::*,
     parsers::{AnyMessage, CommonMessages, Mining, TemplateDistribution},

--- a/test/integration-tests/tests/sniffer_integration.rs
+++ b/test/integration-tests/tests/sniffer_integration.rs
@@ -3,12 +3,12 @@ use integration_tests_sv2::{
     interceptor::{IgnoreMessage, MessageDirection, ReplaceMessage},
     *,
 };
-use roles_logic_sv2::{
+use std::convert::TryInto;
+use stratum_common::roles_logic_sv2::{
     common_messages_sv2::{Protocol, SetupConnection, SetupConnectionSuccess, *},
     parsers::{AnyMessage, CommonMessages},
     template_distribution_sv2::*,
 };
-use std::convert::TryInto;
 
 // This test aims to assert that Sniffer is able to intercept and replace/ignore messages.
 // TP -> sniffer_a -> sniffer_b -> Pool

--- a/test/integration-tests/tests/sv2_mining_device.rs
+++ b/test/integration-tests/tests/sv2_mining_device.rs
@@ -1,5 +1,5 @@
 use integration_tests_sv2::{interceptor::MessageDirection, *};
-use roles_logic_sv2::common_messages_sv2::*;
+use stratum_common::roles_logic_sv2::common_messages_sv2::*;
 
 #[tokio::test]
 async fn sv2_mining_device_and_pool_success() {

--- a/test/integration-tests/tests/translator_integration.rs
+++ b/test/integration-tests/tests/translator_integration.rs
@@ -1,6 +1,6 @@
 // This file contains integration tests for the `TranslatorSv2` module.
 use integration_tests_sv2::{interceptor::MessageDirection, *};
-use roles_logic_sv2::{
+use stratum_common::roles_logic_sv2::{
     common_messages_sv2::*,
     mining_sv2::*,
     parsers::{AnyMessage, CommonMessages, Mining},

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -81,8 +81,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
@@ -90,6 +90,21 @@ name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
+name = "binary_codec_sv2"
+version = "2.0.0"
+dependencies = [
+ "buffer_sv2",
+]
+
+[[package]]
+name = "binary_sv2"
+version = "3.0.0"
+dependencies = [
+ "binary_codec_sv2",
+ "derive_codec_sv2",
+]
 
 [[package]]
 name = "bip32_derivation"
@@ -107,14 +122,20 @@ checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "bech32",
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1 0.29.1",
 ]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-internals"
@@ -134,7 +155,17 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
 ]
 
 [[package]]
@@ -144,7 +175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -152,6 +183,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -188,6 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +264,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +295,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -233,6 +307,45 @@ dependencies = [
  "bitflags",
  "textwrap",
  "unicode-width",
+]
+
+[[package]]
+name = "codec_sv2"
+version = "2.1.0"
+dependencies = [
+ "binary_sv2",
+ "buffer_sv2",
+ "framing_sv2",
+ "noise_sv2",
+ "rand",
+ "tracing",
+]
+
+[[package]]
+name = "common_messages_sv2"
+version = "5.1.0"
+dependencies = [
+ "binary_sv2",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -306,12 +419,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -346,6 +466,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_codec_sv2"
+version = "1.1.1"
+dependencies = [
+ "binary_codec_sv2",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,8 +488,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "error_handling"
 version = "1.0.0"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "framing_sv2"
+version = "5.1.0"
+dependencies = [
+ "binary_sv2",
+ "buffer_sv2",
+ "noise_sv2",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -412,6 +572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,10 +587,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
 ]
@@ -440,6 +627,36 @@ name = "iai"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
+
+[[package]]
+name = "impl-codec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.4",
+]
 
 [[package]]
 name = "inout"
@@ -464,6 +681,13 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "job_declaration_sv2"
+version = "4.0.0"
+dependencies = [
+ "binary_sv2",
+]
 
 [[package]]
 name = "js-sys"
@@ -512,6 +736,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mining_sv2"
+version = "4.0.0"
+dependencies = [
+ "binary_sv2",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "noise_sv2"
+version = "1.4.0"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "rand",
+ "rand_chacha",
+ "secp256k1 0.28.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +785,40 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -567,6 +849,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,22 +881,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.93"
+name = "primitive-types"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -685,6 +1004,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "roles_logic_sv2"
+version = "3.0.0"
+dependencies = [
+ "bitcoin",
+ "chacha20poly1305",
+ "codec_sv2",
+ "common_messages_sv2",
+ "hex-conservative 0.3.0",
+ "job_declaration_sv2",
+ "mining_sv2",
+ "nohash-hasher",
+ "primitive-types",
+ "template_distribution_sv2",
+ "tracing",
+]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +1053,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
+ "bitcoin_hashes 0.13.0",
  "rand",
  "secp256k1-sys 0.9.2",
 ]
@@ -721,7 +1064,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "secp256k1-sys 0.10.1",
 ]
 
@@ -745,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -764,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -805,11 +1148,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stratum-common"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
- "bitcoin",
- "secp256k1 0.28.2",
+ "roles_logic_sv2",
 ]
 
 [[package]]
@@ -827,6 +1175,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "template_distribution_sv2"
+version = "3.1.0"
+dependencies = [
+ "binary_sv2",
 ]
 
 [[package]]
@@ -853,8 +1214,56 @@ name = "toml"
 version = "0.5.6"
 source = "git+https://github.com/diondokter/toml-rs?rev=c4161aa#c4161aa70202b3992dbec79b76e7a8659713b604"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.7.2",
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -862,6 +1271,18 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -874,6 +1295,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -1080,6 +1507,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,3 +1544,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/utils/bip32-key-derivation/Cargo.toml
+++ b/utils/bip32-key-derivation/Cargo.toml
@@ -20,7 +20,8 @@ name = "bip32_derivation-bin"
 path = "src/main.rs"
 
 [dependencies]
-stratum-common = { path = "../../common", features=["bitcoin"], version = "^2.0.0" }
+stratum-common = { path = "../../common" }
+
 
 [dev-dependencies]
 toml = { version = "0.5.6", git = "https://github.com/diondokter/toml-rs", default-features = false, rev = "c4161aa" }

--- a/utils/bip32-key-derivation/src/lib.rs
+++ b/utils/bip32-key-derivation/src/lib.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use stratum_common::bitcoin::{
+use stratum_common::roles_logic_sv2::bitcoin::{
     bip32::{DerivationPath, Error, Xpub},
     secp256k1::Secp256k1,
 };

--- a/utils/bip32-key-derivation/src/main.rs
+++ b/utils/bip32-key-derivation/src/main.rs
@@ -1,6 +1,6 @@
 use bip32_derivation::derive_child_public_key;
 use std::{env, str::FromStr};
-use stratum_common::bitcoin::bip32::Xpub;
+use stratum_common::roles_logic_sv2::bitcoin::bip32::Xpub;
 
 fn main() {
     let args: Vec<String> = env::args().collect();


### PR DESCRIPTION
As discussed in #1740, this PR proposes an alternative solution to close #1458.

All roles have been updated to follow the new import scheme proposed in #1740:

![image](https://github.com/user-attachments/assets/2c116410-42b8-4525-87e2-47ac37e45441)

---

### Notes for Reviewers

During the migration to the new import structure, I observed that `stratum-common` was previously used solely to re-export the `bitcoin` and `secp256k1` crates.

With the new structure, however, `roles-logic-sv2` is now a dependency of `stratum-common`. This introduces a circular dependency if `roles-logic-sv2` continues to access the `bitcoin` crate via `stratum-common`.

To break this cycle, I removed the `bitcoin` and `secp256k1` re-exports from `stratum-common`. Any crates that previously relied on those re-exports now import the required crates directly.

---

### Version Bumps

* `stratum-common`: **2.0.0 → 3.0.0**
  Reason: Removed the `bitcoin` feature and introduced new features

* `network-helpers-sv2`: **3.1.0 → 4.0.0**
  Reason: Removed the `binary_Sv2` feature