### PR TITLE
add noise stream

### DIFF
--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -184,7 +184,15 @@ impl<'a, T: Serialize + GetSize + Deserialize<'a>, B: IsBuffer + AeadBuffer> Wit
         }
     }
 
-    /// Provides with the amount of bytes to read.
+    /// Returns the number of bytes expected in the next read operation.
+    ///
+    /// This value indicates how many more bytes are required to complete the
+    /// current Noise-encrypted frame. It is used to determine the exact size
+    /// of the writable buffer that should be passed to the underlying stream
+    /// during reading.
+    ///
+    /// The returned length dynamically updates as data is received and processed,
+    /// and ensures that we only read as much as needed to complete the frame.
     pub fn writable_len(&self) -> usize {
         self.missing_noise_b
     }

--- a/protocols/v2/codec-sv2/src/decoder.rs
+++ b/protocols/v2/codec-sv2/src/decoder.rs
@@ -184,6 +184,11 @@ impl<'a, T: Serialize + GetSize + Deserialize<'a>, B: IsBuffer + AeadBuffer> Wit
         }
     }
 
+    /// Provides with the amount of bytes to read.
+    pub fn writable_len(&self) -> usize {
+        self.missing_noise_b
+    }
+
     /// Provides a writable buffer for receiving incoming Noise-encrypted Sv2 data.
     ///
     /// This buffer is used to store incoming data, and its size is adjusted based on the number

--- a/roles/roles-utils/network-helpers/src/lib.rs
+++ b/roles/roles-utils/network-helpers/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod noise_connection;
+pub mod noise_stream;
 pub mod plain_connection;
 #[cfg(feature = "sv1")]
 pub mod sv1_connection;

--- a/roles/roles-utils/network-helpers/src/noise_connection.rs
+++ b/roles/roles-utils/network-helpers/src/noise_connection.rs
@@ -1,20 +1,15 @@
 #![allow(clippy::new_ret_no_self)]
-use crate::Error;
+use crate::{
+    noise_stream::{NoiseTcpReadHalf, NoiseTcpStream, NoiseTcpWriteHalf},
+    Error,
+};
 use async_channel::{unbounded, Receiver, Sender};
 use codec_sv2::{
     binary_sv2::{Deserialize, GetSize, Serialize},
-    noise_sv2::{ELLSWIFT_ENCODING_SIZE, INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE},
-    HandShakeFrame, HandshakeRole, StandardEitherFrame, StandardNoiseDecoder, State,
+    HandshakeRole, StandardEitherFrame,
 };
-use std::{convert::TryInto, sync::Arc};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{
-        tcp::{OwnedReadHalf, OwnedWriteHalf},
-        TcpStream,
-    },
-    task,
-};
+use std::sync::Arc;
+use tokio::{net::TcpStream, task};
 use tracing::{debug, error};
 
 pub struct Connection;
@@ -35,35 +30,8 @@ impl<Message> ConnectionState<Message> {
     }
 }
 
