### PR TITLE
Implements Display for messages across the codebase

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/parsers.rs
+++ b/protocols/v2/roles-logic-sv2/src/parsers.rs
@@ -31,7 +31,10 @@ use codec_sv2::{
     framing_sv2::framing::Sv2Frame,
 };
 use common_messages_sv2::*;
-use core::convert::{TryFrom, TryInto};
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt,
+};
 use job_declaration_sv2::*;
 use mining_sv2::*;
 use template_distribution_sv2::*;
@@ -135,6 +138,18 @@ pub enum CommonMessages<'a> {
     SetupConnectionSuccess(SetupConnectionSuccess),
 }
 
+impl fmt::Display for CommonMessages<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CommonMessages::ChannelEndpointChanged(m) => write!(f, "{m}"),
+            CommonMessages::Reconnect(m) => write!(f, "{m}"),
+            CommonMessages::SetupConnection(m) => write!(f, "{m}"),
+            CommonMessages::SetupConnectionError(m) => write!(f, "{m}"),
+            CommonMessages::SetupConnectionSuccess(m) => write!(f, "{m}"),
+        }
+    }
+}
+
 /// A parser of messages of Template Distribution subprotocol, to be used for parsing raw messages
 #[derive(Clone, Debug)]
 pub enum TemplateDistribution<'a> {
@@ -145,6 +160,28 @@ pub enum TemplateDistribution<'a> {
     RequestTransactionDataSuccess(RequestTransactionDataSuccess<'a>),
     SetNewPrevHash(SetNewPrevHash<'a>),
     SubmitSolution(SubmitSolution<'a>),
+}
+
+impl fmt::Display for TemplateDistribution<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TemplateDistribution::CoinbaseOutputConstraints(m) => {
+                write!(f, "CoinbaseOutputConstraints: {m}")
+            }
+            TemplateDistribution::NewTemplate(m) => write!(f, "{m}"),
+            TemplateDistribution::RequestTransactionData(m) => {
+                write!(f, "{m}")
+            }
+            TemplateDistribution::RequestTransactionDataError(m) => {
+                write!(f, "{m}")
+            }
+            TemplateDistribution::RequestTransactionDataSuccess(m) => {
+                write!(f, "{m}")
+            }
+            TemplateDistribution::SetNewPrevHash(m) => write!(f, "{m}"),
+            TemplateDistribution::SubmitSolution(m) => write!(f, "{m}"),
+        }
+    }
 }
 
 /// A parser of messages of Job Declaration subprotocol, to be used for parsing raw messages
@@ -158,6 +195,29 @@ pub enum JobDeclaration<'a> {
     ProvideMissingTransactions(ProvideMissingTransactions<'a>),
     ProvideMissingTransactionsSuccess(ProvideMissingTransactionsSuccess<'a>),
     PushSolution(PushSolution<'a>),
+}
+
+impl fmt::Display for JobDeclaration<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JobDeclaration::AllocateMiningJobToken(m) => write!(f, "AllocateMiningJobToken: {m}"),
+            JobDeclaration::AllocateMiningJobTokenSuccess(m) => {
+                write!(f, "AllocateMiningJobTokenSuccess: {m}")
+            }
+            JobDeclaration::DeclareMiningJob(m) => write!(f, "DeclareMiningJob: {m}"),
+            JobDeclaration::DeclareMiningJobError(m) => write!(f, "DeclareMiningJobError: {m}"),
+            JobDeclaration::DeclareMiningJobSuccess(m) => {
+                write!(f, "DeclareMiningJobSuccess: {m}")
+            }
+            JobDeclaration::ProvideMissingTransactions(m) => {
+                write!(f, "ProvideMissingTransactions: {m}")
+            }
+            JobDeclaration::ProvideMissingTransactionsSuccess(m) => {
+                write!(f, "ProvideMissingTransactionsSuccess: {m}")
+            }
+            JobDeclaration::PushSolution(m) => write!(f, "PushSolution: {m}"),
+        }
+    }
 }
 
 /// Mining subprotocol messages: categorization, encapsulation, and parsing.
@@ -206,6 +266,34 @@ pub enum Mining<'a> {
     SubmitSharesSuccess(SubmitSharesSuccess),
     UpdateChannel(UpdateChannel<'a>),
     UpdateChannelError(UpdateChannelError<'a>),
+}
+
+impl fmt::Display for Mining<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Mining::CloseChannel(m) => write!(f, "{m}"),
+            Mining::NewExtendedMiningJob(m) => write!(f, "{m}"),
+            Mining::NewMiningJob(m) => write!(f, "{m}"),
+            Mining::OpenExtendedMiningChannel(m) => write!(f, "{m}"),
+            Mining::OpenExtendedMiningChannelSuccess(m) => write!(f, "{m}"),
+            Mining::OpenMiningChannelError(m) => write!(f, "{m}"),
+            Mining::OpenStandardMiningChannel(m) => write!(f, "{m}"),
+            Mining::OpenStandardMiningChannelSuccess(m) => write!(f, "{m}"),
+            Mining::SetCustomMiningJob(m) => write!(f, "{m}"),
+            Mining::SetCustomMiningJobError(m) => write!(f, "{m}"),
+            Mining::SetCustomMiningJobSuccess(m) => write!(f, "{m}"),
+            Mining::SetExtranoncePrefix(m) => write!(f, "{m}"),
+            Mining::SetGroupChannel(m) => write!(f, "{m}"),
+            Mining::SetNewPrevHash(m) => write!(f, "{m}"),
+            Mining::SetTarget(m) => write!(f, "{m}"),
+            Mining::SubmitSharesError(m) => write!(f, "{m}"),
+            Mining::SubmitSharesExtended(m) => write!(f, "{m}"),
+            Mining::SubmitSharesStandard(m) => write!(f, "{m}"),
+            Mining::SubmitSharesSuccess(m) => write!(f, "{m}"),
+            Mining::UpdateChannel(m) => write!(f, "{m}"),
+            Mining::UpdateChannelError(m) => write!(f, "{m}"),
+        }
+    }
 }
 
 impl Mining<'_> {
@@ -1016,6 +1104,17 @@ pub enum AnyMessage<'a> {
     Mining(Mining<'a>),
     JobDeclaration(JobDeclaration<'a>),
     TemplateDistribution(TemplateDistribution<'a>),
+}
+
+impl fmt::Display for AnyMessage<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AnyMessage::Common(m) => write!(f, "CommonMessage: {m}"),
+            AnyMessage::Mining(m) => write!(f, "MiningMessage: {m}"),
+            AnyMessage::JobDeclaration(m) => write!(f, "JobDeclarationMessage: {m}"),
+            AnyMessage::TemplateDistribution(m) => write!(f, "TemplateDistributionMessage: {m}"),
+        }
+    }
 }
 
 impl<'a> TryFrom<MiningDeviceMessages<'a>> for AnyMessage<'a> {

--- a/protocols/v2/subprotocols/common-messages/src/channel_endpoint_changed.rs
+++ b/protocols/v2/subprotocols/common-messages/src/channel_endpoint_changed.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize};
 use core::convert::TryInto;
 
@@ -15,4 +15,10 @@ use core::convert::TryInto;
 pub struct ChannelEndpointChanged {
     /// Unique identifier of the channel that has changed its endpoint.
     pub channel_id: u32,
+}
+
+impl fmt::Display for ChannelEndpointChanged {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ChannelEndpointChanged(channel_id: {})", self.channel_id)
+    }
 }

--- a/protocols/v2/subprotocols/common-messages/src/reconnect.rs
+++ b/protocols/v2/subprotocols/common-messages/src/reconnect.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, Str0255};
 use core::convert::TryInto;
 
@@ -18,6 +18,17 @@ pub struct Reconnect<'decoder> {
     pub new_host: Str0255<'decoder>,
     /// When 0, downstream node should attempt to reconnect to current pool host.
     pub new_port: u16,
+}
+
+impl fmt::Display for Reconnect<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Reconnect(new_host: {}, new_port: {})",
+            self.new_host.as_utf8_or_hex(),
+            self.new_port
+        )
+    }
 }
 
 impl PartialEq for Reconnect<'_> {

