### PR TITLE
Fix broken Getting Started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SRI is fully open-source, community-developed, independent of any single entity,
 
 To get started with the Stratum V2 Reference Implementation (SRI), please follow the detailed setup instructions available on the official website:
 
-[Getting Started with Stratum V2](https://stratumprotocol.org/getting-started/)
+[Getting Started with Stratum V2](https://stratumprotocol.org/blog/getting-started/)
 
 This guide provides all the necessary information on prerequisites, installation, and configuration to help you begin using, testing or contributing to SRI.
 


### PR DESCRIPTION
This PR updates the "Getting Started" link in the README to point to the correct blog URL:

🔗 From: https://stratumprotocol.org/getting-started/  
✅ To: https://stratumprotocol.org/blog/getting-started

The previous link led to a 404 page. This update ensures users can access the onboarding guide.