### PR TITLE
chore: Clippy update

### DIFF
--- a/.github/workflows/clippy-lint.yaml
+++ b/.github/workflows/clippy-lint.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.89
           override: true
           components: clippy
       - name: Run Clippy on different workspaces and crates


### PR DESCRIPTION
Some Clippy nightly features have recently become stable, which is causing errors in our CI:

1. https://github.com/stratum-mining/stratum/actions/runs/17832897854/job/50702408733

As noted here: https://github.com/stratum-mining/stratum/pull/1888#issuecomment-3308120510, we can’t update our repository to use the latest stable Clippy without breaking MSRV. I have locked clippy check to 1.89 on CI.