-async fn send_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
-    writer: &mut OwnedWriteHalf,
-    msg: StandardEitherFrame<Message>,
-    state: &mut State,
-    encoder: &mut codec_sv2::NoiseEncoder<Message>,
-) -> Result<(), Error> {
-    let buffer = encoder.encode(msg, state)?;
-    writer
-        .write_all(buffer.as_ref())
-        .await
-        .map_err(|_| Error::SocketClosed)?;
-    Ok(())
-}
-
-async fn receive_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
-    reader: &mut OwnedReadHalf,
-    state: &mut State,
-    decoder: &mut StandardNoiseDecoder<Message>,
-) -> Result<StandardEitherFrame<Message>, Error> {
-    let writable = decoder.writable();
-    reader
-        .read_exact(writable)
-        .await
-        .map_err(|_| Error::SocketClosed)?;
-    decoder.next_frame(state).map_err(Error::CodecError)
-}
-
 impl Connection {
-    pub async fn new<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+    pub async fn new<Message>(
         stream: TcpStream,
         role: HandshakeRole,
     ) -> Result<
@@ -72,84 +40,10 @@ impl Connection {
             Sender<StandardEitherFrame<Message>>,
         ),
         Error,
-    > {
-        let address = stream.peer_addr().map_err(|_| Error::SocketClosed)?;
-        let (mut reader, mut writer) = stream.into_split();
-        let mut decoder = StandardNoiseDecoder::<Message>::new();
-        let mut encoder = codec_sv2::NoiseEncoder::<Message>::new();
-        let mut state = codec_sv2::State::initialized(role.clone());
-
-        // Handshake Phase
-        match role {
-            HandshakeRole::Initiator(_) => {
-                debug!("Initializing as downstream for {}", address);
-                let mut responder_state = codec_sv2::State::not_initialized(&role);
-                let first_msg = state.step_0()?;
-                send_message(&mut writer, first_msg.into(), &mut state, &mut encoder).await?;
-                debug!("First handshake message sent");
-
-                loop {
-                    match receive_message(&mut reader, &mut responder_state, &mut decoder).await {
-                        Ok(second_msg) => {
-                            debug!("Second handshake message received");
-                            let handshake_frame: HandShakeFrame = second_msg
-                                .try_into()
-                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-                            let payload: [u8; INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE] =
-                                handshake_frame
-                                    .get_payload_when_handshaking()
-                                    .try_into()
-                                    .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-                            let transport_state = state.step_2(payload)?;
-                            state = transport_state;
-                            break;
-                        }
-                        Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
-                            debug!("Waiting for more bytes during handshake");
-                        }
-                        Err(e) => {
-                            error!("Handshake failed with upstream: {:?}", e);
-                            return Err(e);
-                        }
-                    }
-                }
-            }
-            HandshakeRole::Responder(_) => {
-                debug!("Initializing as upstream for {}", address);
-                let mut initiator_state = codec_sv2::State::not_initialized(&role);
-
-                loop {
-                    match receive_message(&mut reader, &mut initiator_state, &mut decoder).await {
-                        Ok(first_msg) => {
-                            debug!("First handshake message received");
-                            let handshake_frame: HandShakeFrame = first_msg
-                                .try_into()
-                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-                            let payload: [u8; ELLSWIFT_ENCODING_SIZE] = handshake_frame
-                                .get_payload_when_handshaking()
-                                .try_into()
-                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
-                            let (second_msg, transport_state) = state.step_1(payload)?;
-                            send_message(&mut writer, second_msg.into(), &mut state, &mut encoder)
-                                .await?;
-                            debug!("Second handshake message sent");
-                            state = transport_state;
-                            break;
-                        }
-                        Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
-                            debug!("Waiting for more bytes during handshake");
-                        }
-                        Err(e) => {
-                            error!("Handshake failed with downstream: {:?}", e);
-                            return Err(e);
-                        }
-                    }
-                }
-            }
-        };
-
-        debug!("Handshake completed with state: {:?}", state);
-
+    >
+    where
+        Message: Serialize + Deserialize<'static> + GetSize + Send + 'static,
+    {
         let (sender_incoming, receiver_incoming) = unbounded();
         let (sender_outgoing, receiver_outgoing) = unbounded();
 
@@ -160,68 +54,85 @@ impl Connection {
             receiver_outgoing,
         });
 
-        // Spawn Reader
-        let read_state = state.clone();
-        Self::spawn_reader(reader, read_state, address, conn_state.clone());
+        let (read_half, write_half) = NoiseTcpStream::<Message>::new(stream, role)
+            .await?
+            .into_split();
 
-        // Spawn Writer
-        let write_state = state;
-        Self::spawn_writer(writer, write_state, address, conn_state);
+        Self::spawn_reader(read_half, Arc::clone(&conn_state));
+        Self::spawn_writer(write_half, conn_state);
 
         Ok((receiver_incoming, sender_outgoing))
     }
