### PR TITLE
Improve tracing defaults and add download warning log

### DIFF
--- a/test/integration-tests/lib/template_provider.rs
+++ b/test/integration-tests/lib/template_provider.rs
@@ -1,6 +1,7 @@
 use corepc_node::{types::GetBlockchainInfo, Conf, ConnectParams, Node};
 use std::{env, fs::create_dir_all, path::PathBuf};
 use stratum_common::roles_logic_sv2::bitcoin::{Address, Amount, Txid};
+use tracing::warn;
 
 use crate::utils::{fs_utils, http, tarball};
 
@@ -110,6 +111,7 @@ impl TemplateProvider {
             let tarball_bytes = match env::var("BITCOIND_TARBALL_FILE") {
                 Ok(path) => tarball::read_from_file(&path),
                 Err(_) => {
+                    warn!("Downloading template provider for the testing session. This could take a while...");
                     let download_endpoint =
                         env::var("BITCOIND_DOWNLOAD_ENDPOINT").unwrap_or_else(|_| {
                             "https://github.com/Sjors/bitcoin/releases/download".to_owned()


### PR DESCRIPTION
closes #1183

I ran into this issue a few weeks ago on a slow connection and experienced the same problem described in it.

This PR adds a `warn`-level log message to inform users when a download is in progress. this helps clarify what’s happening during that initial delay. You can see an example of the log output in the first line of the test below:

<img width="1848" height="627" alt="image" src="https://github.com/user-attachments/assets/18d73c7a-5729-4166-9086-613e1f675062" />

To make this work properly, I also updated the `start_tracing` function. Previously, if `RUST_LOG` wasn’t set, the log level would default to `ERROR`. Now, it still respects `RUST_LOG` if provided, but defaults to `INFO` otherwise.