--- a/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
+++ b/protocols/v2/subprotocols/common-messages/src/setup_connection.rs
@@ -2,7 +2,7 @@ use crate::{
     SV2_JOB_DECLARATION_PROTOCOL_DISCRIMINANT, SV2_MINING_PROTOCOL_DISCRIMINANT,
     SV2_TEMPLATE_DISTRIBUTION_PROTOCOL_DISCRIMINANT,
 };
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{
     binary_codec_sv2,
     binary_codec_sv2::CVec,
@@ -52,6 +52,25 @@ pub struct SetupConnection<'decoder> {
     pub firmware: Str0255<'decoder>,
     /// Device identifier.
     pub device_id: Str0255<'decoder>,
+}
+
+impl fmt::Display for SetupConnection<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetupConnection(protocol: {}, min_version: {}, max_version: {}, flags: {}, endpoint_host: {}, endpoint_port: {}, vendor: {}, hardware_version: {}, firmware: {}, device_id: {})",
+            self.protocol as u8,
+            self.min_version,
+            self.max_version,
+            self.flags,
+            self.endpoint_host.as_utf8_or_hex(),
+            self.endpoint_port,
+            self.vendor.as_utf8_or_hex(),
+            self.hardware_version.as_utf8_or_hex(),
+            self.firmware.as_utf8_or_hex(),
+            self.device_id.as_utf8_or_hex()
+        )
+    }
 }
 
 impl SetupConnection<'_> {
@@ -287,6 +306,16 @@ pub struct SetupConnectionSuccess {
     pub flags: u32,
 }
 
+impl fmt::Display for SetupConnectionSuccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetupConnectionSuccess(used_version: {}, flags: {})",
+            self.used_version, self.flags
+        )
+    }
+}
+
 /// Message used by an upstream role to reject a connection setup request from a downstream role.
 ///
 /// This message is sent in response to a [`SetupConnection`] message.
@@ -314,6 +343,17 @@ pub struct SetupConnectionError<'decoder> {
     /// - unsupported-protocol
     /// - protocol-version-mismatch
     pub error_code: Str0255<'decoder>,
+}
+
+impl fmt::Display for SetupConnectionError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetupConnectionError(flags: {}, error_code: {})",
+            self.flags,
+            self.error_code.as_utf8_or_hex()
+        )
+    }
 }
 
 #[repr(C)]

--- a/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/allocate_mining_job_token.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, Str0255, B0255, B064K};
 use core::convert::TryInto;
 
@@ -14,6 +14,17 @@ pub struct AllocateMiningJobToken<'decoder> {
     pub request_id: u32,
 }
 
+impl fmt::Display for AllocateMiningJobToken<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "AllocateMiningJobToken(user_identifier: {}, request_id: {})",
+            self.user_identifier.as_utf8_or_hex(),
+            self.request_id
+        )
+    }
+}
+
 /// Message used by JDS to accept [`AllocateMiningJobToken`] message.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
@@ -27,4 +38,16 @@ pub struct AllocateMiningJobTokenSuccess<'decoder> {
     pub mining_job_token: B0255<'decoder>,
     /// Bitcoin transaction outputs added by JDS.
     pub coinbase_outputs: B064K<'decoder>,
+}
+
+impl fmt::Display for AllocateMiningJobTokenSuccess<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "AllocateMiningJobTokenSuccess(request_id: {}, mining_job_token: {}, coinbase_outputs: {})",
+            self.request_id,
+            self.mining_job_token,
+            self.coinbase_outputs
+        )
+    }
 }

--- a/protocols/v2/subprotocols/job-declaration/src/declare_mining_job.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/declare_mining_job.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Seq064K, Serialize, Str0255, B0255, B064K, U256};
 use core::convert::TryInto;
 
@@ -34,6 +34,22 @@ pub struct DeclareMiningJob<'decoder> {
     pub excess_data: B064K<'decoder>,
 }
 
+impl fmt::Display for DeclareMiningJob<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DeclareMiningJob(request_id: {}, mining_job_token: {}, version: {}, coinbase_prefix: {}, coinbase_suffix: {}, tx_ids_list: {}, excess_data: {})",
+            self.request_id,
+            self.mining_job_token,
+            self.version,
+            self.coinbase_prefix,
+            self.coinbase_suffix,
+            self.tx_ids_list,
+            self.excess_data
+        )
+    }
+}
+
 /// Messaged used by JDS to accept [`DeclareMiningJob`] message.
 ///
 /// If [`Full Template`] mode is used, JDS MAY request txdata via `ProvideMissingTransactions`
@@ -54,6 +70,16 @@ pub struct DeclareMiningJobSuccess<'decoder> {
     pub new_mining_job_token: B0255<'decoder>,
 }
 
+impl fmt::Display for DeclareMiningJobSuccess<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DeclareMiningJobSuccess(request_id: {}, new_mining_job_token: {})",
+            self.request_id, self.new_mining_job_token
+        )
+    }
+}
+
 /// Messaged used by JDS to reject [`DeclareMiningJob`] message.
 ///
 /// Downstream should consider this as a trigger to fallback into some other Pool/JDS or solo
@@ -72,4 +98,16 @@ pub struct DeclareMiningJobError<'decoder> {
     pub error_code: Str0255<'decoder>,
     /// Optional details about the error.
     pub error_details: B064K<'decoder>,
+}
+
+impl fmt::Display for DeclareMiningJobError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DeclareMiningJobError(request_id: {}, error_code: {}, error_details: {})",
+            self.request_id,
+            self.error_code.as_utf8_or_hex(),
+            self.error_details
+        )
+    }
 }

--- a/protocols/v2/subprotocols/job-declaration/src/provide_missing_transactions.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/provide_missing_transactions.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Seq064K, Serialize, B016M};
 use core::convert::TryInto;
 
@@ -28,6 +28,16 @@ pub struct ProvideMissingTransactions<'decoder> {
     pub unknown_tx_position_list: Seq064K<'decoder, u16>,
 }
 
+impl fmt::Display for ProvideMissingTransactions<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ProvideMissingTransactions(request_id: {}, unknown_tx_position_list: {})",
+            self.request_id, self.unknown_tx_position_list
+        )
+    }
+}
+
 /// Message used by JDC to accept [`ProvideMissingTransactions`] message and provide the full
 /// list of transactions in the order they were requested by [`ProvideMissingTransactions`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -39,4 +49,13 @@ pub struct ProvideMissingTransactionsSuccess<'decoder> {
     pub request_id: u32,
     /// List of full transactions as requested by [`ProvideMissingTransactions`].
     pub transaction_list: Seq064K<'decoder, B016M<'decoder>>,
+}
+impl fmt::Display for ProvideMissingTransactionsSuccess<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ProvideMissingTransactionsSuccess(request_id: {}, transaction_list: {})",
+            self.request_id, self.transaction_list
+        )
+    }
 }

--- a/protocols/v2/subprotocols/job-declaration/src/push_solution.rs
+++ b/protocols/v2/subprotocols/job-declaration/src/push_solution.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, B032, U256};
-use core::convert::TryInto;
+use core::{convert::TryInto, fmt};
 
 /// Message used by JDC to push a solution to JDS as soon as it finds a new valid block.
 ///
@@ -34,4 +34,19 @@ pub struct PushSolution<'decoder> {
     /// [`BIP9`]: https://en.bitcoin.it/wiki/BIP_0009
     /// [`BIP320`]: https://en.bitcoin.it/wiki/BIP_0320
     pub version: u32,
+}
+
+impl fmt::Display for PushSolution<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "PushSolution(extranonce: {}, prev_hash: {}, ntime: {}, nonce: {}, nbits: {}, version: {})",
+            self.extranonce,
+            self.prev_hash,
+            self.ntime,
+            self.nonce,
+            self.nbits,
+            self.version
+        )
+    }
 }

--- a/protocols/v2/subprotocols/mining/src/close_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/close_channel.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, Str0255};
 use core::convert::TryInto;
 