-
-    fn spawn_reader<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
-        mut reader: OwnedReadHalf,
-        mut reader_state: State,
-        address: std::net::SocketAddr,
+    fn spawn_reader<Message>(
+        mut read_half: NoiseTcpReadHalf<Message>,
         conn_state: Arc<ConnectionState<Message>>,
-    ) -> task::JoinHandle<()> {
+    ) -> task::JoinHandle<()>
+    where
+        Message: Serialize + Deserialize<'static> + GetSize + Send + 'static,
+    {
         let sender_incoming = conn_state.sender_incoming.clone();
+
         task::spawn(async move {
-            let mut decoder = StandardNoiseDecoder::<Message>::new();
             loop {
-                match receive_message(&mut reader, &mut reader_state, &mut decoder).await {
-                    Ok(frame) => {
-                        if sender_incoming.send(frame).await.is_err() {
-                            error!("Shutting down reader for {}", address);
-                            conn_state.close_all();
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {
+                        debug!("Reader received shutdown signal.");
+                        break;
+                    }
+                    res = read_half.read_frame() => match res {
+                        Ok(frame) => {
+                            if sender_incoming.send(frame).await.is_err() {
+                                error!("Reader: channel closed, shutting down.");
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            error!("Reader: error while reading frame: {e:?}");
                             break;
                         }
                     }
-                    Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
-                        debug!("Waiting for more bytes while reading stream");
-                    }
-                    Err(e) => {
-                        error!("Reader shutting down due to error: {:?}", e);
-                        conn_state.close_all();
-                        break;
-                    }
                 }
             }
+
+            conn_state.close_all();
         })
     }
 
-    fn spawn_writer<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
-        mut writer: OwnedWriteHalf,
-        mut write_state: State,
-        address: std::net::SocketAddr,
+    fn spawn_writer<Message>(
+        mut write_half: NoiseTcpWriteHalf<Message>,
         conn_state: Arc<ConnectionState<Message>>,
-    ) -> task::JoinHandle<()> {
+    ) -> task::JoinHandle<()>
+    where
+        Message: Serialize + Deserialize<'static> + GetSize + Send + 'static,
+    {
         let receiver_outgoing = conn_state.receiver_outgoing.clone();
+
         task::spawn(async move {
-            let mut encoder = codec_sv2::NoiseEncoder::<Message>::new();
-            while let Ok(frame) = receiver_outgoing.recv().await {
-                if let Err(e) =
-                    send_message(&mut writer, frame, &mut write_state, &mut encoder).await
-                {
-                    error!("Error while writing to client {}: {:?}", address, e);
-                    let _ = writer.shutdown().await;
-                    conn_state.close_all();
-                    break;
+            loop {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {
+                        debug!("Writer received shutdown signal.");
+                        break;
+                    }
+                    res = receiver_outgoing.recv() => match res {
+                        Ok(frame) => {
+                            if let Err(e) = write_half.write_frame(frame).await {
+                                error!("Writer: error while writing frame: {e:?}");
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            debug!("Writer: channel closed, shutting down.");
+                            break;
+                        }
+                    }
                 }
             }
-            let _ = writer.shutdown().await;
+
+            if let Err(e) = write_half.shutdown().await {
+                error!("Writer: error during shutdown: {e:?}");
+            }
+
             conn_state.close_all();
         })
     }

--- a/roles/roles-utils/network-helpers/src/noise_stream.rs
+++ b/roles/roles-utils/network-helpers/src/noise_stream.rs
@@ -251,6 +251,7 @@ where
             match self.decoder.next_frame(&mut self.state) {
                 Ok(frame) => return Ok(frame),
                 Err(codec_sv2::Error::MissingBytes(_)) => {
+                    tokio::task::yield_now().await;
                     continue;
                 }
                 Err(e) => return Err(Error::CodecError(e)),

--- a/roles/roles-utils/network-helpers/src/noise_stream.rs
+++ b/roles/roles-utils/network-helpers/src/noise_stream.rs
@@ -34,7 +34,7 @@ use tracing::{debug, error};
 /// If `read_frame()` or `write_frame()` is canceled mid-way,
 /// internal state may be left in an inconsistent state, which can lead to
 /// protocol errors or dropped frames.
-pub struct NoiseTcpStream<Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static> {
+pub struct NoiseTcpStream<Message: Serialize + Deserialize<'static> + GetSize + Send + 'static> {
     reader: NoiseTcpReadHalf<Message>,
     writer: NoiseTcpWriteHalf<Message>,
 }
@@ -43,8 +43,7 @@ pub struct NoiseTcpStream<Message: Serialize + for<'a> Deserialize<'a> + GetSize
 ///
 /// It buffers incoming encrypted bytes, attempts to decode full Noise frames,
 /// and exposes a method to retrieve structured messages of type `Message`.
-pub struct NoiseTcpReadHalf<Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static>
-{
+pub struct NoiseTcpReadHalf<Message: Serialize + Deserialize<'static> + GetSize + Send + 'static> {
     reader: OwnedReadHalf,
     decoder: StandardNoiseDecoder<Message>,
     state: State,
@@ -56,9 +55,7 @@ pub struct NoiseTcpReadHalf<Message: Serialize + for<'a> Deserialize<'a> + GetSi
 ///
 /// It accepts structured messages, encodes them via the Noise protocol,
 /// and writes the result to the socket.
-pub struct NoiseTcpWriteHalf<
-    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
-> {
+pub struct NoiseTcpWriteHalf<Message: Serialize + Deserialize<'static> + GetSize + Send + 'static> {
     writer: OwnedWriteHalf,
     encoder: NoiseEncoder<Message>,
     state: State,
@@ -66,7 +63,7 @@ pub struct NoiseTcpWriteHalf<
 
 impl<Message> NoiseTcpStream<Message>
 where
-    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
+    Message: Serialize + Deserialize<'static> + GetSize + Send + 'static,
 {
     /// Constructs a new `NoiseTcpStream` over the given TCP stream,
     /// performing the Noise handshake in the given `role`.
@@ -168,7 +165,7 @@ where
 
 impl<Message> NoiseTcpWriteHalf<Message>
 where
-    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
+    Message: Serialize + Deserialize<'static> + GetSize + Send + 'static,
 {
     /// Encrypts and writes a full message frame to the socket.
     ///
@@ -214,7 +211,7 @@ where
 
 impl<Message> NoiseTcpReadHalf<Message>
 where
-    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
+    Message: Serialize + Deserialize<'static> + GetSize + Send + 'static,
 {
     /// Reads and decodes a complete frame from the socket.
     ///
@@ -303,7 +300,7 @@ where
     }
 }
 
-async fn send_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+async fn send_message<Message: Serialize + Deserialize<'static> + GetSize + Send + 'static>(
     writer: &mut OwnedWriteHalf,
     msg: StandardEitherFrame<Message>,
     state: &mut State,
@@ -317,7 +314,7 @@ async fn send_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send 
     Ok(())
 }
 
-async fn receive_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+async fn receive_message<Message: Serialize + Deserialize<'static> + GetSize + Send + 'static>(
     reader: &mut OwnedReadHalf,
     state: &mut State,
     decoder: &mut StandardNoiseDecoder<Message>,

--- a/roles/roles-utils/network-helpers/src/noise_stream.rs
+++ b/roles/roles-utils/network-helpers/src/noise_stream.rs
@@ -1,0 +1,186 @@
+use crate::Error;
+use codec_sv2::{
+    binary_sv2::{Deserialize, GetSize, Serialize},
+    noise_sv2::INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE,
+    HandshakeRole, NoiseEncoder, StandardNoiseDecoder, State,
+};
+use tokio::net::{
+    tcp::{OwnedReadHalf, OwnedWriteHalf},
+    TcpStream,
+};
+
+use codec_sv2::{noise_sv2::ELLSWIFT_ENCODING_SIZE, HandShakeFrame, StandardEitherFrame};
+use std::convert::TryInto;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::{debug, error};
+pub struct NoiseTcpStream<Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static> {
+    reader: NoiseTcpReadHalf<Message>,
+    writer: NoiseTcpWriteHalf<Message>,
+}
+
+pub struct NoiseTcpReadHalf<Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static>
+{
+    reader: OwnedReadHalf,
+    decoder: StandardNoiseDecoder<Message>,
+    state: State,
+}
+
+pub struct NoiseTcpWriteHalf<
+    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
+> {
+    writer: OwnedWriteHalf,
+    encoder: NoiseEncoder<Message>,
+    state: State,
+}
+
+impl<Message> NoiseTcpStream<Message>
+where
+    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
+{
+    pub fn into_split(self) -> (NoiseTcpReadHalf<Message>, NoiseTcpWriteHalf<Message>) {
+        (self.reader, self.writer)
+    }
+
+    pub async fn new(stream: TcpStream, role: HandshakeRole) -> Result<Self, Error> {
+        let (mut reader, mut writer) = stream.into_split();
+
+        let mut decoder = StandardNoiseDecoder::<Message>::new();
+        let mut encoder = NoiseEncoder::<Message>::new();
+        let mut state = State::initialized(role.clone());
+
+        match role {
+            HandshakeRole::Initiator(_) => {
+                let mut responder_state = codec_sv2::State::not_initialized(&role);
+                let first_msg = state.step_0()?;
+                send_message(&mut writer, first_msg.into(), &mut state, &mut encoder).await?;
+                debug!("First handshake message sent");
+
+                loop {
+                    match receive_message(&mut reader, &mut responder_state, &mut decoder).await {
+                        Ok(second_msg) => {
+                            debug!("Second handshake message received");
+                            let handshake_frame: HandShakeFrame = second_msg
+                                .try_into()
+                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let payload: [u8; INITIATOR_EXPECTED_HANDSHAKE_MESSAGE_SIZE] =
+                                handshake_frame
+                                    .get_payload_when_handshaking()
+                                    .try_into()
+                                    .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let transport_state = state.step_2(payload)?;
+                            state = transport_state;
+                            break;
+                        }
+                        Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
+                            debug!("Waiting for more bytes during handshake");
+                        }
+                        Err(e) => {
+                            error!("Handshake failed with upstream: {:?}", e);
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+            HandshakeRole::Responder(_) => {
+                let mut initiator_state = codec_sv2::State::not_initialized(&role);
+
+                loop {
+                    match receive_message(&mut reader, &mut initiator_state, &mut decoder).await {
+                        Ok(first_msg) => {
+                            debug!("First handshake message received");
+                            let handshake_frame: HandShakeFrame = first_msg
+                                .try_into()
+                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let payload: [u8; ELLSWIFT_ENCODING_SIZE] = handshake_frame
+                                .get_payload_when_handshaking()
+                                .try_into()
+                                .map_err(|_| Error::HandshakeRemoteInvalidMessage)?;
+                            let (second_msg, transport_state) = state.step_1(payload)?;
+                            send_message(&mut writer, second_msg.into(), &mut state, &mut encoder)
+                                .await?;
+                            debug!("Second handshake message sent");
+                            state = transport_state;
+                            break;
+                        }
+                        Err(Error::CodecError(codec_sv2::Error::MissingBytes(_))) => {
+                            debug!("Waiting for more bytes during handshake");
+                        }
+                        Err(e) => {
+                            error!("Handshake failed with downstream: {:?}", e);
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+        };
+        Ok(Self {
+            reader: NoiseTcpReadHalf {
+                reader,
+                decoder,
+                state: state.clone(),
+            },
+            writer: NoiseTcpWriteHalf {
+                writer,
+                encoder,
+                state,
+            },
+        })
+    }
+}
+
+impl<Message> NoiseTcpWriteHalf<Message>
+where
+    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
+{
+    pub async fn write_frame(&mut self, frame: StandardEitherFrame<Message>) -> Result<(), Error> {
+        let buf = self.encoder.encode(frame, &mut self.state)?;
+        self.writer
+            .write_all(buf.as_ref())
+            .await
+            .map_err(|_| Error::SocketClosed)?;
+        Ok(())
+    }
+}
+
+impl<Message> NoiseTcpReadHalf<Message>
+where
+    Message: Serialize + for<'a> Deserialize<'a> + GetSize + Send + 'static,
+{
+    pub async fn read_frame(&mut self) -> Result<StandardEitherFrame<Message>, Error> {
+        let writable = self.decoder.writable();
+        self.reader
+            .read_exact(writable)
+            .await
+            .map_err(|_| Error::SocketClosed)?;
+        self.decoder
+            .next_frame(&mut self.state)
+            .map_err(Error::CodecError)
+    }
+}
+
+async fn send_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+    writer: &mut OwnedWriteHalf,
+    msg: StandardEitherFrame<Message>,
+    state: &mut State,
+    encoder: &mut NoiseEncoder<Message>,
+) -> Result<(), Error> {
+    let buffer = encoder.encode(msg, state)?;
+    writer
+        .write_all(buffer.as_ref())
+        .await
+        .map_err(|_| Error::SocketClosed)?;
+    Ok(())
+}
+
+async fn receive_message<'a, Message: Serialize + Deserialize<'a> + GetSize + Send + 'static>(
+    reader: &mut OwnedReadHalf,
+    state: &mut State,
+    decoder: &mut StandardNoiseDecoder<Message>,
+) -> Result<StandardEitherFrame<Message>, Error> {
+    let writable = decoder.writable();
+    reader
+        .read_exact(writable)
+        .await
+        .map_err(|_| Error::SocketClosed)?;
+    decoder.next_frame(state).map_err(Error::CodecError)
+}

--- a/roles/roles-utils/network-helpers/src/noise_stream.rs
+++ b/roles/roles-utils/network-helpers/src/noise_stream.rs
@@ -200,6 +200,16 @@ where
             Err(_) => Err(Error::SocketClosed),
         }
     }
+
+    /// Gracefully shuts down the writing half of the stream.
+    ///
+    /// Returns an error if the shutdown fails.
+    pub async fn shutdown(&mut self) -> Result<(), Error> {
+        self.writer
+            .shutdown()
+            .await
+            .map_err(|_| Error::SocketClosed)
+    }
 }
 
 impl<Message> NoiseTcpReadHalf<Message>

--- a/test/integration-tests/lib/utils.rs
+++ b/test/integration-tests/lib/utils.rs
@@ -84,8 +84,7 @@ pub async fn create_downstream(
         Responder::from_authority_kp(&pub_key, &prv_key, std::time::Duration::from_secs(10000))
             .unwrap();
     if let Ok((receiver_from_client, sender_to_client)) =
-        Connection::new::<'static, AnyMessage<'static>>(stream, HandshakeRole::Responder(responder))
-            .await
+        Connection::new::<AnyMessage<'static>>(stream, HandshakeRole::Responder(responder)).await
     {
         Some((receiver_from_client, sender_to_client))
     } else {
@@ -98,8 +97,7 @@ pub async fn create_upstream(
 ) -> Option<(Receiver<MessageFrame>, Sender<MessageFrame>)> {
     let initiator = Initiator::without_pk().expect("This fn call can not fail");
     if let Ok((receiver_from_server, sender_to_server)) =
-        Connection::new::<'static, AnyMessage<'static>>(stream, HandshakeRole::Initiator(initiator))
-            .await
+        Connection::new::<AnyMessage<'static>>(stream, HandshakeRole::Initiator(initiator)).await
     {
         Some((receiver_from_server, sender_to_server))
     } else {


### PR DESCRIPTION
closes: #1780

This PR introduces `NoiseTcpStream`, wrapper around a `TcpStream` that performs a noise handshake and enables encrypted, frame-based communication over TCP .

The design includes:

* A one-time Noise handshake as either `Initiator` or `Responder`
* Framed reading and writing of `StandardEitherFrame<Message>` types
* Explicit read and write halves (`NoiseTcpReadHalf`, `NoiseTcpWriteHalf`)
* Support for both blocking and non-blocking (`try_*`) frame I/O

The `NoiseTcpStream` is not a byte stream in the traditional sense. It encapsulates:

* A stateful encryption/decryption pipeline via the Noise protocol
* Frame reassembly logic required by the SV2 codec
* Buffers and internal state tightly coupled to message boundaries

Therefore, we expose only high-level, frame-based I/O methods:

* `read_frame()` and `write_frame()` (async)
* `try_read_frame()` and `try_write_frame()` (non-blocking)

