### PR TITLE
change coverage workflows to run only when commits are pushed to main

### DIFF
--- a/.github/workflows/coverage-protocols.yaml
+++ b/.github/workflows/coverage-protocols.yaml
@@ -1,7 +1,7 @@
 name: Protocol test Coverage
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/coverage-roles.yaml
+++ b/.github/workflows/coverage-roles.yaml
@@ -1,7 +1,7 @@
 name: Roles test Coverage
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/coverage-utils.yaml
+++ b/.github/workflows/coverage-utils.yaml
@@ -1,7 +1,7 @@
 name: Util Test Coverage
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 


### PR DESCRIPTION
closes #1766;

This pull request updates the GitHub Actions workflow triggers for coverage testing to run on `push` events to the `main` branch instead of `pull_request` events. This ensures that coverage tests are executed after changes are merged into the main branch.