@@ -14,4 +14,15 @@ pub struct CloseChannel<'decoder> {
     pub channel_id: u32,
     /// Reason for closing the channel.
     pub reason_code: Str0255<'decoder>,
+}
+
+impl fmt::Display for CloseChannel<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CloseChannel(channel_id: {}, reason_code: {})",
+            self.channel_id,
+            self.reason_code.as_utf8_or_hex()
+        )
+    }
 }

--- a/protocols/v2/subprotocols/mining/src/new_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/new_mining_job.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use binary_sv2::{binary_codec_sv2, Deserialize, Seq0255, Serialize, Sv2Option, B064K, U256};
-use core::convert::TryInto;
+use core::{convert::TryInto, fmt};
 
 /// Message used by an upstream to provide an updated mining job to downstream.
 ///
@@ -44,6 +44,16 @@ pub struct NewMiningJob<'decoder> {
     ///
     /// Note that this field is fixed and cannot be modified by the downstream node.
     pub merkle_root: U256<'decoder>,
+}
+
+impl fmt::Display for NewMiningJob<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "NewMiningJob(channel_id: {}, job_id: {}, min_ntime: {}, version: {}, merkle_root: {})",
+            self.channel_id, self.job_id, self.min_ntime, self.version, self.merkle_root
+        )
+    }
 }
 
 impl NewMiningJob<'_> {
@@ -109,6 +119,23 @@ pub struct NewExtendedMiningJob<'decoder> {
     pub coinbase_tx_prefix: B064K<'decoder>,
     /// Suffix part of the coinbase transaction.
     pub coinbase_tx_suffix: B064K<'decoder>,
+}
+
+impl fmt::Display for NewExtendedMiningJob<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "NewExtendedMiningJob(channel_id: {}, job_id: {}, min_ntime: {}, version: {}, version_rolling_allowed: {}, merkle_path: {}, coinbase_tx_prefix: {}, coinbase_tx_suffix: {})",
+            self.channel_id,
+            self.job_id,
+            self.min_ntime,
+            self.version,
+            self.version_rolling_allowed,
+            self.merkle_path,
+            self.coinbase_tx_prefix,
+            self.coinbase_tx_suffix
+        )
+    }
 }
 
 impl NewExtendedMiningJob<'_> {

--- a/protocols/v2/subprotocols/mining/src/open_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/open_channel.rs
@@ -1,6 +1,6 @@
 use alloc::{string::ToString, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, Str0255, U32AsRef, B032, U256};
-use core::convert::TryInto;
+use core::{convert::TryInto, fmt};
 /// Message used by a downstream to request opening a Standard Channel.
 ///
 /// Upon receiving `SetupConnectionSuccess` message, the downstream should open channel(s) on the
@@ -34,6 +34,19 @@ pub struct OpenStandardMiningChannel<'decoder> {
     ///
     /// Upstream must accept the target or respond by sending [`OpenMiningChannelError`] message.
     pub max_target: U256<'decoder>,
+}
+
+impl fmt::Display for OpenStandardMiningChannel<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OpenStandardMiningChannel(request_id: {}, user_identity: {}, nominal_hash_rate: {}, max_target: {})",
+            self.request_id,
+            self.user_identity.as_utf8_or_hex(),
+            self.nominal_hash_rate,
+            self.max_target
+        )
+    }
 }
 
 impl OpenStandardMiningChannel<'_> {
@@ -71,6 +84,20 @@ pub struct OpenStandardMiningChannelSuccess<'decoder> {
     pub extranonce_prefix: B032<'decoder>,
     /// Group channel into which the new channel belongs. See SetGroupChannel for details.
     pub group_channel_id: u32,
+}
+
+impl fmt::Display for OpenStandardMiningChannelSuccess<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OpenStandardMiningChannelSuccess(request_id: {}, channel_id: {}, target: {}, extranonce_prefix: {}, group_channel_id: {})",
+            self.request_id,
+            self.channel_id,
+            self.target,
+            self.extranonce_prefix,
+            self.group_channel_id
+        )
+    }
 }
 
 impl OpenStandardMiningChannelSuccess<'_> {
@@ -128,6 +155,20 @@ pub struct OpenExtendedMiningChannel<'decoder> {
     pub min_extranonce_size: u16,
 }
 
+impl fmt::Display for OpenExtendedMiningChannel<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OpenExtendedMiningChannel(request_id: {}, user_identity: {}, nominal_hash_rate: {}, max_target: {}, min_extranonce_size: {})",
+            self.request_id,
+            self.user_identity.as_utf8_or_hex(),
+            self.nominal_hash_rate,
+            self.max_target,
+            self.min_extranonce_size
+        )
+    }
+}
+
 impl OpenExtendedMiningChannel<'_> {
     pub fn get_request_id_as_u32(&self) -> u32 {
         self.request_id
@@ -154,6 +195,20 @@ pub struct OpenExtendedMiningChannelSuccess<'decoder> {
     pub extranonce_prefix: B032<'decoder>,
 }
 
+impl fmt::Display for OpenExtendedMiningChannelSuccess<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OpenExtendedMiningChannelSuccess(request_id: {}, channel_id: {}, target: {}, extranonce_size: {}, extranonce_prefix: {})",
+            self.request_id,
+            self.channel_id,
+            self.target,
+            self.extranonce_size,
+            self.extranonce_prefix
+        )
+    }
+}
+
 /// Message used by upstream to reject [`OpenExtendedMiningChannel`] or
 /// [`OpenStandardMiningchannel`] request from downstream.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -170,6 +225,17 @@ pub struct OpenMiningChannelError<'decoder> {
     /// - ‘unknown-user’
     /// - ‘max-target-out-of-range’
     pub error_code: Str0255<'decoder>,
+}
+
+impl fmt::Display for OpenMiningChannelError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OpenMiningChannelError(request_id: {}, error_code: {})",
+            self.request_id,
+            self.error_code.as_utf8_or_hex()
+        )
+    }
 }
 
 impl OpenMiningChannelError<'_> {

--- a/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
+++ b/protocols/v2/subprotocols/mining/src/set_custom_mining_job.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Seq0255, Serialize, Str0255, B0255, B064K, U256};
 use core::convert::TryInto;
 
@@ -52,6 +52,26 @@ pub struct SetCustomMiningJob<'decoder> {
     pub merkle_path: Seq0255<'decoder, U256<'decoder>>,
 }
 
+impl fmt::Display for SetCustomMiningJob<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SetCustomMiningJob(channel_id={}, request_id={}, token={}, version={}, prev_hash={}, min_ntime={}, nbits={}, coinbase_tx_version={}, coinbase_prefix={}, coinbase_tx_input_n_sequence={}, coinbase_tx_outputs={}, coinbase_tx_locktime={}, merkle_path={})",
+            self.channel_id,
+            self.request_id,
+            self.token,
+            self.version,
+            self.prev_hash,
+            self.min_ntime,
+            self.nbits,
+            self.coinbase_tx_version,
+            self.coinbase_prefix,
+            self.coinbase_tx_input_n_sequence,
+            self.coinbase_tx_outputs,
+            self.coinbase_tx_locktime,
+            self.merkle_path
+        )
+    }
+}
+
 /// Message used by upstream to accept [`SetCustomMiningJob`] request.
 ///
 /// Upon receiving this message, downstream can start submitting shares for this job immediately (by
@@ -64,6 +84,16 @@ pub struct SetCustomMiningJobSuccess {
     pub request_id: u32,
     /// Upstream’s identification of the mining job.
     pub job_id: u32,
+}
+
+impl fmt::Display for SetCustomMiningJobSuccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetCustomMiningJobSuccess(channel_id={}, request_id={}, job_id={})",
+            self.channel_id, self.request_id, self.job_id
+        )
+    }
 }
 
 /// Message used by upstream to reject [`SetCustomMiningJob`] request.
@@ -80,4 +110,16 @@ pub struct SetCustomMiningJobError<'decoder> {
     /// - invalid-mining-job-token
     /// - invalid-job-param-value-{field_name}
     pub error_code: Str0255<'decoder>,
