### PR TITLE
fix unnecessary version bumps

### DIFF
--- a/protocols/v2/subprotocols/job-declaration/Cargo.toml
+++ b/protocols/v2/subprotocols/job-declaration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job_declaration_sv2"
-version = "4.1.0"
+version = "4.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining_sv2"
-version = "4.1.0"
+version = "4.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "job_declaration_sv2"
-version = "4.1.0"
+version = "4.0.0"
 dependencies = [
  "binary_sv2",
  "stratum-common",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "mining_sv2"
-version = "4.1.0"
+version = "4.0.0"
 dependencies = [
  "binary_sv2",
  "stratum-common",

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "job_declaration_sv2"
-version = "4.1.0"
+version = "4.0.0"
 dependencies = [
  "binary_sv2",
  "stratum-common",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "mining_sv2"
-version = "4.1.0"
+version = "4.0.0"
 dependencies = [
  "binary_sv2",
  "stratum-common",


### PR DESCRIPTION
done by mistake on #1728

`job_declaration_sv2` already had MAJOR bumped via #1629 (v3.0.0 to v4.0.0)

`mining_sv2` already had MAJOR bumped via #1651 (v3.0.0 to v4.0.0)

both crates have not yet been published to crates.io, and we were bumping MINOR for both on #1728 

that would have resulted in publishing both crates under v4.1.0, without ever having published v4.0.0

in other words, the changes introduced on #1728 are already covered by the MAJOR bumps that have not yet been published, so no extra MINOR bump is needed