### PR TITLE
Fix unnecessary version bumps done by mistake

### DIFF
--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "common_messages_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "framing_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",

--- a/protocols/v2/framing-sv2/Cargo.toml
+++ b/protocols/v2/framing-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framing_sv2"
-version = "5.1.0"
+version = "5.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/protocols/v2/subprotocols/common-messages/Cargo.toml
+++ b/protocols/v2/subprotocols/common-messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common_messages_sv2"
-version = "5.1.0"
+version = "5.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -657,7 +657,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "common_messages_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
 ]
@@ -978,7 +978,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "framing_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -535,7 +535,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "common_messages_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
 ]
@@ -835,7 +835,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "framing_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "common_messages_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
 ]
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "framing_sv2"
-version = "5.1.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",


### PR DESCRIPTION
This PR fixes some version bumps we did by mistake on PR https://github.com/stratum-mining/stratum/pull/1728.

- `framing_sv2` was already bumped from `4.0.0` to `5.0.0` in https://github.com/stratum-mining/stratum/pull/1667
- `common_messages_sv2` was already bumped from `4.0.0` to `5.0.0` in https://github.com/stratum-mining/stratum/pull/1654