### PR TITLE
run clippy and fmt across codebase

### DIFF
--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -227,9 +227,9 @@ pub trait IsServer<'a> {
     // {"params":["00003000"], "id":null, "method": "mining.set_version_mask"}
     // fn update_version_rolling_mask
 
-    fn notify(&mut self) -> Result<json_rpc::Message, Error>;
+    fn notify(&mut self) -> Result<json_rpc::Message, Error<'_>>;
 
-    fn handle_set_difficulty(&mut self, value: f64) -> Result<json_rpc::Message, Error> {
+    fn handle_set_difficulty(&mut self, value: f64) -> Result<json_rpc::Message, Error<'_>> {
         let set_difficulty = server_to_client::SetDifficulty { value };
         Ok(set_difficulty.into())
     }
@@ -421,7 +421,7 @@ pub trait IsClient<'a> {
 
     fn status(&self) -> ClientStatus;
 
-    fn last_notify(&self) -> Option<server_to_client::Notify>;
+    fn last_notify(&self) -> Option<server_to_client::Notify<'_>>;
 
     /// Check if the given user_name has been authorized by the server
     #[allow(clippy::ptr_arg)]
@@ -464,7 +464,7 @@ pub trait IsClient<'a> {
         id: u64,
         name: String,
         password: String,
-    ) -> Result<json_rpc::Message, Error> {
+    ) -> Result<json_rpc::Message, Error<'_>> {
         match self.status() {
             ClientStatus::Init => Err(Error::IncorrectClientStatus("mining.authorize".to_string())),
             _ => Ok(client_to_server::Authorize { id, name, password }.into()),
@@ -559,7 +559,7 @@ mod tests {
             true
         }
 
-        fn notify(&mut self) -> Result<json_rpc::Message, Error> {
+        fn notify(&mut self) -> Result<json_rpc::Message, Error<'_>> {
             Ok(json_rpc::Message::StandardRequest(
                 json_rpc::StandardRequest {
                     id: 1,

--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -960,7 +960,7 @@ impl ProxyExtendedChannelFactory {
         request_id: u32,
         hash_rate: f32,
         min_extranonce_size: u16,
-    ) -> Result<Vec<Mining>, Error> {
+    ) -> Result<Vec<Mining<'_>>, Error> {
         self.inner
             .new_extended_channel(request_id, hash_rate, min_extranonce_size)
     }

--- a/protocols/v2/subprotocols/mining/src/lib.rs
+++ b/protocols/v2/subprotocols/mining/src/lib.rs
@@ -266,7 +266,7 @@ impl Extranonce {
     // B032 type is more used, this is why the output signature is not ExtendedExtranoncee the B032
     // type is more used, this is why the output signature is not ExtendedExtranoncee
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Option<B032> {
+    pub fn next(&mut self) -> Option<B032<'_>> {
         increment_bytes_be(&mut self.extranonce).ok()?;
         // below unwraps never panics
         Some(self.extranonce.clone().try_into().unwrap())

--- a/roles/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/pool/src/lib/mining_pool/message_handler.rs
@@ -559,7 +559,7 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
                 channel_id,
                 maximum_target: new_target.clone().into(),
             };
-            return Ok(SendTo::Respond(Mining::SetTarget(set_target)));
+            Ok(SendTo::Respond(Mining::SetTarget(set_target)))
         } else {
             error!("UpdateChannelError: invalid-channel-id");
             let update_channel_error = UpdateChannelError {
@@ -569,9 +569,9 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
                     .try_into()
                     .expect("error code must be valid string"),
             };
-            return Ok(SendTo::Respond(Mining::UpdateChannelError(
+            Ok(SendTo::Respond(Mining::UpdateChannelError(
                 update_channel_error,
-            )));
+            )))
         }
     }
 

--- a/roles/test-utils/mining-device-sv1/src/client.rs
+++ b/roles/test-utils/mining-device-sv1/src/client.rs
@@ -462,7 +462,7 @@ impl IsClient<'static> for Client {
         id: u64,
         name: String,
         password: String,
-    ) -> Result<json_rpc::Message, Error> {
+    ) -> Result<json_rpc::Message, Error<'_>> {
         match self.status() {
             ClientStatus::Init => Err(Error::IncorrectClientStatus("mining.authorize".to_string())),
             _ => {
@@ -472,7 +472,7 @@ impl IsClient<'static> for Client {
         }
     }
 
-    fn last_notify(&self) -> Option<server_to_client::Notify> {
+    fn last_notify(&self) -> Option<server_to_client::Notify<'_>> {
         None
     }
 

--- a/roles/translator/src/lib/downstream_sv1/downstream.rs
+++ b/roles/translator/src/lib/downstream_sv1/downstream.rs
@@ -702,7 +702,7 @@ impl IsServer<'static> for Downstream {
         self.version_rolling_min_bit = mask
     }
 
-    fn notify(&mut self) -> Result<json_rpc::Message, v1::error::Error> {
+    fn notify(&mut self) -> Result<json_rpc::Message, v1::error::Error<'_>> {
         unreachable!()
     }
 }

--- a/test/integration-tests/lib/mod.rs
+++ b/test/integration-tests/lib/mod.rs
@@ -51,7 +51,7 @@ pub fn start_sniffer(
     check_on_drop: bool,
     action: Vec<InterceptAction>,
     timeout: Option<u64>,
-) -> (Sniffer, SocketAddr) {
+) -> (Sniffer<'_>, SocketAddr) {
     let listening_address = get_available_address();
     let sniffer = Sniffer::new(
         identifier,


### PR DESCRIPTION
closes #1829 

rust had a release few hours ago : https://github.com/rust-lang/rust/releases/tag/1.89.0

The changes on this PR are the result of `clippy` and `fmt` updated for the new release 