### PR TITLE
Add close channel method to pool

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
+++ b/protocols/v2/roles-logic-sv2/src/handlers/mining.rs
@@ -178,6 +178,7 @@ where
                 }
                 _ => Err(Error::UnexpectedMessage(MESSAGE_TYPE_SET_CUSTOM_MINING_JOB)),
             },
+            Ok(Mining::CloseChannel(m)) => self_mutex.safe_lock(|x| x.handle_close_channel(m))?,
             Ok(_) => Err(Error::UnexpectedMessage(0)),
             Err(e) => Err(e),
         }
@@ -230,6 +231,9 @@ where
     /// This method processes a `SetCustomMiningJob` message and applies the custom mining job
     /// settings.
     fn handle_set_custom_mining_job(&mut self, m: SetCustomMiningJob) -> Result<SendTo<Up>, Error>;
+
+    /// Handles a request to close a mining channel.
+    fn handle_close_channel(&mut self, m: CloseChannel) -> Result<SendTo<Up>, Error>;
 }
 
 /// A trait defining the parser for upstream mining messages used by a downstream.

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -909,7 +909,7 @@ impl ParseMiningMessagesFromDownstream<UpstreamMiningNode> for DownstreamMiningN
         &mut self,
         m: CloseChannel,
     ) -> Result<SendTo<UpstreamMiningNode>, Error> {
-        info!("Received Close Channle: {m}");
+        info!("Received Close Channel: {m}");
         Ok(SendTo::None(None))
     }
 }

--- a/roles/jd-client/src/lib/downstream.rs
+++ b/roles/jd-client/src/lib/downstream.rs
@@ -903,6 +903,15 @@ impl ParseMiningMessagesFromDownstream<UpstreamMiningNode> for DownstreamMiningN
         warn!("Ignoring SetCustomMiningJob");
         Ok(SendTo::None(None))
     }
+
+    /// Handle close channel
+    fn handle_close_channel(
+        &mut self,
+        m: CloseChannel,
+    ) -> Result<SendTo<UpstreamMiningNode>, Error> {
+        info!("Received Close Channle: {m}");
+        Ok(SendTo::None(None))
+    }
 }
 
 impl ParseCommonMessagesFromDownstream for DownstreamMiningNode {

--- a/roles/pool/src/lib/mining_pool/message_handler.rs
+++ b/roles/pool/src/lib/mining_pool/message_handler.rs
@@ -998,4 +998,12 @@ impl ParseMiningMessagesFromDownstream<()> for Downstream {
         };
         Ok(SendTo::Respond(Mining::SetCustomMiningJobSuccess(success)))
     }
+
+    fn handle_close_channel(&mut self, m: CloseChannel) -> Result<SendTo<()>, Error> {
+        info!("Received Close Channel: {m}");
+        self.extended_channels.remove(&m.channel_id);
+        self.standard_channels.remove(&m.channel_id);
+        self.vardiff.remove(&m.channel_id);
+        Ok(SendTo::None(None))
+    }
 }


### PR DESCRIPTION
This PR extends the legacy HandlerSv2 (old) trait `ParseMiningMessagesFromDownstream` to support `CloseChannel` message. While we could update the Pool to use the new HandlerSv2 APIs, doing so would require removing a significant amount of existing code. Instead, this PR adds CloseChannel handling to all required implementors (such as Pool and the legacy JDC).