+}
+
+impl fmt::Display for SetCustomMiningJobError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetCustomMiningJobError(channel_id={}, request_id={}, error_code={})",
+            self.channel_id,
+            self.request_id,
+            self.error_code.as_utf8_or_hex()
+        )
+    }
 }

--- a/protocols/v2/subprotocols/mining/src/set_extranonce_prefix.rs
+++ b/protocols/v2/subprotocols/mining/src/set_extranonce_prefix.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, B032};
 
@@ -17,4 +17,14 @@ pub struct SetExtranoncePrefix<'decoder> {
     pub channel_id: u32,
     /// New extranonce prefix.
     pub extranonce_prefix: B032<'decoder>,
+}
+
+impl fmt::Display for SetExtranoncePrefix<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetExtranoncePrefix(channel_id={}, extranonce_prefix={})",
+            self.channel_id, self.extranonce_prefix
+        )
+    }
 }

--- a/protocols/v2/subprotocols/mining/src/set_group_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/set_group_channel.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Seq064K, Serialize};
 use core::convert::TryInto;
 
@@ -23,4 +23,14 @@ pub struct SetGroupChannel<'decoder> {
     pub group_channel_id: u32,
     /// A sequence of opened standard channel IDs, for which the group channel is being redefined.
     pub channel_ids: Seq064K<'decoder, u32>,
+}
+
+impl fmt::Display for SetGroupChannel<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetGroupChannel(group_channel_id={}, channel_ids={})",
+            self.group_channel_id, self.channel_ids
+        )
+    }
 }

--- a/protocols/v2/subprotocols/mining/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/mining/src/set_new_prev_hash.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, U256};
-use core::convert::TryInto;
+use core::{convert::TryInto, fmt};
 
 /// Message used by upstream to share or distribute the latest block hash.
 ///
@@ -26,4 +26,14 @@ pub struct SetNewPrevHash<'decoder> {
     pub min_ntime: u32,
     /// Block header field.
     pub nbits: u32,
+}
+
+impl fmt::Display for SetNewPrevHash<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetNewPrevHash(channel_id={}, job_id={}, prev_hash={}, min_ntime={}, nbits={})",
+            self.channel_id, self.job_id, self.prev_hash, self.min_ntime, self.nbits
+        )
+    }
 }

--- a/protocols/v2/subprotocols/mining/src/set_target.rs
+++ b/protocols/v2/subprotocols/mining/src/set_target.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, U256};
 use core::convert::TryInto;
 
@@ -20,4 +20,14 @@ pub struct SetTarget<'decoder> {
     pub channel_id: u32,
     /// Maximum value of produced hash that will be accepted by a upstream to accept shares.
     pub maximum_target: U256<'decoder>,
+}
+
+impl fmt::Display for SetTarget<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetTarget(channel_id={}, maximum_target={})",
+            self.channel_id, self.maximum_target
+        )
+    }
 }

--- a/protocols/v2/subprotocols/mining/src/submit_shares.rs
+++ b/protocols/v2/subprotocols/mining/src/submit_shares.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, Str0255, B032};
 use core::convert::TryInto;
 
@@ -24,6 +24,16 @@ pub struct SubmitSharesStandard {
     pub ntime: u32,
     /// Full `nVersion` field.
     pub version: u32,
+}
+
+impl fmt::Display for SubmitSharesStandard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SubmitSharesStandard(channel_id={}, sequence_number={}, job_id={}, nonce={}, ntime={}, version={})",
+            self.channel_id, self.sequence_number, self.job_id, self.nonce, self.ntime, self.version
+        )
+    }
 }
 
 /// Message used by downstream to send result of its hashing work to an upstream.
@@ -62,6 +72,16 @@ pub struct SubmitSharesExtended<'decoder> {
     pub extranonce: B032<'decoder>,
 }
 
+impl fmt::Display for SubmitSharesExtended<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SubmitSharesExtended(channel_id={}, sequence_number={}, job_id={}, nonce={}, ntime={}, version={}, extranonce={})",
+            self.channel_id, self.sequence_number, self.job_id, self.nonce, self.ntime, self.version, self.extranonce
+        )
+    }
+}
+
 /// Message used by upstream to accept [`SubmitSharesStandard`] or [`SubmitSharesExtended`].
 ///
 /// Because it is a common case that shares submission is successful, this response can be provided
@@ -80,6 +100,16 @@ pub struct SubmitSharesSuccess {
     pub new_submits_accepted_count: u32,
     /// Sum of shares acknowledged within this batch.
     pub new_shares_sum: u64,
+}
+
+impl fmt::Display for SubmitSharesSuccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SubmitSharesSuccess(channel_id={}, last_sequence_number={}, new_submits_accepted_count={}, new_shares_sum={})",
+            self.channel_id, self.last_sequence_number, self.new_submits_accepted_count, self.new_shares_sum
+        )
+    }
 }
 
 /// Message used by upstream to reject [`SubmitSharesStandard`] or [`SubmitSharesExtended`].
@@ -102,6 +132,16 @@ pub struct SubmitSharesError<'decoder> {
     /// - difficulty-too-low
     /// - invalid-job-id
     pub error_code: Str0255<'decoder>,
+}
+
+impl fmt::Display for SubmitSharesError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SubmitSharesError(channel_id={}, sequence_number={}, error_code={})",
+            self.channel_id, self.sequence_number, self.error_code
+        )
+    }
 }
 
 impl SubmitSharesError<'_> {

--- a/protocols/v2/subprotocols/mining/src/update_channel.rs
+++ b/protocols/v2/subprotocols/mining/src/update_channel.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize, Str0255, U256};
 use core::convert::TryInto;
 
@@ -34,6 +34,16 @@ pub struct UpdateChannel<'decoder> {
     pub maximum_target: U256<'decoder>,
 }
 
+impl fmt::Display for UpdateChannel<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "⛏️ UpdateChannel(channel_id={}, nominal_hash_rate={}, maximum_target={})",
+            self.channel_id, self.nominal_hash_rate, self.maximum_target
+        )
+    }
+}
+
 /// Message used by upstream to notify downstream about an error in the [`UpdateChannel`] message.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UpdateChannelError<'decoder> {
@@ -45,4 +55,14 @@ pub struct UpdateChannelError<'decoder> {
     /// - max-target-out-of-range
     /// - invalid-channel-id
     pub error_code: Str0255<'decoder>,
+}
+
+impl fmt::Display for UpdateChannelError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "UpdateChannelError(channel_id={}, error_code={})",
+            self.channel_id, self.error_code
+        )
+    }
 }

--- a/protocols/v2/subprotocols/template-distribution/src/coinbase_output_constraints.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/coinbase_output_constraints.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{binary_codec_sv2, Deserialize, Serialize};
 use core::convert::TryInto;
 
@@ -29,4 +29,15 @@ pub struct CoinbaseOutputConstraints {
     pub coinbase_output_max_additional_size: u32,
     /// Additional sigops needed in coinbase transaction outputs.
     pub coinbase_output_max_additional_sigops: u16,
+}
+
+impl fmt::Display for CoinbaseOutputConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CoinbaseOutputConstraints(coinbase_output_max_additional_size: {}, coinbase_output_max_additional_sigops: {})",
+            self.coinbase_output_max_additional_size,
+            self.coinbase_output_max_additional_sigops
+        )
+    }
 }

