### PR TITLE
downgrade `roles_logic_sv2` to 4.0.0

### DIFF
--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "roles_logic_sv2"
-version = "5.0.0"
+version = "4.0.0"
 dependencies = [
  "bitcoin",
  "chacha20poly1305",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/stratum-mining/stratum"
 
 [dependencies]
-roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2", version = "5.0.0" }
+roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2", version = "4.0.0" }
 network_helpers_sv2 = { path = "../roles/roles-utils/network-helpers", version = "4.0.0", features = ["with_buffer_pool"], optional = true }
 
 [features]

--- a/protocols/v2/roles-logic-sv2/Cargo.toml
+++ b/protocols/v2/roles-logic-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roles_logic_sv2"
-version = "5.0.0"
+version = "4.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Common handlers for use within SV2 roles"

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "roles_logic_sv2"
-version = "5.0.0"
+version = "4.0.0"
 dependencies = [
  "bitcoin",
  "chacha20poly1305",

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "roles_logic_sv2"
-version = "5.0.0"
+version = "4.0.0"
 dependencies = [
  "bitcoin",
  "chacha20poly1305",

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -1044,7 +1044,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roles_logic_sv2"
-version = "5.0.0"
+version = "4.0.0"
 dependencies = [
  "bitcoin",
  "chacha20poly1305",


### PR DESCRIPTION
This PR downgrades `roles_logic_sv2` to 4.0.0 since it has been MAJOR bumped twice during this milestone, while its latest [published version](https://crates.io/crates/roles_logic_sv2) is 3.0.0:
- from 3.0.0 to 4.0.0 --> https://github.com/stratum-mining/stratum/commit/cb250ac1feaf847a55b6c20c4915b9c0529b7465
- from 4.0.0 to 5.0.0 --> https://github.com/stratum-mining/stratum/commit/fd01573f4b8ff987566512fc0b7f4b7b4eb8ab54