### PR TITLE
fix: correct typo 'Startum' to 'Stratum' in V1 protocol documentation

### DIFF
--- a/protocols/v1/src/lib.rs
+++ b/protocols/v1/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::result_unit_err)]
-//! Startum V1 application protocol:
+//! Stratum V1 application protocol:
 //!
 //! json-rpc has two types of messages: **request** and **response**.
 //! A request message can be either a **notification** or a **standard message**.


### PR DESCRIPTION
### Fix typo: "Startum" should be "Stratum" in V1 protocol documentation
closes #1892