--- a/protocols/v2/subprotocols/template-distribution/src/new_template.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/new_template.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{
     binary_codec_sv2::{self, free_vec, free_vec_2, CVec, CVec2},
     Deserialize, Error, Seq0255, Serialize, B0255, B064K, U256,
@@ -50,6 +50,29 @@ pub struct NewTemplate<'decoder> {
     pub coinbase_tx_locktime: u32,
     /// Merkle path hashes ordered from deepest.
     pub merkle_path: Seq0255<'decoder, U256<'decoder>>,
+}
+
+impl fmt::Display for NewTemplate<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "NewTemplate(template_id: {}, future_template: {}, version: {}, coinbase_tx_version: {}, \
+             coinbase_prefix: {}, coinbase_tx_input_sequence: {}, coinbase_tx_value_remaining: {}, \
+             coinbase_tx_outputs_count: {}, coinbase_tx_outputs: {}, coinbase_tx_locktime: {}, \
+             merkle_path: {})",
+            self.template_id,
+            self.future_template,
+            self.version,
+            self.coinbase_tx_version,
+            self.coinbase_prefix,
+            self.coinbase_tx_input_sequence,
+            self.coinbase_tx_value_remaining,
+            self.coinbase_tx_outputs_count,
+            self.coinbase_tx_outputs,
+            self.coinbase_tx_locktime,
+            self.merkle_path
+        )
+    }
 }
 
 /// C representation of [`NewTemplate`].

--- a/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/request_transaction_data.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{
     binary_codec_sv2::{self, free_vec, free_vec_2, CVec, CVec2},
     Deserialize, Error, Seq064K, Serialize, Str0255, B016M, B064K,
@@ -17,6 +17,16 @@ pub struct RequestTransactionData {
     ///
     /// This must be identical to previously exchanged [`crate::NewTemplate::template_id`].
     pub template_id: u64,
+}
+
+impl fmt::Display for RequestTransactionData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RequestTransactionData(template_id: {})",
+            self.template_id
+        )
+    }
 }
 
 /// Message used by an upstream(Template Provider) to respond successfully to a
@@ -60,6 +70,16 @@ pub struct RequestTransactionDataSuccess<'decoder> {
     pub excess_data: B064K<'decoder>,
     /// The transaction data, serialized as a series of B0_16M byte arrays.
     pub transaction_list: Seq064K<'decoder, B016M<'decoder>>,
+}
+
+impl fmt::Display for RequestTransactionDataSuccess<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RequestTransactionDataSuccess(template_id: {}, excess_data: {}, transaction_list: {})",
+            self.template_id, self.excess_data, self.transaction_list
+        )
+    }
 }
 
 /// C representation of [`RequestTransactionDataSuccess`].
@@ -123,6 +143,17 @@ pub struct RequestTransactionDataError<'decoder> {
     /// Possible error codes:
     /// - template-id-not-found
     pub error_code: Str0255<'decoder>,
+}
+
+impl fmt::Display for RequestTransactionDataError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RequestTransactionDataError(template_id: {}, error_code: {})",
+            self.template_id,
+            self.error_code.as_utf8_or_hex()
+        )
+    }
 }
 
 /// C representation of [`RequestTransactionDataError`].

--- a/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/set_new_prev_hash.rs
@@ -3,7 +3,7 @@ use binary_sv2::{
     binary_codec_sv2::{self, free_vec, CVec},
     Deserialize, Error, Serialize, U256,
 };
-use core::convert::TryInto;
+use core::{convert::TryInto, fmt};
 
 /// Message used by an upstream(Template Provider) to indicate the latest block header hash
 /// to mine on.
@@ -31,6 +31,20 @@ pub struct SetNewPrevHash<'decoder> {
     /// may be lower than the target implied by nBits in several cases, including weak-block based
     /// block propagation.
     pub target: U256<'decoder>,
+}
+
+impl fmt::Display for SetNewPrevHash<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetNewPrevHash {{ template_id: {}, prev_hash: {}, header_timestamp: {}, n_bits: {}, target: {} }}",
+            self.template_id,
+            self.prev_hash,
+            self.header_timestamp,
+            self.n_bits,
+            self.target
+        )
+    }
 }
 
 /// C representation of [`SetNewPrevHash`].

--- a/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
+++ b/protocols/v2/subprotocols/template-distribution/src/submit_solution.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
 use binary_sv2::{
     binary_codec_sv2::{self, free_vec, CVec},
     Deserialize, Error, Serialize, B064K,
@@ -37,6 +37,20 @@ pub struct SubmitSolution<'decoder> {
     /// Full serialized coinbase transaction, meeting all the requirements of the `NewMiningJob` or
     /// `NewExtendedMiningJob` message.
     pub coinbase_tx: B064K<'decoder>,
+}
+
+impl fmt::Display for SubmitSolution<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SubmitSolution {{ template_id: {}, version: {}, header_timestamp: {}, header_nonce: {}, coinbase_tx: {} }}",
+            self.template_id,
+            self.version,
+            self.header_timestamp,
+            self.header_nonce,
+            self.coinbase_tx
+        )
+    }
 }
 
 /// C representation of [`SubmitSolution`].

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -654,7 +654,7 @@ impl ParseMiningMessagesFromDownstream<UpstreamMiningNode> for DownstreamMiningN
             std::str::from_utf8(m.user_identity.as_ref()).unwrap_or("Unknown identity"),
             m.get_request_id_as_u32()
         );
-        debug!("OpenExtendedMiningChannel: {:?}", m);
+        debug!("OpenExtendedMiningChannel: {}", m);
 
         // Check if the downstream is in solo mining mode.
         if !self.status.is_solo_miner() {
@@ -801,7 +801,7 @@ impl ParseMiningMessagesFromDownstream<UpstreamMiningNode> for DownstreamMiningN
         m: SubmitSharesExtended,
     ) -> Result<SendTo<UpstreamMiningNode>, Error> {
         info!("Received SubmitSharesExtended message");
-        debug!("SubmitSharesExtended {:?}", m);
+        debug!("SubmitSharesExtended {}", m);
 
         // Process the submitted share using the channel factory.
         match self

--- a/roles/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-client/src/lib/job_declarator/message_handler.rs
@@ -51,7 +51,7 @@ impl ParseJobDeclarationMessagesFromUpstream for JobDeclarator {
             "Received `DeclareMiningJobSuccess` with id {}",
             message.request_id
         );
-        debug!("`DeclareMiningJobSuccess`: {:?}", message);
+        debug!("`DeclareMiningJobSuccess`: {}", message);
         let message = JobDeclaration::DeclareMiningJobSuccess(message.into_static());
         Ok(SendTo::None(Some(message)))
     }
@@ -69,7 +69,7 @@ impl ParseJobDeclarationMessagesFromUpstream for JobDeclarator {
             "Received `DeclareMiningJobError`, error code: {}",
             std::str::from_utf8(message.error_code.as_ref()).unwrap_or("unknown error code")
         );
-        debug!("`DeclareMiningJobError`: {:?}", message);
+        debug!("`DeclareMiningJobError`: {}", message);
         Ok(SendTo::None(None))
     }
 
@@ -96,7 +96,7 @@ impl ParseJobDeclarationMessagesFromUpstream for JobDeclarator {
             "Received `ProvideMissingTransactions` with id: {}",
             message.request_id
         );
-        debug!("`ProvideMissingTransactions`: {:?}", message);
+        debug!("`ProvideMissingTransactions`: {}", message);
 
         // Find the corresponding declared job in the window using the request ID.
         // Extract the full transaction list from the found job's details.

