### PR TITLE
feat: add set_chain_tip method to client channels' APIs

### DIFF
--- a/protocols/v2/channels-sv2/src/client/extended.rs
+++ b/protocols/v2/channels-sv2/src/client/extended.rs
@@ -114,6 +114,10 @@ impl<'a> ExtendedChannel<'a> {
         self.chain_tip.as_ref()
     }
 
+    pub fn set_chain_tip(&mut self, chain_tip: ChainTip) {
+        self.chain_tip = Some(chain_tip);
+    }
+
     /// Sets the extranonce prefix.
     ///
     /// Note: after this, all new jobs will be associated with the new extranonce prefix.

--- a/protocols/v2/channels-sv2/src/client/standard.rs
+++ b/protocols/v2/channels-sv2/src/client/standard.rs
@@ -89,6 +89,10 @@ impl<'a> StandardChannel<'a> {
         self.chain_tip.as_ref()
     }
 
+    pub fn set_chain_tip(&mut self, chain_tip: ChainTip) {
+        self.chain_tip = Some(chain_tip);
+    }
+
     pub fn set_extranonce_prefix(
         &mut self,
         extranonce_prefix: Vec<u8>,


### PR DESCRIPTION
This PR adds a new public method to client channels' APIs called `set_chain_tip`.

This is useful for the new tProxy during new channels initialization, and it could be useful for other future applications as well.