### PR TITLE
Turns `channel_sv2::client::*` `no_std` compatible

### DIFF
--- a/protocols/v2/channels-sv2/Cargo.toml
+++ b/protocols/v2/channels-sv2/Cargo.toml
@@ -22,3 +22,9 @@ job_declaration_sv2 = { path = "../subprotocols/job-declaration", version = "^4.
 tracing = { version = "0.1"}
 bitcoin = { version = "0.32.5" }
 primitive-types = "0.13.1"
+hashbrown = { version = "0.15.5", optional = true }
+
+
+[features]
+default = []
+no_std = ["hashbrown"]

--- a/protocols/v2/channels-sv2/README.md
+++ b/protocols/v2/channels-sv2/README.md
@@ -9,3 +9,9 @@
 `channels_sv2` provides primitives and abstractions for Stratum V2 (Sv2) Channels.
 
 This crate implements the core channel management functionality for both mining clients and servers, including standard, extended and group channels, and share accounting mechanisms.
+
+The `client` module is compatible with `no_std` environments. To enable this mode, build the crate with the `no_std` feature. In this configuration, standard library collections are replaced with the `hashbrown` crate, together with `core` and `alloc`, allowing the module to be used in embedded or constrained contexts.
+
+```bash
+cargo build --features no_std
+```

--- a/protocols/v2/channels-sv2/src/bip141.rs
+++ b/protocols/v2/channels-sv2/src/bip141.rs
@@ -1,9 +1,12 @@
 //! Provides functionality to strip coinbase_tx_prefix and coinbase_tx_suffix from bip141 marker,
 //! flag and witness data.
+extern crate alloc;
+
+use alloc::vec::Vec;
 use bitcoin::{blockdata::transaction::Transaction, consensus::Decodable};
 use mining_sv2::FULL_EXTRANONCE_LEN;
 
-use std::io::Cursor;
+use bitcoin::io::Cursor;
 
 const MARKER_FLAG_OFFSET: usize = 4;
 const MARKER_FLAG_LEN: usize = 2;

--- a/protocols/v2/channels-sv2/src/client/extended.rs
+++ b/protocols/v2/channels-sv2/src/client/extended.rs
@@ -3,6 +3,8 @@
 //! This module provides an abstraction over the state of an [Sv2](https://stratumprotocol.org/specification)
 //! **Extended Channel** within a mining client.
 
+extern crate alloc;
+use super::HashMap;
 use crate::{
     bip141::try_strip_bip141,
     chain_tip::ChainTip,
@@ -13,6 +15,7 @@ use crate::{
     merkle_root::merkle_root_from_path,
     target::{bytes_to_hex, target_to_difficulty, u256_to_block_hash},
 };
+use alloc::{format, string::String, vec, vec::Vec};
 use binary_sv2::{self, Sv2Option};
 use bitcoin::{
     blockdata::block::{Header, Version},
@@ -23,7 +26,6 @@ use mining_sv2::{
     NewExtendedMiningJob, SetNewPrevHash as SetNewPrevHashMp, SubmitSharesExtended, Target,
     FULL_EXTRANONCE_LEN,
 };
-use std::{collections::HashMap, convert::TryInto};
 use tracing::debug;
 
 /// A type alias representing an extended mining job tied to a specific `extranonce_prefix`.

--- a/protocols/v2/channels-sv2/src/client/group.rs
+++ b/protocols/v2/channels-sv2/src/client/group.rs
@@ -4,9 +4,10 @@
 //! abstraction over the state of a Sv2 group channel. It tracks group-level job state
 //! and associated standard channels, but delegates share validation and job lifecycle
 //! to standard channels.
+
+use super::{HashMap, HashSet};
 use crate::client::error::GroupChannelError;
 use mining_sv2::{NewExtendedMiningJob, SetNewPrevHash as SetNewPrevHashMp};
-use std::collections::{HashMap, HashSet};
 
 /// Mining Client abstraction over the state of an Sv2 Group Channel.
 ///

--- a/protocols/v2/channels-sv2/src/client/mod.rs
+++ b/protocols/v2/channels-sv2/src/client/mod.rs
@@ -5,3 +5,14 @@ pub mod extended;
 pub mod group;
 pub mod share_accounting;
 pub mod standard;
+
+// Type aliases that switch between `std::collections` and `hashbrown`
+// depending on whether the `no_std` feature is enabled.
+#[cfg(not(feature = "no_std"))]
+type HashMap<K, V> = std::collections::HashMap<K, V>;
+#[cfg(not(feature = "no_std"))]
+type HashSet<T> = std::collections::HashSet<T>;
+#[cfg(feature = "no_std")]
+type HashMap<K, V> = hashbrown::HashMap<K, V>;
+#[cfg(feature = "no_std")]
+type HashSet<T> = hashbrown::HashSet<T>;

--- a/protocols/v2/channels-sv2/src/client/mod.rs
+++ b/protocols/v2/channels-sv2/src/client/mod.rs
@@ -1,4 +1,9 @@
 //! Sv2 channels - Mining Clients Abstractions.
+//!
+//! The `client` module is compatible with `no_std` environments. To enable this mode, build the
+//! crate with the `no_std` feature. In this configuration, standard library collections are
+//! replaced with the `hashbrown` crate, together with `core` and `alloc`, allowing the module to be
+//! used in embedded or constrained contexts.
 
 pub mod error;
 pub mod extended;

--- a/protocols/v2/channels-sv2/src/client/share_accounting.rs
+++ b/protocols/v2/channels-sv2/src/client/share_accounting.rs
@@ -3,8 +3,9 @@
 //! This module provides types and logic for validating mining shares, tracking share
 //! statistics, and reporting share validation results and errors. These abstractions
 //! are intended for use in Mining Clients.
+
+use super::HashSet;
 use bitcoin::hashes::sha256d::Hash;
-use std::collections::HashSet;
 
 /// The outcome of share validation, as seen by a Mining Client.
 ///

--- a/protocols/v2/channels-sv2/src/client/standard.rs
+++ b/protocols/v2/channels-sv2/src/client/standard.rs
@@ -4,6 +4,8 @@
 //! client's Sv2 Standard Channel. It tracks channel-level job management, share accounting,
 //! and chain tip state, enabling share validation and mining job lifecycle management.
 
+extern crate alloc;
+use super::HashMap;
 use crate::{
     chain_tip::ChainTip,
     client::{
@@ -13,6 +15,7 @@ use crate::{
     merkle_root::merkle_root_from_path,
     target::{bytes_to_hex, target_to_difficulty, u256_to_block_hash},
 };
+use alloc::{format, string::String, vec::Vec};
 use binary_sv2::{self, Sv2Option};
 use bitcoin::{
     blockdata::block::{Header, Version},
@@ -23,7 +26,6 @@ use mining_sv2::{
     NewExtendedMiningJob, NewMiningJob, SetNewPrevHash as SetNewPrevHashMp, SubmitSharesStandard,
     Target, FULL_EXTRANONCE_LEN,
 };
-use std::{collections::HashMap, convert::TryInto};
 use tracing::debug;
 
 /// Mining Client abstraction over the state of a Sv2 Standard Channel.
@@ -197,7 +199,6 @@ impl<'a> StandardChannel<'a> {
     pub fn on_new_mining_job(&mut self, new_mining_job: NewMiningJob<'a>) {
         match new_mining_job.min_ntime.clone().into_inner() {
             Some(_min_ntime) => {
-                println!();
                 if let Some(active_job) = self.active_job.as_ref() {
                     self.past_jobs.insert(active_job.job_id, active_job.clone());
                 }

--- a/protocols/v2/channels-sv2/src/lib.rs
+++ b/protocols/v2/channels-sv2/src/lib.rs
@@ -12,11 +12,16 @@
 //! - Standard, extended, and group channel support
 //! - Share accounting
 //! - Job store abstractions
+#![cfg_attr(feature = "no_std", no_std)]
+
+#[cfg(not(feature = "no_std"))]
+pub mod server;
+
+#[cfg(not(feature = "no_std"))]
+pub mod template;
 
 pub mod bip141;
 pub mod chain_tip;
 pub mod client;
 mod merkle_root;
-pub mod server;
 pub mod target;
-pub mod template;

--- a/protocols/v2/channels-sv2/src/lib.rs
+++ b/protocols/v2/channels-sv2/src/lib.rs
@@ -12,6 +12,7 @@
 //! - Standard, extended, and group channel support
 //! - Share accounting
 //! - Job store abstractions
+//! - [`client`] module is `no_std` compatible. To enable it build the crate with `no_std` feature.
 #![cfg_attr(feature = "no_std", no_std)]
 
 #[cfg(not(feature = "no_std"))]

--- a/protocols/v2/channels-sv2/src/merkle_root.rs
+++ b/protocols/v2/channels-sv2/src/merkle_root.rs
@@ -1,3 +1,6 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
 use bitcoin::{
     consensus,
     hashes::{sha256d::Hash as DHash, Hash},
@@ -33,7 +36,6 @@ pub fn merkle_root_from_path<T: AsRef<[u8]>>(
         Ok(trans) => trans,
         Err(e) => {
             error!("ERROR: {}", e);
-            dbg!(e);
             return None;
         }
     };

--- a/protocols/v2/channels-sv2/src/target.rs
+++ b/protocols/v2/channels-sv2/src/target.rs
@@ -1,11 +1,12 @@
 //! Helper functions related to [`Target`]
 
+extern crate alloc;
+use alloc::string::String;
 use binary_sv2::U256;
 use bitcoin::{hash_types::BlockHash, hashes::Hash};
+use core::{cmp::max, fmt::Write, ops::Div};
 use mining_sv2::Target;
 use primitive_types::U256 as U256Primitive;
-use std::{cmp::max, convert::TryInto, fmt::Write, ops::Div};
-
 /// Converts a `Target` to a `f64` difficulty.
 pub fn target_to_difficulty(target: Target) -> f64 {
     // Genesis block target: 0x00000000ffff0000000000000000000000000000000000000000000000000000

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -201,7 +201,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-executor",
  "async-io",
  "async-lock",
@@ -496,11 +496,11 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1221,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashlink"
@@ -1395,7 +1395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashlink"
@@ -1250,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hermit-abi"
@@ -682,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "job_declaration_sv2"
@@ -752,9 +752,9 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -803,9 +803,9 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -1076,9 +1076,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",


### PR DESCRIPTION
closes #1822 ;

- Adds `hashbrown ` to replace `HashMap` and `HashSet`
- Replacing `std::io::Cursor` with `bitcoin::io::Cursor`
- Replacing `std` types and macros with `alloc` equivalents.

Updated auxiliary modules ( like merkle_root, bip141) to be `no_std` compatible types because `channels_sv2` depends on them.