### PR TITLE
ci: add semver checks for config-helpers in workflow

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -124,3 +124,7 @@ jobs:
       - name: Run semver checks for roles/roles-utils/rpc
         working-directory: roles/roles-utils/rpc
         run: cargo semver-checks
+
+      - name: Run semver checks for roles/roles-utils/config-helpers
+        working-directory: roles/roles-utils/config-helpers
+        run: cargo semver-checks


### PR DESCRIPTION
This PR adds `config_helpers_sv2` to our `semver-checks` workflow.

Follow up to PR #1811 