--- a/roles/jd-client/src/lib/job_declarator/mod.rs
+++ b/roles/jd-client/src/lib/job_declarator/mod.rs
@@ -471,7 +471,7 @@ impl JobDeclarator {
                             }
                         }
                         Ok(SendTo::None(Some(JobDeclaration::DeclareMiningJobError(m)))) => {
-                            error!("Job is not verified: {:?}", m);
+                            error!("Job is not verified: {}", m);
                         }
                         Ok(SendTo::None(None)) => (),
                         Ok(SendTo::Respond(m)) => {

--- a/roles/jd-client/src/lib/template_receiver/message_handler.rs
+++ b/roles/jd-client/src/lib/template_receiver/message_handler.rs
@@ -24,7 +24,7 @@ impl ParseTemplateDistributionMessagesFromServer for TemplateRx {
             "Received NewTemplate with id: {}, is future: {}",
             m.template_id, m.future_template
         );
-        debug!("NewTemplate: {:?}", m);
+        debug!("NewTemplate: {}", m);
         let new_template = m.into_static();
         let new_template = TemplateDistribution::NewTemplate(new_template);
         Ok(SendTo::None(Some(new_template)))
@@ -37,7 +37,7 @@ impl ParseTemplateDistributionMessagesFromServer for TemplateRx {
     // other components like the `JobDeclarator` and downstream.
     fn handle_set_new_prev_hash(&mut self, m: SetNewPrevHash) -> Result<SendTo, Error> {
         info!("Received SetNewPrevHash for template: {}", m.template_id);
-        debug!("SetNewPrevHash: {:?}", m);
+        debug!("SetNewPrevHash: {}", m);
         let new_prev_hash = SetNewPrevHash {
             template_id: m.template_id,
             prev_hash: m.prev_hash.into_static(),
@@ -63,7 +63,7 @@ impl ParseTemplateDistributionMessagesFromServer for TemplateRx {
             "Received RequestTransactionDataSuccess for template: {}",
             m.template_id
         );
-        debug!("RequestTransactionDataSuccess: {:?}", m);
+        debug!("RequestTransactionDataSuccess: {}", m);
         let m = RequestTransactionDataSuccess {
             transaction_list: m.transaction_list.into_static(),
             excess_data: m.excess_data.into_static(),

--- a/roles/jd-client/src/lib/upstream_sv2/upstream.rs
+++ b/roles/jd-client/src/lib/upstream_sv2/upstream.rs
@@ -673,7 +673,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
             "Received OpenExtendedMiningChannelSuccess with request id: {} and channel id: {}",
             m.request_id, m.channel_id
         );
-        debug!("OpenStandardMiningChannelSuccess: {:?}", m);
+        debug!("OpenStandardMiningChannelSuccess: {}", m);
         // --- Create the PoolChannelFactory  ---
         let ids = Arc::new(Mutex::new(roles_logic_sv2::utils::GroupId::new()));
         let jdc_signature_len = self.jdc_signature.len();
@@ -798,7 +798,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
             "Received SetExtranoncePrefix for channel id: {}",
             m.channel_id
         );
-        debug!("SetExtranoncePrefix: {:?}", m);
+        debug!("SetExtranoncePrefix: {}", m);
         Ok(SendTo::RelaySameMessageToRemote(
             self.downstream.as_ref().unwrap().clone(),
         ))
@@ -813,7 +813,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
         m: roles_logic_sv2::mining_sv2::SubmitSharesSuccess,
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, RolesLogicError> {
         info!("Received SubmitSharesSuccess");
-        debug!("SubmitSharesSuccess: {:?}", m);
+        debug!("SubmitSharesSuccess: {}", m);
         Ok(SendTo::RelaySameMessageToRemote(
             self.downstream.as_ref().unwrap().clone(),
         ))
@@ -904,7 +904,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
             "Received SetCustomMiningJobSuccess for channel id: {} for job id: {}",
             m.channel_id, m.job_id
         );
-        debug!("SetCustomMiningJobSuccess: {:?}", m);
+        debug!("SetCustomMiningJobSuccess: {}", m);
         if let Some(template_id) = self.template_to_job_id.take_template_id(m.request_id) {
             self.template_to_job_id
                 .register_job_id(template_id, m.job_id);
@@ -937,7 +937,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
         m: roles_logic_sv2::mining_sv2::SetTarget,
     ) -> Result<SendTo<Downstream>, RolesLogicError> {
         info!("Received SetTarget for channel id: {}", m.channel_id);
-        debug!("SetTarget: {:?}", m);
+        debug!("SetTarget: {}", m);
         if let Some(factory) = self.channel_factory.as_mut() {
             factory.update_target_for_channel(m.channel_id, m.maximum_target.clone().into());
             factory.set_target(&mut m.maximum_target.clone().into());

--- a/roles/jd-server/src/lib/job_declarator/message_handler.rs
+++ b/roles/jd-server/src/lib/job_declarator/message_handler.rs
@@ -63,7 +63,7 @@ impl ParseJobDeclarationMessagesFromDownstream for JobDeclaratorDownstream {
         };
         let message_enum = JobDeclaration::AllocateMiningJobTokenSuccess(message_success);
         info!(
-            "Sending AllocateMiningJobTokenSuccess to proxy {:?}",
+            "Sending AllocateMiningJobTokenSuccess to proxy {}",
             message_enum
         );
         Ok(SendTo::Respond(message_enum))
@@ -78,7 +78,7 @@ impl ParseJobDeclarationMessagesFromDownstream for JobDeclaratorDownstream {
             "Received `DeclareMiningJob` with id: {}",
             message.request_id
         );
-        debug!("`DeclareMiningJob`: {:?}", message);
+        debug!("`DeclareMiningJob`: {}", message);
         if let Some(old_mining_job) = self.declared_mining_job.0.take() {
             clear_declared_mining_job(old_mining_job, &message, self.mempool.clone())?;
         }
@@ -156,7 +156,7 @@ impl ParseJobDeclarationMessagesFromDownstream for JobDeclaratorDownstream {
             "Received `ProvideMissingTransactionsSuccess` with id: {}",
             message.request_id
         );
-        debug!("`ProvideMissingTransactionsSuccess`: {:?}", message);
+        debug!("`ProvideMissingTransactionsSuccess`: {}", message);
         let (declared_mining_job, ref mut transactions_with_state, missing_indexes) =
             &mut self.declared_mining_job;
         let mut unknown_transactions: Vec<Transaction> = vec![];
@@ -223,7 +223,7 @@ impl ParseJobDeclarationMessagesFromDownstream for JobDeclaratorDownstream {
 
     fn handle_push_solution(&mut self, message: PushSolution<'_>) -> Result<SendTo, Error> {
         info!("Received PushSolution from JDC");
-        debug!("`PushSolution`: {:?}", message);
+        debug!("`PushSolution`: {}", message);
         let m = JobDeclaration::PushSolution(message.clone().into_static());
         Ok(SendTo::None(Some(m)))
     }

--- a/roles/jd-server/src/lib/job_declarator/mod.rs
+++ b/roles/jd-server/src/lib/job_declarator/mod.rs
@@ -320,11 +320,11 @@ impl JobDeclaratorDownstream {
                                 Self::send(self_mutex.clone(), m).await.unwrap();
                             }
                             Ok(SendTo::RelayNewMessage(message)) => {
-                                error!("JD Server: unexpected relay new message {:?}", message);
+                                error!("JD Server: unexpected relay new message {}", message);
                             }
                             Ok(SendTo::RelayNewMessageToRemote(remote, message)) => {
                                 error!(
-                                    "JD Server: unexpected relay new message to remote. Remote: {:?}, Message: {:?}",
+                                    "JD Server: unexpected relay new message to remote. Remote: {:?}, Message: {}",
                                     remote,
                                     message
                                 );

--- a/roles/mining-proxy/src/lib/downstream_mining.rs
+++ b/roles/mining-proxy/src/lib/downstream_mining.rs
@@ -315,7 +315,7 @@ impl ParseMiningMessagesFromDownstream<UpstreamMiningNode> for DownstreamMiningN
             std::str::from_utf8(req.user_identity.as_ref()).unwrap_or("Unknown identity"),
             req.get_request_id_as_u32()
         );
-        debug!("OpenStandardMiningChannel: {:?}", req);
+        debug!("OpenStandardMiningChannel: {}", req);
         let downstream_mining_data = self.get_downstream_mining_data();
         let routing_logic = super::get_routing_logic();
 
@@ -392,7 +392,7 @@ impl ParseMiningMessagesFromDownstream<UpstreamMiningNode> for DownstreamMiningN
         m: SubmitSharesStandard,
     ) -> Result<SendTo<UpstreamMiningNode>, Error> {
         info!("Received SubmitSharesStandard");
-        debug!("SubmitSharesStandard {:?}", m);
+        debug!("SubmitSharesStandard {}", m);
         // TODO maybe we want to check if shares meet target before
         // sending them upstream If that is the case it should be
         // done by GroupChannel not here

--- a/roles/mining-proxy/src/lib/upstream_mining.rs
+++ b/roles/mining-proxy/src/lib/upstream_mining.rs
@@ -949,7 +949,7 @@ impl ParseMiningMessagesFromUpstream<DownstreamMiningNode> for UpstreamMiningNod
             "Received OpenExtendedMiningChannelSuccess with request id: {} and channel id: {}",
             m.request_id, m.channel_id
         );
-        debug!("OpenStandardMiningChannelSuccess: {:?}", m);
+        debug!("OpenStandardMiningChannelSuccess: {}", m);
         let extranonce_prefix: Extranonce = m.extranonce_prefix.clone().into();
         let range_0 = 0..m.extranonce_prefix.clone().to_vec().len();
         let range_1 = range_0.end..(range_0.end + EXTRANONCE_RANGE_1_LENGTH);
@@ -1005,7 +1005,7 @@ impl ParseMiningMessagesFromUpstream<DownstreamMiningNode> for UpstreamMiningNod
         m: SubmitSharesSuccess,
     ) -> Result<SendTo<DownstreamMiningNode>, Error> {
         info!("Received SubmitSharesSuccess");
-        debug!("SubmitSharesSuccess: {:?}", m);
+        debug!("SubmitSharesSuccess: {}", m);
         match &self
             .downstream_selector
             .downstream_from_channel_id(m.channel_id)
@@ -1065,7 +1065,7 @@ impl ParseMiningMessagesFromUpstream<DownstreamMiningNode> for UpstreamMiningNod
             m.job_id,
             m.is_future()
         );
-        debug!("NewExtendedMiningJob: {:?}", m);
+        debug!("NewExtendedMiningJob: {}", m);
         let mut res = vec![];
         match &mut self.channel_kind {
             ChannelKind::Group(group) => {
@@ -1155,7 +1155,7 @@ impl ParseMiningMessagesFromUpstream<DownstreamMiningNode> for UpstreamMiningNod
             "Received SetNewPrevHash channel id: {}, job id: {}",
             m.channel_id, m.job_id
         );
-        debug!("SetNewPrevHash: {:?}", m);
+        debug!("SetNewPrevHash: {}", m);
         match &mut self.channel_kind {
             ChannelKind::Group(group) => {
                 group.update_new_prev_hash(&m);
@@ -1195,7 +1195,7 @@ impl ParseMiningMessagesFromUpstream<DownstreamMiningNode> for UpstreamMiningNod
             "Received SetCustomMiningJobSuccess for channel id: {} for job id: {}",
             m.channel_id, m.job_id
         );
-        debug!("SetCustomMiningJobSuccess: {:?}", m);
+        debug!("SetCustomMiningJobSuccess: {}", m);
         Ok(SendTo::None(None))
     }
 

--- a/roles/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/pool/src/lib/mining_pool/message_handler.rs
@@ -71,7 +71,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
             .map(|s| s.to_string())
             .map_err(|e| Error::InvalidUserIdentity(e.to_string()))?;
 
-        info!("Received OpenStandardMiningChannel: {:?}", incoming);
+        info!("Received OpenStandardMiningChannel: {}", incoming);
 
         let nominal_hash_rate = incoming.nominal_hash_rate;
         let requested_max_target = incoming.max_target.into_static();
@@ -240,7 +240,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
             .map(|s| s.to_string())
             .map_err(|e| Error::InvalidUserIdentity(e.to_string()))?;
 
-        info!("Received OpenExtendedMiningChannel: {:?}", m);
+        info!("Received OpenExtendedMiningChannel: {}", m);
 
         let nominal_hash_rate = m.nominal_hash_rate;
         let requested_max_target = m.max_target.into_static();
@@ -418,7 +418,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
     //   target difficulty.
     // - `Err(Error)` - If calculating the target fails or the channel factory interaction fails.
     fn handle_update_channel(&mut self, m: UpdateChannel) -> Result<SendTo<()>, Error> {
-        info!("Received UpdateChannel message: {:?}", m);
+        info!("Received UpdateChannel message: {}", m);
 
         let channel_id = m.channel_id;
         let new_nominal_hash_rate = m.nominal_hash_rate;
@@ -560,7 +560,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
         &mut self,
         m: SubmitSharesStandard,
     ) -> Result<SendTo<()>, Error> {
-        info!("Received: {:?}", m);
+        info!("Received: {}", m);
 
         let channel_id = m.channel_id;
         if !self.standard_channels.contains_key(&channel_id) {
@@ -613,7 +613,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
                     new_submits_accepted_count,
                     new_shares_sum,
                 };
-                info!("SubmitSharesStandard: {:?} ✅", success);
+                info!("SubmitSharesStandard: {} ✅", success);
                 Ok(SendTo::Respond(Mining::SubmitSharesSuccess(success)))
             }
             Ok(ShareValidationResult::BlockFound(template_id, coinbase)) => {
@@ -722,7 +722,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
         &mut self,
         m: SubmitSharesExtended,
     ) -> Result<SendTo<()>, Error> {
-        info!("Received: {:?}", m);
+        info!("Received: {}", m);
 
         let channel_id = m.channel_id;
         if !self.extended_channels.contains_key(&channel_id) {
@@ -773,7 +773,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
                     new_submits_accepted_count,
                     new_shares_sum,
                 };
-                info!("SubmitSharesExtended: {:?} ✅", success);
+                info!("SubmitSharesExtended: {} ✅", success);
                 Ok(SendTo::Respond(Mining::SubmitSharesSuccess(success)))
             }
             Ok(ShareValidationResult::BlockFound(template_id, coinbase)) => {
@@ -879,7 +879,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
     //   custom job setup.
     // - `Err(Error)` - If the channel factory interaction fails.
     fn handle_set_custom_mining_job(&mut self, m: SetCustomMiningJob) -> Result<SendTo<()>, Error> {
-        info!("Received SetCustomMiningJob: {:?}", m);
+        info!("Received SetCustomMiningJob: {}", m);
 
         // this is a naive implementation, but ideally we should check the SetCustomMiningJob
         // message parameters, especially:

--- a/roles/pool/src/lib/mining_pool/mod.rs
+++ b/roles/pool/src/lib/mining_pool/mod.rs
@@ -380,7 +380,7 @@ impl Downstream {
     ) -> PoolResult<()> {
         match send_to {
             Ok(SendTo::Respond(message)) => {
-                debug!("Sending to downstream: {:?}", message);
+                debug!("Sending to downstream: {}", message);
                 // returning an error will send the error to the main thread,
                 // and the main thread will drop the downstream from the pool
                 if let &Mining::OpenMiningChannelError(_) = &message {
@@ -591,7 +591,7 @@ impl Pool {
             .safe_lock(|s| s.status_tx.clone())
             .map_err(|e| PoolError::PoisonLock(e.to_string()))?;
         while let Ok(new_prev_hash) = rx.recv().await {
-            debug!("New prev hash received: {:?}", new_prev_hash);
+            debug!("New prev hash received: {}", new_prev_hash);
             let res = self_
                 .safe_lock(|s| {
                     s.last_new_prev_hash = Some(new_prev_hash.clone());
@@ -724,7 +724,7 @@ impl Pool {
         let status_tx = self_.safe_lock(|s| s.status_tx.clone())?;
         while let Ok(new_template) = rx.recv().await {
             info!(
-                "New template received, creating a new mining job(s): {:?}",
+                "New template received, creating a new mining job(s): {}",
                 new_template
             );
 
@@ -1151,7 +1151,7 @@ async fn send_set_target_downstream(
 
     let mining_msg = Mining::SetTarget(target_message);
 
-    info!("Sending SetTarget message to downstream: {:?}", mining_msg);
+    info!("Sending SetTarget message to downstream: {}", mining_msg);
 
     let sv2_frame: StdFrame = AnyMessage::Mining(mining_msg).try_into()?;
 

--- a/roles/pool/src/lib/mining_pool/setup_connection.rs
+++ b/roles/pool/src/lib/mining_pool/setup_connection.rs
@@ -91,7 +91,7 @@ impl SetupConnectionHandler {
 
         match message {
             CommonMessages::SetupConnectionSuccess(m) => {
-                debug!("Sent back SetupConnectionSuccess: {:?}", m);
+                debug!("Sent back SetupConnectionSuccess: {}", m);
                 Ok(CommonDownstreamData {
                     header_only: has_requires_std_job(m.flags),
                     work_selection: has_work_selection(m.flags),

--- a/roles/pool/src/lib/template_receiver/message_handler.rs
+++ b/roles/pool/src/lib/template_receiver/message_handler.rs
@@ -20,7 +20,7 @@ impl ParseTemplateDistributionMessagesFromServer for TemplateRx {
             "Received NewTemplate with id: {}, is future: {}",
             m.template_id, m.future_template
         );
-        debug!("NewTemplate: {:?}", m);
+        debug!("NewTemplate: {}", m);
         let new_template = TemplateDistribution::NewTemplate(m.into_static());
         Ok(SendTo::RelayNewMessageToRemote(
             Arc::new(Mutex::new(())),
@@ -31,7 +31,7 @@ impl ParseTemplateDistributionMessagesFromServer for TemplateRx {
     // Handles a `SetNewPrevHash` and return `RelayNewMessageToRemote`
     fn handle_set_new_prev_hash(&mut self, m: SetNewPrevHash) -> Result<SendTo, Error> {
         info!("Received SetNewPrevHash for template: {}", m.template_id);
-        debug!("SetNewPrevHash: {:?}", m);
+        debug!("SetNewPrevHash: {}", m);
         let new_prev_hash = TemplateDistribution::SetNewPrevHash(m.into_static());
         Ok(SendTo::RelayNewMessageToRemote(
             Arc::new(Mutex::new(())),
@@ -52,7 +52,7 @@ impl ParseTemplateDistributionMessagesFromServer for TemplateRx {
             "Received RequestTransactionDataSuccess for template: {}",
             m.template_id
         );
-        debug!("RequestTransactionDataSuccess: {:?}", m);
+        debug!("RequestTransactionDataSuccess: {}", m);
         // Just ignore tx data messages this are meant for the declarators
         Ok(SendTo::None(None))
     }

--- a/roles/pool/src/lib/template_receiver/mod.rs
+++ b/roles/pool/src/lib/template_receiver/mod.rs
@@ -221,7 +221,7 @@ impl TemplateRx {
     async fn on_new_solution(self_: Arc<Mutex<Self>>, rx: Receiver<SubmitSolution<'static>>) {
         let status_tx = self_.safe_lock(|s| s.status_tx.clone()).unwrap();
         while let Ok(solution) = rx.recv().await {
-            info!("Sending Solution to TP: {:?}", &solution);
+            info!("Sending Solution to TP: {}", &solution);
             let sv2_frame_res: Result<StdFrame, _> =
                 AnyMessage::TemplateDistribution(TemplateDistribution::SubmitSolution(solution))
                     .try_into();

--- a/roles/test-utils/mining-device/src/lib/mod.rs
+++ b/roles/test-utils/mining-device/src/lib/mod.rs
@@ -410,7 +410,7 @@ impl ParseMiningMessagesFromUpstream<()> for Device {
         m: SubmitSharesSuccess,
     ) -> Result<SendTo<()>, Error> {
         info!("Received SubmitSharesSuccess");
-        debug!("SubmitSharesSuccess: {:?}", m);
+        debug!("SubmitSharesSuccess: {}", m);
         Ok(SendTo::None(None))
     }
 
@@ -429,7 +429,7 @@ impl ParseMiningMessagesFromUpstream<()> for Device {
             m.job_id,
             m.is_future()
         );
-        debug!("NewMiningJob: {:?}", m);
+        debug!("NewMiningJob: {}", m);
         match (m.is_future(), self.prev_hash.as_ref()) {
             (false, Some(p_h)) => {
                 self.miner
@@ -458,7 +458,7 @@ impl ParseMiningMessagesFromUpstream<()> for Device {
             "Received SetNewPrevHash channel id: {}, job id: {}",
             m.channel_id, m.job_id
         );
-        debug!("SetNewPrevHash: {:?}", m);
+        debug!("SetNewPrevHash: {}", m);
         let jobs: Vec<&NewMiningJob<'static>> = self
             .jobs
             .iter()
@@ -497,7 +497,7 @@ impl ParseMiningMessagesFromUpstream<()> for Device {
 
     fn handle_set_target(&mut self, m: SetTarget) -> Result<SendTo<()>, Error> {
         info!("Received SetTarget for channel id: {}", m.channel_id);
-        debug!("SetTarget: {:?}", m);
+        debug!("SetTarget: {}", m);
         self.miner
             .safe_lock(|miner| miner.new_target(m.maximum_target.to_vec()))
             .unwrap();

--- a/roles/translator/src/lib/upstream_sv2/upstream.rs
+++ b/roles/translator/src/lib/upstream_sv2/upstream.rs
@@ -729,7 +729,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
             "Received OpenExtendedMiningChannelSuccess with request id: {} and channel id: {}",
             m.request_id, m.channel_id
         );
-        debug!("OpenStandardMiningChannelSuccess: {:?}", m);
+        debug!("OpenStandardMiningChannelSuccess: {}", m);
         let tproxy_e1_len = super::super::utils::proxy_extranonce1_len(
             m.extranonce_size as usize,
             self.min_extranonce_size.into(),
@@ -800,7 +800,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
         m: roles_logic_sv2::mining_sv2::SubmitSharesSuccess,
     ) -> Result<SendTo<Downstream>, RolesLogicError> {
         info!("Received SubmitSharesSuccess");
-        debug!("SubmitSharesSuccess: {:?}", m);
+        debug!("SubmitSharesSuccess: {}", m);
         Ok(SendTo::None(None))
     }
 
@@ -839,7 +839,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
             m.job_id,
             m.is_future()
         );
-        debug!("NewExtendedMiningJob: {:?}", m);
+        debug!("NewExtendedMiningJob: {}", m);
         if self.is_work_selection_enabled() {
             Ok(SendTo::None(None))
         } else {
@@ -866,7 +866,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
             "Received SetNewPrevHash channel id: {}, job id: {}",
             m.channel_id, m.job_id
         );
-        debug!("SetNewPrevHash: {:?}", m);
+        debug!("SetNewPrevHash: {}", m);
         if self.is_work_selection_enabled() {
             Ok(SendTo::None(None))
         } else {
@@ -884,7 +884,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
             "Received SetCustomMiningJobSuccess for channel id: {} for job id: {}",
             m.channel_id, m.job_id
         );
-        debug!("SetCustomMiningJobSuccess: {:?}", m);
+        debug!("SetCustomMiningJobSuccess: {}", m);
         self.last_job_id = Some(m.job_id);
         Ok(SendTo::None(None))
     }
@@ -904,7 +904,7 @@ impl ParseMiningMessagesFromUpstream<Downstream> for Upstream {
         m: roles_logic_sv2::mining_sv2::SetTarget,
     ) -> Result<SendTo<Downstream>, RolesLogicError> {
         info!("Received SetTarget for channel id: {}", m.channel_id);
-        debug!("SetTarget: {:?}", m);
+        debug!("SetTarget: {}", m);
         let m = m.into_static();
         self.target.safe_lock(|t| *t = m.maximum_target.to_vec())?;
         Ok(SendTo::None(None))


### PR DESCRIPTION

**Implements `Display` traits for:**

* Low-level data types, including:

  * `Seq0255`, `Seq064K`, `B016M`, `B064K`, `U256`, etc.

* Protocol messages:

  * Common messages
  * Job declaration
  * Mining
  * Template distribution

* Parsers

Additionally, in roles, replaced `{:?}` in several log entries with `{}` to format parsed byte arrays more clearly.

This change will allow logs to be received in a cleaner, more human-readable format, like this:
![image](https://github.com/user-attachments/assets/2b1e2402-4074-4966-8d66-d9c650f263e1)

Instead of the previous debug format:
![image](https://github.com/user-attachments/assets/60449241-e378-49d6-8613-50f8fba72f84)

Also, added emojis to some protocol messages for easier identification when reviewing.

There's still plenty of work to do regarding log formatting