### PR TITLE
Simplify network helpers

### DIFF
--- a/protocols/v2/codec-sv2/src/lib.rs
+++ b/protocols/v2/codec-sv2/src/lib.rs
@@ -79,7 +79,7 @@ pub use framing_sv2::{self, framing::handshake_message_to_frame as h2f};
 /// process accordingly.
 #[allow(clippy::large_enum_variant)]
 #[cfg(feature = "noise_sv2")]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HandshakeRole {
     /// The initiator role in the Noise handshake process.
     ///
@@ -103,7 +103,7 @@ pub enum HandshakeRole {
 /// [`State::HandShake`] and finally to transport mode [`State::Transport`] as the encryption
 /// handshake is completed.
 #[cfg(feature = "noise_sv2")]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum State {
     /// The codec has not been initialized yet.

--- a/protocols/v2/noise-sv2/src/cipher_state.rs
+++ b/protocols/v2/noise-sv2/src/cipher_state.rs
@@ -175,6 +175,7 @@ where
 // `GenericCipher` enables easy switching between ciphers while maintaining secure key and nonce
 // management.
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 pub enum GenericCipher {
     ChaCha20Poly1305(Cipher<ChaCha20Poly1305>),
     #[allow(dead_code)]
@@ -302,6 +303,7 @@ impl CipherState<Aes256Gcm> for GenericCipher {
 // It stores the optional encryption key, the nonce, and the optional cipher instance itself. The
 // [`CipherState`] trait is implemented to provide a consistent interface for managing cipher
 // state across different AEAD ciphers.
+#[derive(Clone)]
 pub struct Cipher<C: AeadCipher> {
     // Optional 32-byte encryption key.
     k: Option<[u8; 32]>,

--- a/protocols/v2/noise-sv2/src/initiator.rs
+++ b/protocols/v2/noise-sv2/src/initiator.rs
@@ -61,6 +61,7 @@ use secp256k1::{
 /// exchanges, and maintains the handshake hash, chaining key, and nonce for message encryption.
 /// After the handshake, it facilitates secure communication using either [`ChaCha20Poly1305`] or
 /// `AES-GCM` ciphers. Sensitive data is securely erased when no longer needed.
+#[derive(Clone)]
 pub struct Initiator {
     // Cipher used for encrypting and decrypting messages during the handshake.
     //

--- a/protocols/v2/noise-sv2/src/lib.rs
+++ b/protocols/v2/noise-sv2/src/lib.rs
@@ -105,6 +105,7 @@ const PARITY: secp256k1::Parity = secp256k1::Parity::Even;
 /// Manages the encryption and decryption of messages between two parties, the [`Initiator`] and
 /// [`Responder`], using the Noise protocol. A symmetric cipher is used for both encrypting
 /// outgoing messages and decrypting incoming messages.
+#[derive(Clone)]
 pub struct NoiseCodec {
     // Cipher to encrypt outgoing messages.
     encryptor: GenericCipher,

--- a/protocols/v2/noise-sv2/src/responder.rs
+++ b/protocols/v2/noise-sv2/src/responder.rs
@@ -60,6 +60,7 @@ const VERSION: u16 = 0;
 /// a connection with the initiator. The responder manages key generation, Diffie-Hellman exchanges,
 /// message decryption, and state transitions, ensuring secure communication. Sensitive
 /// cryptographic material is securely erased when no longer needed.
+#[derive(Clone)]
 pub struct Responder {
     // Cipher used for encrypting and decrypting messages during the handshake.
     //

--- a/roles/roles-utils/network-helpers/src/lib.rs
+++ b/roles/roles-utils/network-helpers/src/lib.rs
@@ -1,19 +1,10 @@
-use binary_sv2::{Deserialize, GetSize, Serialize};
 pub mod noise_connection;
 pub mod plain_connection;
 #[cfg(feature = "sv1")]
 pub mod sv1_connection;
 
-use async_channel::{Receiver, RecvError, SendError, Sender};
-use codec_sv2::{
-    noise_sv2::{ELLSWIFT_ENCODING_SIZE, INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE},
-    Error as CodecError, HandShakeFrame, HandshakeRole, StandardEitherFrame,
-};
-use futures::lock::Mutex;
-use std::{
-    convert::TryInto,
-    sync::{atomic::AtomicBool, Arc},
-};
+use async_channel::{RecvError, SendError};
+use codec_sv2::Error as CodecError;
 
 #[derive(Debug)]
 pub enum Error {
@@ -41,81 +32,3 @@ impl<T> From<SendError<T>> for Error {
         Error::SendError
     }
 }
-
-trait SetState {
-    async fn set_state(self_: Arc<Mutex<Self>>, state: codec_sv2::State);
-}
-
-async fn initialize_as_downstream<
-    'a,
-    Message: Serialize + Deserialize<'a> + GetSize,
-    T: SetState,
->(
-    self_: Arc<Mutex<T>>,
-    role: HandshakeRole,
-    sender_outgoing: Sender<StandardEitherFrame<Message>>,
-    receiver_incoming: Receiver<StandardEitherFrame<Message>>,
-) -> Result<(), Error> {
-    let mut state = codec_sv2::State::initialized(role);
-
-    // Create and send first handshake message
-    let first_message = state.step_0()?;
-    sender_outgoing.send(first_message.into()).await?;
-
-    // Receive and deserialize second handshake message
-    let second_message = receiver_incoming.recv().await?;
-    let second_message: HandShakeFrame = second_message
-        .try_into()
-        .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-    let second_message: [u8; INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE] = second_message
-        .get_payload_when_handshaking()
-        .try_into()
-        .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-
-    // Create and send thirth handshake message
-    let transport_mode = state.step_2(second_message)?;
-
-    T::set_state(self_, transport_mode).await;
-    while !TRANSPORT_READY.load(std::sync::atomic::Ordering::SeqCst) {
-        std::hint::spin_loop()
-    }
-    Ok(())
-}
-
-async fn initialize_as_upstream<'a, Message: Serialize + Deserialize<'a> + GetSize, T: SetState>(
-    self_: Arc<Mutex<T>>,
-    role: HandshakeRole,
-    sender_outgoing: Sender<StandardEitherFrame<Message>>,
-    receiver_incoming: Receiver<StandardEitherFrame<Message>>,
-) -> Result<(), Error> {
-    let mut state = codec_sv2::State::initialized(role);
-
-    // Receive and deserialize first handshake message
-    let first_message: HandShakeFrame = receiver_incoming
-        .recv()
-        .await?
-        .try_into()
-        .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-    let first_message: [u8; ELLSWIFT_ENCODING_SIZE] = first_message
-        .get_payload_when_handshaking()
-        .try_into()
-        .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-
-    // Create and send second handshake message
-    let (second_message, transport_mode) = state.step_1(first_message)?;
-    HANDSHAKE_READY.store(false, std::sync::atomic::Ordering::SeqCst);
-    sender_outgoing.send(second_message.into()).await?;
-
-    // This sets the state to Handshake state - this prompts the task above to move the state
-    // to transport mode so that the next incoming message will be decoded correctly
-    // It is important to do this directly before sending the fourth message
-    T::set_state(self_, transport_mode).await;
-    while !TRANSPORT_READY.load(std::sync::atomic::Ordering::SeqCst) {
-        std::hint::spin_loop()
-    }
-
-    Ok(())
-}
-
-static HANDSHAKE_READY: AtomicBool = AtomicBool::new(false);
-static TRANSPORT_READY: AtomicBool = AtomicBool::new(false);

--- a/roles/roles-utils/network-helpers/src/noise_connection.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::new_ret_no_self)]
 use crate::Error;
 use async_channel::{unbounded, Receiver, Sender};
 use binary_sv2::{Deserialize, GetSize, Serialize};

--- a/roles/roles-utils/network-helpers/src/noise_connection.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection.rs
@@ -1,13 +1,18 @@
 use crate::Error;
 use async_channel::{unbounded, Receiver, Sender};
 use binary_sv2::{Deserialize, GetSize, Serialize};
-use codec_sv2::{HandshakeRole, StandardEitherFrame, StandardNoiseDecoder};
-use futures::lock::Mutex;
-use std::sync::Arc;
+use codec_sv2::{
+    noise_sv2::{ELLSWIFT_ENCODING_SIZE, INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE},
+    HandShakeFrame, HandshakeRole, StandardEitherFrame, StandardNoiseDecoder, State,
+};
+use std::convert::TryInto;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::TcpStream,
-    select, task,
+    net::{
+        tcp::{OwnedReadHalf, OwnedWriteHalf},
+        TcpStream,
+    },
+    task,
 };
 use tracing::{debug, error};
 
@@ -16,23 +21,34 @@ pub struct Connection {
     pub state: codec_sv2::State,
 }
 
-impl crate::SetState for Connection {
-    async fn set_state(self_: Arc<Mutex<Self>>, state: codec_sv2::State) {
-        loop {
-            if crate::HANDSHAKE_READY.load(std::sync::atomic::Ordering::SeqCst) {
-                if let Some(mut connection) = self_.try_lock() {
-                    connection.state = state;
-                    crate::TRANSPORT_READY.store(true, std::sync::atomic::Ordering::Relaxed);
-                    break;
-                };
-            }
-            task::yield_now().await;
-        }
-    }
+async fn send_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+    writer: &mut OwnedWriteHalf,
+    msg: StandardEitherFrame<Message>,
+    state: &mut State,
+    encoder: &mut codec_sv2::NoiseEncoder<Message>,
+) -> Result<(), Error> {
+    let buffer = encoder.encode(msg, state)?;
+    writer
+        .write_all(buffer.as_ref())
+        .await
+        .map_err(|_| Error::SocketClosed)?;
+    Ok(())
+}
+
+async fn receive_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+    reader: &mut OwnedReadHalf,
+    state: &mut State,
+    decoder: &mut StandardNoiseDecoder<Message>,
+) -> Result<StandardEitherFrame<Message>, Error> {
+    let writable = decoder.writable();
+    reader
+        .read_exact(writable)
+        .await
+        .map_err(|_| Error::SocketClosed)?;
+    decoder.next_frame(state).map_err(Error::CodecError)
 }
 
 impl Connection {
-    #[allow(clippy::new_ret_no_self)]
     pub async fn new<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
         stream: TcpStream,
         role: HandshakeRole,
@@ -44,138 +60,143 @@ impl Connection {
         Error,
     > {
         let address = stream.peer_addr().map_err(|_| Error::SocketClosed)?;
-
         let (mut reader, mut writer) = stream.into_split();
+        let mut decoder = StandardNoiseDecoder::<Message>::new();
+        let mut encoder = codec_sv2::NoiseEncoder::<Message>::new();
+        let mut state = codec_sv2::State::initialized(role.clone());
 
-        let (sender_incoming, receiver_incoming): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
-        ) = unbounded();
-        let (sender_outgoing, receiver_outgoing): (
-            Sender<StandardEitherFrame<Message>>,
-            Receiver<StandardEitherFrame<Message>>,
-        ) = unbounded();
-
-        let state = codec_sv2::State::not_initialized(&role);
-
-        let connection = Arc::new(Mutex::new(Self { state }));
-
-        let cloned1 = connection.clone();
-        let cloned2 = connection.clone();
-
-        task::spawn(async move {
-            select!(
-              _ = tokio::signal::ctrl_c() => { },
-              _ = async {
-                let mut decoder = StandardNoiseDecoder::<Message>::new();
-                loop {
-                  let writable = decoder.writable();
-                  match reader.read_exact(writable).await {
-                    Ok(_) => {
-                      let mut connection = cloned1.lock().await;
-                      let decoded = decoder.next_frame(&mut connection.state);
-                      drop(connection);
-                      match decoded {
-                        Ok(x) => {
-                          if sender_incoming.send(x).await.is_err() {
-                            error!("Shutting down noise stream reader!");
-                            break;
-                          }
-                        }
-                        Err(e) => {
-                          if let codec_sv2::Error::MissingBytes(_) = e {
-                          } else {
-                            error!("Shutting down noise stream reader! {:#?}", e);
-                            sender_incoming.close();
-                            break;
-                          }
-                        }
-                      }
-                    }
-                    Err(e) => {
-                      error!(
-                        "Disconnected from client while reading : {} - {}",
-                        e, &address
-                      );
-                      sender_incoming.close();
-                      break;
-                    }
-                  }
-                }
-              } => {}
-            );
-        });
-
-        let receiver_outgoing_cloned = receiver_outgoing.clone();
-        task::spawn(async move {
-            select!(
-              _ = tokio::signal::ctrl_c() => { },
-              _ = async {
-                let mut encoder = codec_sv2::NoiseEncoder::<Message>::new();
-                loop {
-                  let received = receiver_outgoing_cloned.recv().await;
-
-                  match received {
-                    Ok(frame) => {
-                      let mut connection = cloned2.lock().await;
-                      let b = encoder.encode(frame, &mut connection.state).unwrap();
-                      drop(connection);
-                      let b = b.as_ref();
-                      match (writer).write_all(b).await {
-                        Ok(_) => (),
-                        Err(e) => {
-                          let _ = writer.shutdown().await;
-                          // Just fail and force to reinitialize everything
-                          error!(
-                            "Disconnecting from client due to error writing: {} - {}",
-                            e, &address
-                          );
-                          task::yield_now().await;
-                          break;
-                        }
-                      }
-                    }
-                    Err(e) => {
-                      // Just fail and force to reinitialize everything
-                      let _ = writer.shutdown().await;
-                      error!(
-                        "Disconnecting from client due to error receiving: {} - {}",
-                        e, &address
-                      );
-                      task::yield_now().await;
-                      break;
-                    }
-                  };
-                  crate::HANDSHAKE_READY.store(true, std::sync::atomic::Ordering::Relaxed);
-                }
-              } => {}
-            );
-        });
-
-        // DO THE NOISE HANDSHAKE
+        // Handshake Phase
         match role {
             HandshakeRole::Initiator(_) => {
-                debug!("Initializing as downstream for - {}", &address);
-                crate::initialize_as_downstream(
-                    connection.clone(),
-                    role,
-                    sender_outgoing.clone(),
-                    receiver_incoming.clone(),
-                )
-                .await?
+                debug!("Initializing as downstream for {}", address);
+                let mut responder_state = codec_sv2::State::not_initialized(&role);
+                let first_msg = state.step_0()?;
+                send_message(&mut writer, first_msg.into(), &mut state, &mut encoder).await?;
+                debug!("First handshake message sent");
+
+                loop {
+                    match receive_message(&mut reader, &mut responder_state, &mut decoder).await {
+                        Ok(second_msg) => {
+                            debug!("Second handshake message received");
+                            let handshake_frame: HandShakeFrame = second_msg
+                                .try_into()
+                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let payload: [u8; INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE] =
+                                handshake_frame
+                                    .get_payload_when_handshaking()
+                                    .try_into()
+                                    .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let transport_state = state.step_2(payload)?;
+                            state = transport_state;
+                            break;
+                        }
+                        Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
+                            debug!("Waiting for more bytes during handshake");
+                        }
+                        Err(e) => {
+                            error!("Handshake failed with upstream: {:?}", e);
+                            return Err(e);
+                        }
+                    }
+                }
             }
             HandshakeRole::Responder(_) => {
-                debug!("Initializing as upstream for - {}", &address);
-                crate::initialize_as_upstream(
-                    connection.clone(),
-                    role,
-                    sender_outgoing.clone(),
-                    receiver_incoming.clone(),
-                )
-                .await?
+                debug!("Initializing as upstream for {}", address);
+                let mut initiator_state = codec_sv2::State::not_initialized(&role);
+
+                loop {
+                    match receive_message(&mut reader, &mut initiator_state, &mut decoder).await {
+                        Ok(first_msg) => {
+                            debug!("First handshake message received");
+                            let handshake_frame: HandShakeFrame = first_msg
+                                .try_into()
+                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let payload: [u8; ELLSWIFT_ENCODING_SIZE] = handshake_frame
+                                .get_payload_when_handshaking()
+                                .try_into()
+                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let (second_msg, transport_state) = state.step_1(payload)?;
+                            send_message(&mut writer, second_msg.into(), &mut state, &mut encoder)
+                                .await?;
+                            debug!("Second handshake message sent");
+                            state = transport_state;
+                            break;
+                        }
+                        Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
+                            debug!("Waiting for more bytes during handshake");
+                        }
+                        Err(e) => {
+                            error!("Handshake failed with downstream: {:?}", e);
+                            return Err(e);
+                        }
+                    }
+                }
             }
         };
-        debug!("Noise handshake complete - {}", &address);
+
+        debug!("Handshake completed with state: {:?}", state);
+
+        let (sender_incoming, receiver_incoming) = unbounded();
+        let (sender_outgoing, receiver_outgoing) = unbounded();
+
+        // Spawn Reader
+        let read_state = state.clone();
+        Self::spawn_reader(reader, read_state, address, sender_incoming.clone());
+
+        // Spawn Writer
+        let write_state = state;
+        Self::spawn_writer(writer, write_state, address, receiver_outgoing.clone());
+
         Ok((receiver_incoming, sender_outgoing))
+    }
+
+    fn spawn_reader<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+        mut reader: OwnedReadHalf,
+        mut reader_state: State,
+        address: std::net::SocketAddr,
+        sender_incoming: Sender<StandardEitherFrame<Message>>,
+    ) -> task::JoinHandle<()> {
+        task::spawn(async move {
+            let mut decoder = StandardNoiseDecoder::<Message>::new();
+            loop {
+                match receive_message(&mut reader, &mut reader_state, &mut decoder).await {
+                    Ok(frame) => {
+                        if sender_incoming.send(frame).await.is_err() {
+                            error!("Shutting down reader for {}", address);
+                            break;
+                        }
+                    }
+                    Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
+                        debug!("Waiting for more bytes while reading stream");
+                    }
+                    Err(e) => {
+                        error!("Reader shutting down due to error: {:?}", e);
+                        sender_incoming.close();
+                        break;
+                    }
+                }
+            }
+        })
+    }
+
+    fn spawn_writer<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+        mut writer: OwnedWriteHalf,
+        mut write_state: State,
+        address: std::net::SocketAddr,
+        receiver_outgoing: Receiver<StandardEitherFrame<Message>>,
+    ) -> task::JoinHandle<()> {
+        task::spawn(async move {
+            let mut encoder = codec_sv2::NoiseEncoder::<Message>::new();
+            while let Ok(frame) = receiver_outgoing.recv().await {
+                if let Err(e) =
+                    send_message(&mut writer, frame, &mut write_state, &mut encoder).await
+                {
+                    error!("Error while writing to client {}: {:?}", address, e);
+                    let _ = writer.shutdown().await;
+                    break;
+                }
+            }
+            let _ = writer.shutdown().await;
+        })
     }
 }


### PR DESCRIPTION
This PR restructures the network_helpers noise_connection flow to make it simpler and more reliable. Previously, we were starting background tasks before completing the handshake, which made the flow confusing and likely caused ghost tasks. Now, the handshake is fully completed first, and only then are the read/write tasks spawned. We also removed the shared state wrapped in sync primitives instead, each stream gets its own cloned state, avoiding unnecessary locking since encryption and decryption are independent in Noise. Overall, this simplifies the architecture, hopefully eliminated zombie task, and makes the flow much easier to reason about.