### PR TITLE
Correct Coinbase Output Length Calculation in `Pool` Role Implementation

### DIFF
--- a/roles/pool/src/lib/mod.rs
+++ b/roles/pool/src/lib/mod.rs
@@ -72,7 +72,10 @@ impl PoolSv2 {
 
         // Prepare coinbase output information required by TemplateRx.
         let coinbase_output_result = get_coinbase_output(&config)?;
-        let coinbase_output_len = coinbase_output_result.len() as u32;
+        let coinbase_output_len = coinbase_output_result
+            .iter()
+            .map(|output| output.size() as u32)
+            .sum();
         let tp_authority_public_key = config.tp_authority_public_key().cloned();
         let coinbase_output_sigops = coinbase_output_result
             .iter()


### PR DESCRIPTION
closes #1762 

This pull request addresses an issue with the coinbase output length calculation in the `Pool` role.

### Problem:

The code was previously using the length of the `Vec<TxOut>` (number of outputs) to estimate the coinbase output size:

```rust
let coinbase_output_len = coinbase_output_result.len() as u32;
```

However, this approach only reflects the count of outputs, not their actual serialized size, which is critical for accurate calculation.

### Solution:

We now calculate the total serialized size by summing the sizes of individual `TxOut` elements. This aligns with the field’s intended purpose:

> *The maximum additional serialized bytes which the pool will add in coinbase transaction outputs.*

### Logs:

Here are the results with and without the fix:

**With the fix:**
![image](https://github.com/user-attachments/assets/a15219fb-7b91-4fff-aac7-9e4c10b52593)

**Without the fix:**
![image](https://github.com/user-attachments/assets/38a869e3-94ad-43ad-917f-d05c06c06131)