### PR TITLE
fix: add missing dependency versions for cargo publish

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/stratum-mining/stratum"
 
 [dependencies]
-roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2" }
-network_helpers_sv2 = { path = "../roles/roles-utils/network-helpers", features = ["with_buffer_pool"], optional = true }
+roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2", version = "3.0.0" }
+network_helpers_sv2 = { path = "../roles/roles-utils/network-helpers", version = "4.0.0", features = ["with_buffer_pool"], optional = true }
 
 [features]
 with_network_helpers = ["dep:network_helpers_sv2"]

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -23,7 +23,7 @@ chacha20poly1305 = { version = "0.10.1"}
 nohash-hasher = "0.2.0"
 primitive-types = "0.13.1"
 hex = {package = "hex-conservative", version = "0.3.0"}
-codec_sv2 = { path = "../../../protocols/v2/codec-sv2", features = ["noise_sv2", "with_buffer_pool"] }
+codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0", features = ["noise_sv2", "with_buffer_pool"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common" }
+stratum-common = { path = "../../../common", version = "3.0.0" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc","raw_value"] }
 hex = "0.4.3"

--- a/utils/bip32-key-derivation/Cargo.toml
+++ b/utils/bip32-key-derivation/Cargo.toml
@@ -20,7 +20,7 @@ name = "bip32_derivation-bin"
 path = "src/main.rs"
 
 [dependencies]
-stratum-common = { path = "../../common" }
+stratum-common = { path = "../../common", version = "3.0.0" }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Adds version specifications to local path dependencies in `common`, `roles-logic-sv2`, `bip32-derivation`, and `rpc` crates.

The absence of those versions made the `cargo publish` workflow to fail: https://github.com/stratum-mining/stratum/actions/runs/16174649282/job/45656653602