### PR TITLE
decouple job state from channels with JobStore

### DIFF
--- a/protocols/v2/binary-sv2/codec/src/lib.rs
+++ b/protocols/v2/binary-sv2/codec/src/lib.rs
@@ -480,7 +480,7 @@ impl From<Vec<u8>> for EncodableField<'_> {
 }
 
 #[cfg(feature = "with_buffer_pool")]
-impl<'a> From<buffer_sv2::Slice> for EncodableField<'a> {
+impl From<buffer_sv2::Slice> for EncodableField<'_> {
     fn from(_v: buffer_sv2::Slice) -> Self {
         unreachable!()
     }

--- a/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
@@ -5,7 +5,12 @@ use crate::{
         chain_tip::ChainTip,
         server::{
             error::ExtendedChannelError,
-            jobs::{extended::ExtendedJob, factory::JobFactory, JobOrigin},
+            jobs::{
+                extended::ExtendedJob,
+                factory::JobFactory,
+                job_store::{DefaultJobStore, JobStore},
+                JobOrigin,
+            },
             share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
         },
     },
@@ -22,7 +27,7 @@ use bitcoin::{
 };
 use codec_sv2::binary_sv2;
 use mining_sv2::{SetCustomMiningJob, SubmitSharesExtended, Target, MAX_EXTRANONCE_LEN};
-use std::{collections::HashMap, convert::TryInto};
+use std::{collections::HashMap, convert::TryInto, fmt::Display};
 use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
 use tracing::debug;
 
@@ -47,7 +52,7 @@ use tracing::debug;
 /// - the channel's share validation state
 /// - the channel's job factory
 /// - the channel's chain tip
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ExtendedChannel<'a> {
     channel_id: u32,
     user_identity: String,
@@ -56,15 +61,7 @@ pub struct ExtendedChannel<'a> {
     requested_max_target: Target,
     target: Target, // todo: try to use Target from rust-bitcoin
     nominal_hashrate: f32,
-    // maps template_id to job_id on future jobs
-    future_template_to_job_id: HashMap<u64, u32>,
-    // future jobs are indexed with job_id (u32)
-    future_jobs: HashMap<u32, ExtendedJob<'a>>,
-    active_job: Option<ExtendedJob<'a>>,
-    // past jobs are indexed with job_id (u32)
-    past_jobs: HashMap<u32, ExtendedJob<'a>>,
-    // stale jobs are indexed with job_id (u32)
-    stale_jobs: HashMap<u32, ExtendedJob<'a>>,
+    job_store: Box<dyn JobStore<ExtendedJob<'a>>>,
     job_factory: JobFactory,
     share_accounting: ShareAccounting,
     expected_share_per_minute: f32,
@@ -83,6 +80,7 @@ impl<'a> ExtendedChannel<'a> {
         requested_min_rollable_extranonce_size: u16,
         share_batch_size: usize,
         expected_share_per_minute: f32,
+        job_store: Box<dyn JobStore<ExtendedJob<'a>>>,
     ) -> Result<Self, ExtendedChannelError> {
         let target_u256 =
             match hash_rate_to_target(nominal_hashrate.into(), expected_share_per_minute.into()) {
@@ -112,11 +110,7 @@ impl<'a> ExtendedChannel<'a> {
             requested_max_target: max_target,
             target,
             nominal_hashrate,
-            future_template_to_job_id: HashMap::new(),
-            future_jobs: HashMap::new(),
-            active_job: None,
-            past_jobs: HashMap::new(),
-            stale_jobs: HashMap::new(),
+            job_store,
             job_factory: JobFactory::new(version_rolling_allowed),
             share_accounting: ShareAccounting::new(share_batch_size),
             expected_share_per_minute,
@@ -192,7 +186,7 @@ impl<'a> ExtendedChannel<'a> {
     }
 
     pub fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32> {
-        &self.future_template_to_job_id
+        &self.job_store.get_future_template_to_job_id()
     }
 
     pub fn get_nominal_hashrate(&self) -> f32 {
@@ -262,15 +256,15 @@ impl<'a> ExtendedChannel<'a> {
     }
 
     pub fn get_active_job(&self) -> Option<&ExtendedJob<'a>> {
-        self.active_job.as_ref()
+        self.job_store.get_active_job()
     }
 
     pub fn get_future_jobs(&self) -> &HashMap<u32, ExtendedJob<'a>> {
-        &self.future_jobs
+        self.job_store.get_future_jobs()
     }
 
     pub fn get_past_jobs(&self) -> &HashMap<u32, ExtendedJob<'a>> {
-        &self.past_jobs
+        self.job_store.get_past_jobs()
     }
 
     pub fn get_share_accounting(&self) -> &ShareAccounting {
@@ -302,9 +296,7 @@ impl<'a> ExtendedChannel<'a> {
                     )
                     .map_err(ExtendedChannelError::JobFactoryError)?;
                 let new_job_id = new_job.get_job_id();
-                self.future_jobs.insert(new_job_id, new_job);
-                self.future_template_to_job_id
-                    .insert(template.template_id, new_job_id);
+                self.job_store.add_future_job(template.template_id, new_job);
             }
             false => {
                 match self.chain_tip.clone() {
@@ -321,15 +313,7 @@ impl<'a> ExtendedChannel<'a> {
                                 coinbase_reward_outputs,
                             )
                             .map_err(ExtendedChannelError::JobFactoryError)?;
-                        // if there's already some active job, move it to the past jobs
-                        // and set the new job as the active job
-                        if let Some(active_job) = self.active_job.take() {
-                            self.past_jobs.insert(active_job.get_job_id(), active_job);
-                            self.active_job = Some(new_job);
-                        } else {
-                            // if there's no active job, simply set the new job as the active job
-                            self.active_job = Some(new_job);
-                        }
+                        self.job_store.add_active_job(new_job);
                     }
                 }
             }
@@ -352,44 +336,18 @@ impl<'a> ExtendedChannel<'a> {
         &mut self,
         set_new_prev_hash: SetNewPrevHashTdp<'a>,
     ) -> Result<(), ExtendedChannelError> {
-        match self.future_jobs.is_empty() {
+        match self.job_store.get_future_jobs().is_empty() {
             true => {
                 return Err(ExtendedChannelError::TemplateIdNotFound);
             }
             false => {
                 // the SetNewPrevHash message was addressed to a specific future template
-                let future_job_id = self
-                    .future_template_to_job_id
-                    .remove(&set_new_prev_hash.template_id)
-                    .ok_or(ExtendedChannelError::TemplateIdNotFound)?;
-
-                // move currently active job to past jobs (so it can be marked as stale)
-                let currently_active_job = self.active_job.take();
-                if let Some(active_job) = currently_active_job {
-                    self.past_jobs.insert(active_job.get_job_id(), active_job);
-                }
-
-                // activate the future job
-                let mut activated_job = self
-                    .future_jobs
-                    .remove(&future_job_id)
-                    .expect("future job must exist");
-
-                activated_job.activate(set_new_prev_hash.header_timestamp);
-
-                self.active_job = Some(activated_job);
-
-                self.future_jobs.clear();
-                self.future_template_to_job_id.clear();
+                self.job_store.activate_future_job(
+                    set_new_prev_hash.template_id,
+                    set_new_prev_hash.header_timestamp,
+                );
             }
         }
-
-        // mark all past jobs as stale, so that shares can be rejected with the appropriate error
-        // code
-        self.stale_jobs = self.past_jobs.clone();
-
-        // clear past jobs, as we're no longer going to validate shares for them
-        self.past_jobs.clear();
 
         // clear seen shares, as shares for past chain tip will be rejected as stale
         self.share_accounting.flush_seen_shares();
@@ -425,11 +383,7 @@ impl<'a> ExtendedChannel<'a> {
 
         let job_id = new_job.get_job_id();
 
-        if let Some(active_job) = self.active_job.take() {
-            self.past_jobs.insert(active_job.get_job_id(), active_job);
-        }
-
-        self.active_job = Some(new_job);
+        self.job_store.add_active_job(new_job);
 
         Ok(job_id)
     }
@@ -445,15 +399,15 @@ impl<'a> ExtendedChannel<'a> {
 
         // check if job_id is active job
         let is_active_job = self
-            .active_job
-            .as_ref()
+            .job_store
+            .get_active_job()
             .is_some_and(|job| job.get_job_id() == job_id);
 
         // check if job_id is past job
-        let is_past_job = self.past_jobs.contains_key(&job_id);
+        let is_past_job = self.job_store.get_past_jobs().contains_key(&job_id);
 
         // check if job_id is stale job
-        let is_stale_job = self.stale_jobs.contains_key(&job_id);
+        let is_stale_job = self.job_store.get_stale_jobs().contains_key(&job_id);
 
         if is_stale_job {
             return Err(ShareValidationError::Stale);
@@ -465,11 +419,19 @@ impl<'a> ExtendedChannel<'a> {
         }
 
         let job = if is_active_job {
-            self.active_job.as_ref().expect("active job must exist")
+            self.job_store
+                .get_active_job()
+                .expect("active job must exist")
         } else if is_past_job {
-            self.past_jobs.get(&job_id).expect("past job must exist")
+            self.job_store
+                .get_past_jobs()
+                .get(&job_id)
+                .expect("past job must exist")
         } else {
-            self.stale_jobs.get(&job_id).expect("stale job must exist")
+            self.job_store
+                .get_stale_jobs()
+                .get(&job_id)
+                .expect("stale job must exist")
         };
 
         let extranonce_prefix = job.get_extranonce_prefix();
@@ -610,10 +572,11 @@ impl<'a> ExtendedChannel<'a> {
 mod tests {
     use crate::channels::{
         chain_tip::ChainTip,
+        client::extended::ExtendedJob,
         server::{
             error::ExtendedChannelError,
             extended::ExtendedChannel,
-            jobs::JobOrigin,
+            jobs::{job_store::DefaultJobStore, JobOrigin},
             share_accounting::{ShareValidationError, ShareValidationResult},
         },
     };
@@ -643,6 +606,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         let mut channel = ExtendedChannel::new(
             channel_id,
@@ -654,6 +618,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -791,6 +756,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         let mut channel = ExtendedChannel::new(
             channel_id,
@@ -802,6 +768,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -905,6 +872,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         // this extended channel lives on JDC
         let mut jdc_extended_channel = ExtendedChannel::new(
@@ -917,6 +885,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -1009,6 +978,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         // this extended channel lives on Pool Mining Server
         let mut pool_extended_channel = ExtendedChannel::new(
@@ -1021,6 +991,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -1066,6 +1037,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         let mut channel = ExtendedChannel::new(
             channel_id,
@@ -1077,6 +1049,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -1141,6 +1114,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         let mut channel = ExtendedChannel::new(
             channel_id,
@@ -1152,6 +1126,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -1247,6 +1222,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         let mut channel = ExtendedChannel::new(
             channel_id,
@@ -1258,6 +1234,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -1356,6 +1333,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         let mut channel = ExtendedChannel::new(
             channel_id,
@@ -1367,6 +1345,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -1475,6 +1454,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         // this is the most permissive possible max_target
         let max_target: Target = [0xff; 32].into();
@@ -1490,6 +1470,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 
@@ -1569,6 +1550,7 @@ mod tests {
         let version_rolling_allowed = true;
         let rollable_extranonce_size = (MAX_EXTRANONCE_LEN - extranonce_prefix.len()) as u16;
         let share_batch_size = 100;
+        let job_store = Box::new(DefaultJobStore::new());
 
         let mut channel = ExtendedChannel::new(
             channel_id,
@@ -1580,6 +1562,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            job_store,
         )
         .unwrap();
 

--- a/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/extended.rs
@@ -5,12 +5,7 @@ use crate::{
         chain_tip::ChainTip,
         server::{
             error::ExtendedChannelError,
-            jobs::{
-                extended::ExtendedJob,
-                factory::JobFactory,
-                job_store::{DefaultJobStore, JobStore},
-                JobOrigin,
-            },
+            jobs::{extended::ExtendedJob, factory::JobFactory, job_store::JobStore, JobOrigin},
             share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
         },
     },
@@ -27,7 +22,7 @@ use bitcoin::{
 };
 use codec_sv2::binary_sv2;
 use mining_sv2::{SetCustomMiningJob, SubmitSharesExtended, Target, MAX_EXTRANONCE_LEN};
-use std::{collections::HashMap, convert::TryInto, fmt::Display};
+use std::{collections::HashMap, convert::TryInto};
 use template_distribution_sv2::{NewTemplate, SetNewPrevHash as SetNewPrevHashTdp};
 use tracing::debug;
 
@@ -186,7 +181,7 @@ impl<'a> ExtendedChannel<'a> {
     }
 
     pub fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32> {
-        &self.job_store.get_future_template_to_job_id()
+        self.job_store.get_future_template_to_job_id()
     }
 
     pub fn get_nominal_hashrate(&self) -> f32 {
@@ -295,7 +290,6 @@ impl<'a> ExtendedChannel<'a> {
                         coinbase_reward_outputs,
                     )
                     .map_err(ExtendedChannelError::JobFactoryError)?;
-                let new_job_id = new_job.get_job_id();
                 self.job_store.add_future_job(template.template_id, new_job);
             }
             false => {

--- a/protocols/v2/roles-logic-sv2/src/channels/server/group.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/group.rs
@@ -3,11 +3,7 @@ use crate::channels::{
     chain_tip::ChainTip,
     server::{
         error::GroupChannelError,
-        jobs::{
-            extended::ExtendedJob,
-            factory::JobFactory,
-            job_store::{self, JobStore},
-        },
+        jobs::{extended::ExtendedJob, factory::JobFactory, job_store::JobStore},
     },
 };
 use bitcoin::transaction::TxOut;
@@ -111,7 +107,6 @@ impl<'a> GroupChannel<'a> {
                         coinbase_reward_outputs,
                     )
                     .map_err(GroupChannelError::JobFactoryError)?;
-                let new_job_id = new_job.get_job_id();
                 self.job_store.add_future_job(template.template_id, new_job);
             }
             false => {

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
@@ -27,7 +27,7 @@ pub struct ExtendedJob<'a> {
     job_message: NewExtendedMiningJob<'a>,
 }
 
-impl<'a> Job for ExtendedJob<'a> {
+impl Job for ExtendedJob<'_> {
     fn get_job_id(&self) -> u32 {
         self.job_message.job_id
     }

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/extended.rs
@@ -1,3 +1,4 @@
+use super::Job;
 use crate::{
     channels::{
         chain_tip::ChainTip,
@@ -24,6 +25,16 @@ pub struct ExtendedJob<'a> {
     extranonce_prefix: Vec<u8>,
     coinbase_outputs: Vec<TxOut>,
     job_message: NewExtendedMiningJob<'a>,
+}
+
+impl<'a> Job for ExtendedJob<'a> {
+    fn get_job_id(&self) -> u32 {
+        self.job_message.job_id
+    }
+
+    fn activate(&mut self, min_ntime: u32) {
+        self.activate(min_ntime);
+    }
 }
 
 impl<'a> ExtendedJob<'a> {

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/job_store.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/job_store.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::TryInto, fmt::Debug};
+use std::{collections::HashMap, fmt::Debug};
 
 use super::Job;
 
@@ -35,6 +35,12 @@ impl<T: Job + Clone> DefaultJobStore<T> {
             past_jobs: HashMap::new(),
             stale_jobs: HashMap::new(),
         }
+    }
+}
+
+impl<T: Job + Clone> Default for DefaultJobStore<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/job_store.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/job_store.rs
@@ -1,0 +1,113 @@
+use std::{collections::HashMap, convert::TryInto, fmt::Debug};
+
+use super::Job;
+
+pub trait JobStore<T: Job>: Send + Sync + Debug {
+    fn add_future_job(&mut self, template_id: u64, job: T) -> u32;
+    fn add_active_job(&mut self, job: T);
+    fn activate_future_job(&mut self, template_id: u64, prev_hash_header_timestamp: u32) -> bool;
+    fn set_active_job(&mut self, job: T);
+    fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32>;
+    fn get_active_job(&self) -> Option<&T>;
+    fn get_future_jobs(&self) -> &HashMap<u32, T>;
+    fn get_past_jobs(&self) -> &HashMap<u32, T>;
+    fn get_stale_jobs(&self) -> &HashMap<u32, T>;
+}
+
+#[derive(Debug)]
+pub struct DefaultJobStore<T: Job + Clone> {
+    future_template_to_job_id: HashMap<u64, u32>,
+    // future jobs are indexed with job_id (u32)
+    future_jobs: HashMap<u32, T>,
+    active_job: Option<T>,
+    // past jobs are indexed with job_id (u32)
+    past_jobs: HashMap<u32, T>,
+    // stale jobs are indexed with job_id (u32)
+    stale_jobs: HashMap<u32, T>,
+}
+
+impl<T: Job + Clone> DefaultJobStore<T> {
+    pub fn new() -> Self {
+        Self {
+            future_template_to_job_id: HashMap::new(),
+            future_jobs: HashMap::new(),
+            active_job: None,
+            past_jobs: HashMap::new(),
+            stale_jobs: HashMap::new(),
+        }
+    }
+}
+
+impl<T: Job + Clone + Debug> JobStore<T> for DefaultJobStore<T> {
+    fn add_future_job(&mut self, template_id: u64, new_job: T) -> u32 {
+        let new_job_id = new_job.get_job_id();
+        self.future_jobs.insert(new_job_id, new_job);
+        self.future_template_to_job_id
+            .insert(template_id, new_job_id);
+        new_job_id
+    }
+
+    fn add_active_job(&mut self, job: T) {
+        // move currently active job to past jobs (so it can be marked as stale)
+        if let Some(active_job) = self.active_job.take() {
+            self.past_jobs.insert(active_job.get_job_id(), active_job);
+        }
+        // set the new active job
+        self.active_job = Some(job);
+    }
+
+    fn set_active_job(&mut self, job: T) {
+        self.active_job = Some(job);
+    }
+
+    fn activate_future_job(&mut self, template_id: u64, prev_hash_header_timestamp: u32) -> bool {
+        let mut future_job =
+            if let Some(job_id) = self.future_template_to_job_id.remove(&template_id) {
+                if let Some(job) = self.future_jobs.remove(&job_id) {
+                    job
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            };
+
+        // move currently active job to past jobs (so it can be marked as stale)
+        if let Some(active_job) = self.active_job.take() {
+            self.past_jobs.insert(active_job.get_job_id(), active_job);
+        }
+
+        // activate the future job
+        future_job.activate(prev_hash_header_timestamp);
+        self.active_job = Some(future_job);
+        self.future_jobs.clear();
+        self.future_template_to_job_id.clear();
+        // mark all past jobs as stale, so that shares can be rejected with the appropriate error
+        // code
+        self.stale_jobs = self.past_jobs.clone();
+
+        // clear past jobs, as we're no longer going to validate shares for them
+        self.past_jobs.clear();
+        true
+    }
+
+    fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32> {
+        &self.future_template_to_job_id
+    }
+
+    fn get_active_job(&self) -> Option<&T> {
+        self.active_job.as_ref()
+    }
+
+    fn get_future_jobs(&self) -> &HashMap<u32, T> {
+        &self.future_jobs
+    }
+
+    fn get_past_jobs(&self) -> &HashMap<u32, T> {
+        &self.past_jobs
+    }
+
+    fn get_stale_jobs(&self) -> &HashMap<u32, T> {
+        &self.stale_jobs
+    }
+}

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/mod.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod extended;
 pub mod factory;
+pub mod job_store;
 pub mod standard;
 
 use mining_sv2::SetCustomMiningJob;
@@ -10,4 +11,9 @@ use template_distribution_sv2::NewTemplate;
 pub enum JobOrigin<'a> {
     NewTemplate(NewTemplate<'a>),
     SetCustomMiningJob(SetCustomMiningJob<'a>),
+}
+
+pub trait Job: Send + Sync {
+    fn get_job_id(&self) -> u32;
+    fn activate(&mut self, prev_hash_header_timestamp: u32);
 }

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
@@ -17,7 +17,7 @@ pub struct StandardJob<'a> {
     job_message: NewMiningJob<'a>,
 }
 
-impl<'a> Job for StandardJob<'a> {
+impl Job for StandardJob<'_> {
     fn get_job_id(&self) -> u32 {
         self.job_message.job_id
     }

--- a/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/jobs/standard.rs
@@ -1,4 +1,4 @@
-use crate::channels::server::jobs::error::StandardJobError;
+use crate::channels::server::jobs::{error::StandardJobError, Job};
 use bitcoin::{consensus::Decodable, transaction::TxOut};
 use codec_sv2::binary_sv2::{Sv2Option, U256};
 use mining_sv2::NewMiningJob;
@@ -15,6 +15,16 @@ pub struct StandardJob<'a> {
     extranonce_prefix: Vec<u8>,
     coinbase_outputs: Vec<TxOut>,
     job_message: NewMiningJob<'a>,
+}
+
+impl<'a> Job for StandardJob<'a> {
+    fn get_job_id(&self) -> u32 {
+        self.job_message.job_id
+    }
+
+    fn activate(&mut self, min_ntime: u32) {
+        self.activate(min_ntime);
+    }
 }
 
 impl<'a> StandardJob<'a> {

--- a/protocols/v2/roles-logic-sv2/src/channels/server/standard.rs
+++ b/protocols/v2/roles-logic-sv2/src/channels/server/standard.rs
@@ -61,6 +61,7 @@ pub struct StandardChannel<'a> {
 }
 
 impl<'a> StandardChannel<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         channel_id: u32,
         user_identity: String,
@@ -219,7 +220,7 @@ impl<'a> StandardChannel<'a> {
     }
 
     pub fn get_stale_jobs(&self) -> &HashMap<u32, StandardJob<'a>> {
-        &self.job_store.get_stale_jobs()
+        self.job_store.get_stale_jobs()
     }
 
     pub fn get_shares_per_minute(&self) -> f32 {
@@ -264,7 +265,6 @@ impl<'a> StandardChannel<'a> {
                         coinbase_reward_outputs,
                     )
                     .map_err(StandardChannelError::JobFactoryError)?;
-                let new_job_id = new_job.get_job_id();
                 self.job_store.add_future_job(template.template_id, new_job);
             }
             false => {

--- a/roles/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/pool/src/lib/mining_pool/message_handler.rs
@@ -15,6 +15,7 @@ use stratum_common::roles_logic_sv2::{
     channels::server::{
         error::{ExtendedChannelError, StandardChannelError},
         extended::ExtendedChannel,
+        jobs::job_store::DefaultJobStore,
         share_accounting::{ShareValidationError, ShareValidationResult},
         standard::StandardChannel,
     },
@@ -83,7 +84,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
             .to_vec();
 
         let channel_id = self.channel_id_factory.next();
-
+        let job_store = Box::new(DefaultJobStore::new());
         let mut standard_channel = match StandardChannel::new(
             channel_id,
             user_identity,
@@ -92,6 +93,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
             nominal_hash_rate,
             self.share_batch_size,
             self.shares_per_minute,
+            job_store,
         ) {
             Ok(channel) => channel,
             Err(e) => match e {
@@ -204,7 +206,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
         let vardiff = VardiffState::new()?;
 
         self.standard_channels
-            .insert(channel_id, Arc::new(RwLock::new(standard_channel.clone())));
+            .insert(channel_id, Arc::new(RwLock::new(standard_channel)));
 
         self.vardiff
             .insert(channel_id, Arc::new(RwLock::new(Box::new(vardiff))));
@@ -269,7 +271,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
         };
 
         let channel_id = self.channel_id_factory.next();
-
+        let job_store = Box::new(DefaultJobStore::new());
         let mut extended_channel = match ExtendedChannel::new(
             channel_id,
             user_identity,
@@ -280,6 +282,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
             requested_min_rollable_extranonce_size,
             self.share_batch_size,
             self.shares_per_minute,
+            job_store,
         ) {
             Ok(channel) => channel,
             Err(e) => match e {
@@ -398,7 +401,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
         let vardiff = VardiffState::new()?;
 
         self.extended_channels
-            .insert(channel_id, Arc::new(RwLock::new(extended_channel.clone())));
+            .insert(channel_id, Arc::new(RwLock::new(extended_channel)));
         self.vardiff
             .insert(channel_id, Arc::new(RwLock::new(Box::new(vardiff))));
 

--- a/roles/translator/src/lib/error.rs
+++ b/roles/translator/src/lib/error.rs
@@ -315,7 +315,7 @@ impl From<async_channel::SendError<Frame<AnyMessage<'_>, codec_sv2::buffer_sv2::
     }
 }
 
-impl<'a> From<VardiffError> for Error<'a> {
+impl From<VardiffError> for Error<'_> {
     fn from(value: VardiffError) -> Self {
         Self::RolesSv2Logic(value.into())
     }


### PR DESCRIPTION
Currently, the channels structs manage jobs internally. This proposal decoubles job state from channels by utilizing a `JobStore` trait instead of using the job maps directly. A `DefaultJobStore` is also introduced that mirrors the 1-to-1 channel-to-jobstate architecture that is currently provided.

The overall goal of this proposal is to allow for more customizability (ie supporting a wider range of architectures potentially warranted by the end developer)