### PR TITLE
ressurect `test/scale`

### DIFF
--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -35,3 +35,4 @@ jobs:
           cargo fmt --all --manifest-path=roles/Cargo.toml -- --check
           cargo fmt --all --manifest-path=utils/Cargo.toml -- --check
           cargo fmt --all --manifest-path=test/integration-tests/Cargo.toml -- --check
+          cargo fmt --all --manifest-path=test/scale/Cargo.toml -- --check

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cobertura.xml
 **/template-provider
 stratum-message-generator
 *.log
+test/scale/Cargo.lock

--- a/scripts/rust/clippy.sh
+++ b/scripts/rust/clippy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-workspaces=("benches" "common" "roles" "protocols" "utils" "test/integration-tests")
+workspaces=("benches" "common" "roles" "protocols" "utils" "test/integration-tests" "test/scale")
 
 # print current rust version
 echo "Rust version: $(rustc --version)"

--- a/test/scale/Cargo.toml
+++ b/test/scale/Cargo.toml
@@ -9,7 +9,7 @@ lto = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "4.5.41", features = ["derive"] }
 async-channel = "1.5.1"
 async-std="1.8.0"
 bytes = "1.0.1"

--- a/test/scale/Cargo.toml
+++ b/test/scale/Cargo.toml
@@ -15,7 +15,7 @@ async-std="1.8.0"
 bytes = "1.0.1"
 binary_sv2 = { path = "../../protocols/v2/binary-sv2" }
 codec_sv2 = { path = "../../protocols/v2/codec-sv2", features=["noise_sv2"] }
-network_helpers_sv2 = { version = "0.1", path = "../../roles/roles-utils/network-helpers" }
+network_helpers_sv2 = { version = "4.0.0", path = "../../roles/roles-utils/network-helpers" }
 roles_logic_sv2 = { path = "../../protocols/v2/roles-logic-sv2" }
 tokio = { version = "1.44.1", features = ["full"] }
 key-utils = { version = "^1.0.0", path = "../../utils/key-utils" }


### PR DESCRIPTION
Closes #1105;

- Updates the crate code to catch-up with the SRI changes
- Updates Clap to use a more recent version
- Added the crate to fmt and clippy CI process;
