### PR TITLE
Finishes rust docs for `channel_sv2`

### DIFF
--- a/protocols/v2/channels-sv2/src/chain_tip.rs
+++ b/protocols/v2/channels-sv2/src/chain_tip.rs
@@ -3,7 +3,9 @@ use binary_sv2::U256;
 
 /// An abstraction over the chain tip, carrying information from `SetNewPrevHash` messages.
 ///
-/// Used while creating non-future jobs.
+/// Used for:
+/// - creating non-future jobs
+/// - validating shares.
 #[derive(Debug, Clone)]
 pub struct ChainTip {
     prev_hash: U256<'static>,
@@ -12,6 +14,7 @@ pub struct ChainTip {
 }
 
 impl ChainTip {
+    /// Constructs a new `ChainTip` instance.
     pub fn new(prev_hash: U256<'static>, nbits: u32, min_ntime: u32) -> Self {
         Self {
             prev_hash,
@@ -20,14 +23,17 @@ impl ChainTip {
         }
     }
 
+    /// Retrieves the hash of the previous block
     pub fn prev_hash(&self) -> U256<'static> {
         self.prev_hash.clone()
     }
 
+    /// Retrieves the network difficulty for the current block
     pub fn nbits(&self) -> u32 {
         self.nbits
     }
 
+    /// Retrieves the smallest nTime value available for hashing
     pub fn min_ntime(&self) -> u32 {
         self.min_ntime
     }

--- a/protocols/v2/channels-sv2/src/client/error.rs
+++ b/protocols/v2/channels-sv2/src/client/error.rs
@@ -1,20 +1,43 @@
+//! # Channel Error Types
+//!
+//! This module defines error types for different channel contexts: extended, standard,
+//! and group channels. Each error type represents specific categories of failures that
+//! can occur during channel operations.
+
 use crate::bip141::StripBip141Error;
 
+/// Errors that can occur within an **extended channel** context.
+///
+/// These include conditions where the extranonce prefix exceeds allowed limits
+/// or a referenced job ID is not recognized by the channel.
 #[derive(Debug)]
 pub enum ExtendedChannelError {
+    /// The provided extranonce prefix exceeds the maximum allowed size.
     NewExtranoncePrefixTooLarge,
+
+    /// The specified job ID was not found in the extended channel.
     JobIdNotFound,
     FailedToTryToStripBip141(StripBip141Error),
     FailedToSerializeToB064K,
 }
 
+/// Errors that can occur within a **standard channel** context.
+///
+/// These cover scenarios such as missing job IDs or an oversized extranonce prefix.
 #[derive(Debug)]
 pub enum StandardChannelError {
+    /// The specified job ID was not found in the standard channel.
     JobIdNotFound,
+
+    /// The provided extranonce prefix exceeds the maximum allowed size.
     NewExtranoncePrefixTooLarge,
 }
 
+/// Errors that can occur within a **group channel** context.
+///
+/// Currently includes only job ID lookup failures.
 #[derive(Debug)]
 pub enum GroupChannelError {
+    /// The specified job ID was not found in the group channel.
     JobIdNotFound,
 }

--- a/protocols/v2/channels-sv2/src/client/mod.rs
+++ b/protocols/v2/channels-sv2/src/client/mod.rs
@@ -1,4 +1,4 @@
-//! Abstractions for channels to be used by mining clients.
+//! Sv2 channels - Mining Clients Abstractions.
 
 pub mod error;
 pub mod extended;

--- a/protocols/v2/channels-sv2/src/client/share_accounting.rs
+++ b/protocols/v2/channels-sv2/src/client/share_accounting.rs
@@ -1,16 +1,30 @@
-//! Abstractions for share validation for a Mining Client
-
+//! Share Validation - Mining Client Abstraction.
+//!
+//! This module provides types and logic for validating mining shares, tracking share
+//! statistics, and reporting share validation results and errors. These abstractions
+//! are intended for use in Mining Clients.
 use bitcoin::hashes::sha256d::Hash;
 use std::collections::HashSet;
 
-/// The outcome of share validation, from the perspective of a Mining Client.
+/// The outcome of share validation, as seen by a Mining Client.
+///
+/// - `Valid`: The share is valid and accepted.
+/// - `BlockFound`: The submitted share resulted in a new block being found.
 #[derive(Debug)]
 pub enum ShareValidationResult {
     Valid,
     BlockFound,
 }
 
-/// The error variants that can occur during share validation
+/// Possible errors encountered during share validation.
+///
+/// - `Invalid`: The share is malformed or not valid.
+/// - `Stale`: The share refers to an outdated job or block tip.
+/// - `InvalidJobId`: The job ID referenced by the share is not recognized.
+/// - `DoesNotMeetTarget`: The share does not meet the required target difficulty.
+/// - `VersionRollingNotAllowed`: Version rolling is not permitted for this channel/job.
+/// - `DuplicateShare`: The share has already been submitted (detected by hash).
+/// - `NoChainTip`: The chain tip is unknown or unavailable.
 #[derive(Debug)]
 pub enum ShareValidationError {
     Invalid,
@@ -22,10 +36,15 @@ pub enum ShareValidationError {
     NoChainTip,
 }
 
-/// The state of share validation on the context of some specific channel (either Extended or
-/// Standard)
+/// Tracks share validation state for a specific channel (Extended or Standard).
 ///
-/// Only meant for usage on Mining Clients.
+/// Used only on Mining Clients.
+/// Keeps statistics and state for shares submitted through the channel:
+/// - last received share's sequence number
+/// - total accepted shares
+/// - cumulative work from accepted shares
+/// - hashes of seen shares (for duplicate detection)
+/// - highest difficulty seen in accepted shares
 #[derive(Clone, Debug)]
 pub struct ShareAccounting {
     last_share_sequence_number: u32,
@@ -42,6 +61,7 @@ impl Default for ShareAccounting {
 }
 
 impl ShareAccounting {
+    /// Creates a new [`ShareAccounting`] instance, initializing all statistics to zero.
     pub fn new() -> Self {
         Self {
             last_share_sequence_number: 0,
@@ -52,6 +72,11 @@ impl ShareAccounting {
         }
     }
 
+    /// Updates the accounting state with a newly accepted share.
+    ///
+    /// - Increments share count and total work.
+    /// - Updates last share sequence number.
+    /// - Records share hash to detect duplicates.
     pub fn update_share_accounting(
         &mut self,
         share_work: u64,
@@ -64,37 +89,40 @@ impl ShareAccounting {
         self.seen_shares.insert(share_hash);
     }
 
-    /// clears the hashset of seen shares
+    /// Clears the set of seen share hashes.
     ///
-    /// should be called on every chain tip update
-    /// to avoid unbounded growth of memory
+    /// Should be called on every chain tip update
+    /// to prevent unbounded memory growth.
     pub fn flush_seen_shares(&mut self) {
         self.seen_shares.clear();
     }
 
+    /// Returns the sequence number of the last share received.
     pub fn get_last_share_sequence_number(&self) -> u32 {
         self.last_share_sequence_number
     }
 
+    /// Returns the total number of shares accepted.
     pub fn get_shares_accepted(&self) -> u32 {
         self.shares_accepted
     }
 
+    /// Returns the cumulative work of all accepted shares.
     pub fn get_share_work_sum(&self) -> u64 {
         self.share_work_sum
     }
 
-    /// Checks if the share has been seen.
-    /// Useful to avoid duplicate shares.
+    /// Checks if the given share hash has already been seen (duplicate detection).
     pub fn is_share_seen(&self, share_hash: Hash) -> bool {
         self.seen_shares.contains(&share_hash)
     }
 
+    /// Returns the highest difficulty among all accepted shares.
     pub fn get_best_diff(&self) -> f64 {
         self.best_diff
     }
 
-    /// Updates the best diff if the new diff is higher.
+    /// Updates the best difficulty if the new difficulty is higher than the current best.
     pub fn update_best_diff(&mut self, diff: f64) {
         if diff > self.best_diff {
             self.best_diff = diff;

--- a/protocols/v2/channels-sv2/src/lib.rs
+++ b/protocols/v2/channels-sv2/src/lib.rs
@@ -1,3 +1,18 @@
+//! # Stratum V2 Channels
+//!
+//! `channels_sv2` provides primitives and abstractions for Stratum V2 (Sv2) Channels.
+//!
+//! This crate implements the core channel management functionality for both mining clients and
+//! servers, including standard, extended, and group channels, and share accounting mechanisms.
+//!
+//! ## Features
+//!
+//! - Channel primitives for SV2 mining protocol
+//! - Channel management for mining servers and clients
+//! - Standard, extended, and group channel support
+//! - Share accounting
+//! - Job store abstractions
+
 pub mod bip141;
 pub mod chain_tip;
 pub mod client;

--- a/protocols/v2/channels-sv2/src/server/error.rs
+++ b/protocols/v2/channels-sv2/src/server/error.rs
@@ -1,3 +1,5 @@
+//! # Channel Error Types
+
 use crate::server::jobs::error::JobFactoryError;
 
 #[derive(Debug)]

--- a/protocols/v2/channels-sv2/src/server/group.rs
+++ b/protocols/v2/channels-sv2/src/server/group.rs
@@ -213,7 +213,7 @@ impl<'a> GroupChannel<'a> {
                                 coinbase_reward_outputs,
                             )
                             .map_err(GroupChannelError::JobFactoryError)?;
-                        self.job_store.set_active_job(new_job);
+                        self.job_store.add_active_job(new_job);
                     }
                 }
             }

--- a/protocols/v2/channels-sv2/src/server/jobs/error.rs
+++ b/protocols/v2/channels-sv2/src/server/jobs/error.rs
@@ -1,3 +1,5 @@
+//! # Job Error Types
+
 #[derive(Debug)]
 pub enum ExtendedJobError {
     FailedToDeserializeCoinbase,

--- a/protocols/v2/channels-sv2/src/server/jobs/extended.rs
+++ b/protocols/v2/channels-sv2/src/server/jobs/extended.rs
@@ -79,7 +79,9 @@ impl<'a> ExtendedJob<'a> {
             job_message,
         })
     }
-
+    /// Creates a new extended job from a custom mining job message.
+    ///
+    /// Used for jobs originating from [`SetCustomMiningJob`] messages.
     pub fn from_custom_job(
         custom_job: SetCustomMiningJob<'a>,
         extranonce_prefix: Vec<u8>,
@@ -180,6 +182,10 @@ impl<'a> ExtendedJob<'a> {
         })
     }
 
+    /// Converts the `ExtendedJob` into a `StandardJob`.
+    ///
+    /// Only possible if the job was created from a `NewTemplate`.
+    /// Jobs created from `SetCustomMiningJob` cannot be converted
     pub fn into_standard_job(
         self,
         channel_id: u32,
@@ -222,46 +228,51 @@ impl<'a> ExtendedJob<'a> {
         Ok(standard_job)
     }
 
+    /// Returns the job ID for this job.
     pub fn get_job_id(&self) -> u32 {
         self.job_message.job_id
     }
 
+    /// Returns the origin message for this job (template or custom job).
     pub fn get_origin(&self) -> &JobOrigin<'a> {
         &self.origin
     }
 
+    /// Returns the coinbase transaction without for this job without BIP141 data.
     pub fn get_coinbase_tx_prefix_without_bip141(&self) -> Vec<u8> {
         self.job_message.coinbase_tx_prefix.inner_as_ref().to_vec()
     }
 
+    /// Returns the coinbase transaction suffix for this job without BIP141 data.
     pub fn get_coinbase_tx_suffix_without_bip141(&self) -> Vec<u8> {
         self.job_message.coinbase_tx_suffix.inner_as_ref().to_vec()
     }
 
+    /// Returns the extranonce prefix used for this job.
     pub fn get_extranonce_prefix(&self) -> &Vec<u8> {
         &self.extranonce_prefix
     }
-
+    /// Returns all coinbase outputs for this job.
     pub fn get_coinbase_outputs(&self) -> &Vec<TxOut> {
         &self.coinbase_outputs
     }
-
+    /// Returns the [`NewExtendedMiningJob`] message for this job.
     pub fn get_job_message(&self) -> &NewExtendedMiningJob<'a> {
         &self.job_message
     }
-
+    /// Returns the merkle path for this job.
     pub fn get_merkle_path(&self) -> &Seq0255<'a, U256<'a>> {
         &self.job_message.merkle_path
     }
-
+    /// Returns the minimum ntime for this job (if set).
     pub fn get_min_ntime(&self) -> Sv2Option<'a, u32> {
         self.job_message.min_ntime.clone()
     }
-
+    /// Returns the block version for this job.
     pub fn get_version(&self) -> u32 {
         self.job_message.version
     }
-
+    /// Returns true if version rolling is allowed for this job.
     pub fn version_rolling_allowed(&self) -> bool {
         self.job_message.version_rolling_allowed
     }

--- a/protocols/v2/channels-sv2/src/server/jobs/factory.rs
+++ b/protocols/v2/channels-sv2/src/server/jobs/factory.rs
@@ -1,4 +1,25 @@
 //! Abstraction of a factory for creating Sv2 Extended or Standard Jobs.
+//!
+//! This module provides the [`JobFactory`] struct, which enables the creation
+//! of uniquely identified Extended and Standard mining jobs as required by
+//! Stratum V2 (SV2) mining servers. It manages job ID assignment, construction
+//! of coinbase transactions, and correct association of template and custom job
+//! parameters.
+//!
+//! ## Responsibilities
+//!
+//! - **Job ID Generation**: Ensures all jobs have unique IDs per factory instance.
+//! - **Job Construction**: Builds Extended and Standard jobs from SV2 templates and custom job
+//!   messages, assembling all required coinbase transaction data and metadata.
+//! - **Coinbase Output Validation**: Verifies that coinbase outputs match SV2 template constraints
+//!   and protocol rules.
+//! - **Version Rolling**: Tracks version rolling allowance for created jobs.
+//!
+//! ## Usage
+//!
+//! Designed for mining server implementations. Use `JobFactory` to generate jobs in response to
+//! incoming SV2 messages (`NewTemplate`, `SetCustomMiningJob`), ensuring protocol correctness and
+//! uniqueness of job IDs.
 use crate::{
     bip141::try_strip_bip141,
     chain_tip::ChainTip,

--- a/protocols/v2/channels-sv2/src/server/jobs/job_store.rs
+++ b/protocols/v2/channels-sv2/src/server/jobs/job_store.rs
@@ -36,9 +36,6 @@ pub trait JobStore<T: Job>: Send + Sync + Debug {
     /// Returns `true` if successful, `false` if not found.
     fn activate_future_job(&mut self, template_id: u64, prev_hash_header_timestamp: u32) -> bool;
 
-    /// Directly sets the active job (without moving previous job to past).
-    fn set_active_job(&mut self, job: T);
-
     /// Returns the mapping from future template IDs to job IDs.
     fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32>;
 
@@ -105,10 +102,6 @@ impl<T: Job + Clone + Debug> JobStore<T> for DefaultJobStore<T> {
             self.past_jobs.insert(active_job.get_job_id(), active_job);
         }
         // Set the new active job
-        self.active_job = Some(job);
-    }
-
-    fn set_active_job(&mut self, job: T) {
         self.active_job = Some(job);
     }
 

--- a/protocols/v2/channels-sv2/src/server/jobs/job_store.rs
+++ b/protocols/v2/channels-sv2/src/server/jobs/job_store.rs
@@ -1,32 +1,78 @@
+//! Abstractions for job storage and lifecycle management in SV2 mining channels.
+//!
+//! This module provides the [`JobStore`] trait and a default implementation for
+//! tracking mining job states (future, active, past, stale) for SV2 Extended and Standard channels.
+//!
+//! ## Responsibilities
+//!
+//! - **Job Storage**: Manages collections of jobs indexed by job ID and template ID.
+//! - **Job Activation**: Handles transitions between future, active, past, and stale jobs.
+//! - **Template Mapping**: Tracks mappings from template IDs to job IDs for future jobs.
+//! - **Lifecycle Management**: Ensures correct state transitions when activating jobs or updating
+//!   chain tips.
+//!
+//! ## Usage
+//!
+//! Use the [`JobStore`] trait for custom job store implementations, or the [`DefaultJobStore`]
+//! for standard job lifecycle management in mining channel abstractions.
+
 use std::{collections::HashMap, fmt::Debug};
 
 use super::Job;
 
+/// Trait for job lifecycle management in mining channels.
+///
+/// Types implementing `JobStore` must support tracking and transitioning jobs through various
+/// states (future, active, past, stale), and provide access to job collections and mappings.
 pub trait JobStore<T: Job>: Send + Sync + Debug {
+    /// Adds a future job associated with a template ID.
+    /// Returns the new job's ID.
     fn add_future_job(&mut self, template_id: u64, job: T) -> u32;
+
+    /// Adds an active job, moving the previous active job (if any) to past jobs.
     fn add_active_job(&mut self, job: T);
+
+    /// Activates a future job given by template ID and header timestamp.
+    /// Returns `true` if successful, `false` if not found.
     fn activate_future_job(&mut self, template_id: u64, prev_hash_header_timestamp: u32) -> bool;
+
+    /// Directly sets the active job (without moving previous job to past).
     fn set_active_job(&mut self, job: T);
+
+    /// Returns the mapping from future template IDs to job IDs.
     fn get_future_template_to_job_id(&self) -> &HashMap<u64, u32>;
+
+    /// Returns the currently active job, if any.
     fn get_active_job(&self) -> Option<&T>;
+
+    /// Returns all future jobs, indexed by job ID.
     fn get_future_jobs(&self) -> &HashMap<u32, T>;
+
+    /// Returns all past jobs (previously active jobs), indexed by job ID.
     fn get_past_jobs(&self) -> &HashMap<u32, T>;
+
+    /// Returns all stale jobs (jobs from previous chain tip), indexed by job ID.
     fn get_stale_jobs(&self) -> &HashMap<u32, T>;
 }
 
+/// Default implementation of [`JobStore`] for tracking mining job states in SV2 channels.
+///
+/// Maintains collections for future, active, past, and stale jobs, and tracks template-to-job ID
+/// mappings for future job activation.
 #[derive(Debug)]
 pub struct DefaultJobStore<T: Job + Clone> {
     future_template_to_job_id: HashMap<u64, u32>,
-    // future jobs are indexed with job_id (u32)
+    // Future jobs are indexed with job_id (u32)
     future_jobs: HashMap<u32, T>,
     active_job: Option<T>,
-    // past jobs are indexed with job_id (u32)
+    // Past jobs are indexed with job_id (u32)
     past_jobs: HashMap<u32, T>,
-    // stale jobs are indexed with job_id (u32)
+    // Stale jobs are indexed with job_id (u32)
     stale_jobs: HashMap<u32, T>,
 }
 
 impl<T: Job + Clone> DefaultJobStore<T> {
+    /// Creates a new empty job store.
     pub fn new() -> Self {
         Self {
             future_template_to_job_id: HashMap::new(),
@@ -54,11 +100,11 @@ impl<T: Job + Clone + Debug> JobStore<T> for DefaultJobStore<T> {
     }
 
     fn add_active_job(&mut self, job: T) {
-        // move currently active job to past jobs (so it can be marked as stale)
+        // Move currently active job to past jobs (so it can be marked as stale)
         if let Some(active_job) = self.active_job.take() {
             self.past_jobs.insert(active_job.get_job_id(), active_job);
         }
-        // set the new active job
+        // Set the new active job
         self.active_job = Some(job);
     }
 
@@ -78,21 +124,21 @@ impl<T: Job + Clone + Debug> JobStore<T> for DefaultJobStore<T> {
                 return false;
             };
 
-        // move currently active job to past jobs (so it can be marked as stale)
+        // Move currently active job to past jobs (so it can be marked as stale)
         if let Some(active_job) = self.active_job.take() {
             self.past_jobs.insert(active_job.get_job_id(), active_job);
         }
 
-        // activate the future job
+        // Activate the future job
         future_job.activate(prev_hash_header_timestamp);
         self.active_job = Some(future_job);
         self.future_jobs.clear();
         self.future_template_to_job_id.clear();
-        // mark all past jobs as stale, so that shares can be rejected with the appropriate error
+        // Mark all past jobs as stale, so that shares can be rejected with the appropriate error
         // code
         self.stale_jobs = self.past_jobs.clone();
 
-        // clear past jobs, as we're no longer going to validate shares for them
+        // Clear past jobs, as we're no longer going to validate shares for them
         self.past_jobs.clear();
         true
     }

--- a/protocols/v2/channels-sv2/src/server/jobs/mod.rs
+++ b/protocols/v2/channels-sv2/src/server/jobs/mod.rs
@@ -1,3 +1,23 @@
+//! Mining job construction - Mining Server Abstraction.
+//!
+//! This module provides submodules and traits for representing, constructing, and managing
+//! Extended and Standard mining jobs in Stratum V2 (SV2) mining servers.
+//!
+//! ## Responsibilities
+//!
+//! - **Error Handling**: See [`error`] submodule for job-related error types.
+//! - **Extended Jobs**: See [`extended`] submodule for SV2 extended job implementation.
+//! - **Standard Jobs**: See [`standard`] submodule for SV2 standard job implementation.
+//! - **Job Factories**: See [`factory`] for job creation logic and unique job ID assignment.
+//! - **Job Storage**: See [`job_store`] for job lifecycle management and storage abstractions.
+//! - **Job Origin Tracking**: Tracks job origin (template or custom job message).
+//! - **Job Trait**: Unified trait for all mining job types, supporting activation and job ID
+//!   retrieval.
+//!
+//! ## Usage
+//!
+//! Use these abstractions for implementing mining server job management and SV2 protocol logic.
+
 pub mod error;
 pub mod extended;
 pub mod factory;
@@ -13,7 +33,14 @@ pub enum JobOrigin<'a> {
     SetCustomMiningJob(SetCustomMiningJob<'a>),
 }
 
+/// Trait for mining job types in SV2 mining servers.
+///
+/// Types implementing `Job` must provide a unique job ID and support activation upon chain tip
+/// update.
 pub trait Job: Send + Sync {
+    /// Returns the unique job ID for this job.
     fn get_job_id(&self) -> u32;
+
+    /// Activates the job for a new chain tip or prev_hash header timestamp.
     fn activate(&mut self, prev_hash_header_timestamp: u32);
 }

--- a/protocols/v2/channels-sv2/src/server/mod.rs
+++ b/protocols/v2/channels-sv2/src/server/mod.rs
@@ -1,4 +1,4 @@
-//! Abstractions for channels to be used by mining servers.
+//! Sv2 channels - Mining Servers Abstraction.
 
 pub mod error;
 pub mod extended;

--- a/protocols/v2/channels-sv2/src/server/share_accounting.rs
+++ b/protocols/v2/channels-sv2/src/server/share_accounting.rs
@@ -1,4 +1,22 @@
-//! Abstractions for share validation for a Mining Server
+//! Share Validation - Mining Server Abstraction.
+//!
+//! This module provides types and logic for validating mining shares and tracking share accounting
+//! state on a mining server. It is used to determine the outcome of submitted shares, track
+//! duplicate submissions, maintain batch acknowledgment state, and compute share statistics for
+//! downstream Stratum V2 (SV2) messaging.
+//!
+//! ## Responsibilities
+//!
+//! - **Share Validation Result**: Encapsulates the result of validating a mining share, including
+//!   success, batch acknowledgment, and block discovery.
+//! - **Share Validation Error**: Enumerates possible failure reasons when validating a share.
+//! - **Share Accounting**: Tracks per-channel share statistics, acknowledges batches, detects
+//!   duplicate shares, and maintains best difficulty found.
+//!
+//! ## Usage
+//!
+//! Intended for use within mining server implementations that process SV2 share submissions and
+//! issue `SubmitShares.Success` messages. Not intended for use by mining clients.
 
 use bitcoin::hashes::sha256d::Hash;
 use std::collections::HashSet;
@@ -19,31 +37,47 @@ use std::collections::HashSet;
 /// where `template_id` is `None` if the share is for a custom job.
 #[derive(Debug)]
 pub enum ShareValidationResult {
+    /// The share is valid and accepted.
     Valid,
-    // last_sequence_number, new_submits_accepted_count, new_shares_sum
+    /// The share is valid and triggers a batch acknowledgment.
+    /// Contains:
+    /// - `last_sequence_number`: The sequence number of the last accepted share in the batch.
+    /// - `new_submits_accepted_count`: The number of new shares accepted in this batch.
+    /// - `new_shares_sum`: The total work contributed by shares in this batch.
     ValidWithAcknowledgement(u32, u32, u64),
-    // template_id, coinbase
-    // template_id is None if custom job
+    /// The share solves a block.
+    /// Contains:
+    /// - `template_id`: The template ID associated with the job, or `None` for custom jobs.
+    /// - `coinbase`: The serialized coinbase transaction for the block.
     BlockFound(Option<u64>, Vec<u8>),
 }
 
-/// The error variants that can occur during share validation
+/// The error variants that can occur during share validation.
 #[derive(Debug)]
 pub enum ShareValidationError {
+    /// The share is invalid for unspecified reasons.
     Invalid,
+    /// The share is stale due to chain tip changes.
     Stale,
+    /// The submitted job ID does not refer to any known job for this channel.
     InvalidJobId,
+    /// The share does not meet the required target difficulty.
     DoesNotMeetTarget,
+    /// The submitted share attempts version rolling when not allowed.
     VersionRollingNotAllowed,
+    /// The share is a duplicate of a previously accepted share.
     DuplicateShare,
+    /// The coinbase transaction was invalid or malformed.
     InvalidCoinbase,
+    /// No chain tip is set for the channel (required for share validation).
     NoChainTip,
 }
 
-/// The state of share validation on the context of some specific channel (either Extended or
-/// Standard)
+/// The state of share validation in the context of some specific channel (either Extended or
+/// Standard).
 ///
-/// Only meant for usage on Mining Servers.
+/// This struct manages per-channel share statistics, batch acknowledgment, duplicate detection,
+/// and difficulty tracking. Only meant for usage on Mining Servers.
 #[derive(Clone, Debug)]
 pub struct ShareAccounting {
     last_share_sequence_number: u32,
@@ -55,6 +89,9 @@ pub struct ShareAccounting {
 }
 
 impl ShareAccounting {
+    /// Constructs a new `ShareAccounting` instance for a channel.
+    ///
+    /// `share_batch_size` controls how many accepted shares trigger a batch acknowledgment.
     pub fn new(share_batch_size: usize) -> Self {
         Self {
             last_share_sequence_number: 0,
@@ -66,6 +103,11 @@ impl ShareAccounting {
         }
     }
 
+    /// Updates internal accounting for a newly accepted share.
+    ///
+    /// - Increments total shares accepted and work sum.
+    /// - Updates last accepted sequence number.
+    /// - Records the share hash to detect duplicates.
     pub fn update_share_accounting(
         &mut self,
         share_work: u64,
@@ -78,45 +120,50 @@ impl ShareAccounting {
         self.seen_shares.insert(share_hash);
     }
 
-    /// clears the hashset of seen shares
+    /// Clears the set of seen share hashes.
     ///
-    /// should be called on every chain tip update
-    /// to avoid unbounded growth of memory
+    /// Should be called on every chain tip update to avoid unbounded growth of memory
+    /// and allow new shares for the new tip.
     pub fn flush_seen_shares(&mut self) {
         self.seen_shares.clear();
     }
 
+    /// Returns the sequence number of the last accepted share.
     pub fn get_last_share_sequence_number(&self) -> u32 {
         self.last_share_sequence_number
     }
 
+    /// Returns the total number of shares accepted on this channel.
     pub fn get_shares_accepted(&self) -> u32 {
         self.shares_accepted
     }
 
+    /// Returns the sum of work contributed by all accepted shares.
     pub fn get_share_work_sum(&self) -> u64 {
         self.share_work_sum
     }
 
+    /// Returns the configured batch size for share acknowledgments.
     pub fn get_share_batch_size(&self) -> usize {
         self.share_batch_size
     }
 
+    /// Returns true if the current count of accepted shares triggers an acknowledgment.
     pub fn should_acknowledge(&self) -> bool {
         self.shares_accepted % self.share_batch_size as u32 == 0
     }
 
-    /// Checks if the share has been seen.
-    /// Useful to avoid duplicate shares.
+    /// Checks if the share hash has already been accepted (duplicate detection).
     pub fn is_share_seen(&self, share_hash: Hash) -> bool {
         self.seen_shares.contains(&share_hash)
     }
 
+    /// Returns the highest difficulty found among accepted shares.
     pub fn get_best_diff(&self) -> f64 {
         self.best_diff
     }
 
-    /// Updates the best diff if the new diff is higher.
+    /// Updates the best difficulty if the new value is higher.
     pub fn update_best_diff(&mut self, diff: f64) {
         if diff > self.best_diff {
             self.best_diff = diff;

--- a/protocols/v2/channels-sv2/src/target.rs
+++ b/protocols/v2/channels-sv2/src/target.rs
@@ -1,3 +1,5 @@
+//! Helper functions related to [`Target`]
+
 use binary_sv2::U256;
 use bitcoin::{hash_types::BlockHash, hashes::Hash};
 use mining_sv2::Target;
@@ -43,8 +45,8 @@ pub fn u256_to_block_hash(v: U256<'static>) -> BlockHash {
     BlockHash::from_raw_hash(hash)
 }
 
-// Helper function to format bytes as hex string
-// useful for visualizing targets
+/// Helper function to format bytes as hex string
+/// useful for visualizing targets
 pub fn bytes_to_hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
     for &b in bytes {

--- a/protocols/v2/channels-sv2/src/template.rs
+++ b/protocols/v2/channels-sv2/src/template.rs
@@ -1,3 +1,4 @@
+//! Utility to deserialize outputs from a `NewTemplate` message.
 use bitcoin::{consensus::Decodable, transaction::TxOut};
 use std::io::Cursor;
 


### PR DESCRIPTION
closes #1810 

Add missing rust docs for:
- `protocols::v2::channels_sv2`
- `protocols::v2::channels_sv2::server`
- `protocols::v2::channels_sv2::client`
- removed `set_active_job` from trait `JobStore` and replace it with `add_active_job` where needed.

Addresses a few typos