### PR TITLE
Update rpc_sv2 version to 1.1.0 in Cargo.toml and Cargo.lock

### DIFF
--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "rpc_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64 0.21.7",
  "hex",

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc_sv2"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV2 JD Server RPC"

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "rpc_sv2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64 0.21.7",
  "hex",


### PR DESCRIPTION
This PR bumps `rpc_sv2` to `1.1.0`, because of past changes introduced by https://github.com/stratum-mining/stratum/commit/732cc88629adfa69810c1023f26ebb76d84be011#diff-a8edde79879e48e4a33faed108f32632b83aa06146a72810793fcf4a8ecfd1cbR32-R53

Closes #1814 