### PR TITLE
bump: `sv1_api` v1.0.1 → v2.0.0

### DIFF
--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -1129,7 +1129,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",

--- a/protocols/v1/Cargo.toml
+++ b/protocols/v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sv1_api"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2018"
 readme = "README.md"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -2512,7 +2512,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -18,7 +18,7 @@ async-std = { version = "1.8.0", optional = true }
 async-channel = { version = "1.8.0", optional = true }
 tokio = { version = "1.44.1", features = ["full"] }
 codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^2.0.0", features=["noise_sv2"], optional = true }
-sv1_api = { path = "../../../protocols/v1/", version = "^1.0.0", optional = true }
+sv1_api = { path = "../../../protocols/v1/", version = "^2.0.0", optional = true }
 tracing = { version = "0.1" }
 futures = "0.3.28"
 tokio-util = { version = "0.7.10", default-features = false, features = ["codec"], optional = true }

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -2336,7 +2336,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",


### PR DESCRIPTION
Closes #1819 