### PR TITLE
rfc: add metal GPU miner (native sv2)

### DIFF
--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -581,6 +581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +924,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
 name = "corepc-client"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1251,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "framing_sv2"
@@ -1900,9 +1944,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libredox"
@@ -1953,6 +1997,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +2021,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "metal"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.9.4",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +2045,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "mining_device"
 version = "0.1.3"
 dependencies = [
+ "anyhow",
  "async-channel 1.9.0",
  "async-recursion 0.3.2",
  "buffer_sv2",
@@ -1985,6 +2054,7 @@ dependencies = [
  "futures",
  "half",
  "key-utils",
+ "metal",
  "num-format",
  "num_cpus",
  "primitive-types",
@@ -2165,6 +2235,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2364,12 @@ dependencies = [
  "mining_sv2",
  "template_distribution_sv2",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"

--- a/roles/test-utils/mining-device/Cargo.toml
+++ b/roles/test-utils/mining-device/Cargo.toml
@@ -1,3 +1,10 @@
+[features]
+default = []
+# Enable Metal GPU support on macOS (enables optional dep "metal")
+gpu-metal = ["metal"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+metal = { version = "0.27", optional = true }
 [package]
 name = "mining_device"
 version = "0.1.3"
@@ -34,6 +41,7 @@ sha2 = { version = "0.10.6", features = ["compress", "asm"] }
 tokio = "1.44.1"
 primitive-types = "0.13.1"
 num-format = "0.4"
+anyhow = "1"
 
 [dev-dependencies]
 # Criterion 0.5 without default features; combined with a dev pin of `half = 2.3.1` to stay Rust 1.75-compatible.
@@ -52,3 +60,8 @@ harness = false
 [[bench]]
 name = "scaling_bench"
 harness = false
+
+[[bench]]
+name = "gpu_metal_bench"
+harness = false
+required-features = ["gpu-metal"]

--- a/roles/test-utils/mining-device/README.md
+++ b/roles/test-utils/mining-device/README.md
@@ -85,7 +85,10 @@ This setting only affects the CPU loop structure; it does not change the hash fu
 
 By default, the miner uses one worker thread per logical CPU minus one (N-1). This leaves a core available for the operating system and scheduling overhead.
 
-You can override this with `--cores <N>`, clamped between `1` and the number of logical CPUs.
+You can override this with `--cores <N>`, clamped between `0` and the number of logical CPUs.
+
+- If you pass `--cores 0`, CPU workers are disabled. This is useful for GPU-only testing when built with the `gpu-metal` feature on macOS.
+- When the GPU path is enabled (built with `--features gpu-metal` on macOS), the miner reserves two CPU cores by default to feed the GPU and the OS, unless `--cores` explicitly sets a value.
 
 Examples:
 
@@ -123,6 +126,26 @@ MINING_DEVICE_BATCH_SIZES=1,4,8,16,32,64,128 cargo bench --bench microbatch_benc
 ```
 
 Tip: pick the smallest `N` that gives you near-peak throughput to keep share-finding latency low.
+
+## Optional: GPU mining (macOS Metal)
+
+On macOS, you can use a simple GPU mining path via Metal. This is experimental and feature-gated.
+
+- Build with feature: add `--features gpu-metal` to your cargo command. When built with this feature, the GPU path is enabled automatically.
+
+Examples:
+
+```zsh
+# Run with GPU enabled (requires macOS and Metal feature)
+RUST_LOG=info cargo run --release --features gpu-metal -- \
+        --address-pool 127.0.0.1:20000
+
+# Benchmark GPU path only (no pool needed)
+cargo bench --manifest-path roles/test-utils/mining-device/Cargo.toml \
+        --bench gpu_metal_bench --features gpu-metal
+```
+
+When the GPU path is enabled, the miner starts a GPU worker alongside CPU workers and conservatively reserves a couple of CPU cores to feed the GPU.
 
 ### Total scaling (multi-core)
 

--- a/roles/test-utils/mining-device/benches/gpu_metal_bench.rs
+++ b/roles/test-utils/mining-device/benches/gpu_metal_bench.rs
@@ -1,0 +1,110 @@
+#![cfg(all(target_os = "macos", feature = "gpu-metal"))]
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use mining_device::FastSha256d;
+use rand::{thread_rng, Rng};
+use stratum_common::roles_logic_sv2::bitcoin::{
+    block::Version, blockdata::block::Header, hash_types::BlockHash, hashes::Hash, CompactTarget,
+};
+
+fn random_header() -> Header {
+    let mut rng = thread_rng();
+    let prev_hash: [u8; 32] = rng.gen();
+    let prev_hash = Hash::from_byte_array(prev_hash);
+    let merkle_root: [u8; 32] = rng.gen();
+    let merkle_root = Hash::from_byte_array(merkle_root);
+    Header {
+        version: Version::from_consensus(rng.gen::<i32>()),
+        prev_blockhash: BlockHash::from_raw_hash(prev_hash),
+        merkle_root,
+        time: std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH - std::time::Duration::from_secs(60))
+            .unwrap()
+            .as_secs() as u32,
+        bits: CompactTarget::from_consensus(rng.gen()),
+        nonce: 0,
+    }
+}
+
+fn bench_gpu(c: &mut Criterion) {
+    if let Ok((tew, max_tg)) = mining_device::gpu_device_info() {
+        println!(
+            "Metal device: thread_execution_width={tew}, max_total_threads_per_threadgroup={max_tg}"
+        );
+    }
+    let header = random_header();
+    let mut fast = FastSha256d::from_header_static(&header);
+    // Reconstruct inputs for the GPU kernel from the CPU fast-hasher state by doing one hash and
+    // capturing template
+    let time = header.time;
+    let nonce = header.nonce;
+    let _ = fast.hash_with_nonce_time(nonce, time);
+
+    // Unsafe: extract private fields via serialize path again to build block1 and midstate
+    // consistently Rebuild the block1 and midstate with the same logic in
+    // FastSha256d::from_header_static For simplicity in this bench, we redo it locally rather
+    // than exposing internals.
+    let ser = stratum_common::roles_logic_sv2::bitcoin::consensus::encode::serialize(&header);
+    let mut header_bytes = [0u8; 80];
+    header_bytes.copy_from_slice(&ser);
+    let chunk0 = &header_bytes[0..64];
+    let chunk1_last16 = &header_bytes[64..80];
+    let mut state0 = {
+        fn init() -> [u32; 8] {
+            [
+                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+                0x5be0cd19,
+            ]
+        }
+        let mut st = init();
+        let mut block = [0u8; 64];
+        block.copy_from_slice(chunk0);
+        let ga0 = sha2::digest::generic_array::GenericArray::<u8, sha2::digest::typenum::U64>::clone_from_slice(&block);
+        sha2::compress256(&mut st, std::slice::from_ref(&ga0));
+        st
+    };
+    let mut block1 = [0u8; 64];
+    block1[0..16].copy_from_slice(chunk1_last16);
+    block1[16] = 0x80;
+    block1[56..64].copy_from_slice(&640u64.to_be_bytes());
+
+    // Target = zero so we don't trigger real submits; just measure speed
+    let target = [0u8; 32];
+
+    // Convert midstate to host u32 array (already big-endian words per SHA-256 state)
+    let midstate = state0;
+
+    // Sweep thread configurations to find saturation; keep per_thread constant initially
+    let configs: &[(u32, u32)] = &[
+        (1024, 20000),
+        (2048, 20000),
+        (4096, 20000),
+        (8192, 20000),
+        (16384, 20000),
+        (32768, 20000),
+        (65536, 20000),
+        (131072, 20000),
+        (262144, 20000),
+    ];
+    for &(threads, per_thread) in configs {
+        match mining_device::gpu_measure_metal(
+            midstate, block1, target, time, nonce, threads, per_thread,
+        ) {
+            Ok(mhps) => {
+                println!(
+                    "Metal GPU: threads={threads}, per_thread={per_thread} -> ~{mhps:.2} MH/s"
+                );
+            }
+            Err(e) => {
+                println!("Metal GPU init/dispatch failed: {e}");
+            }
+        }
+    }
+    // Also add a trivial criterion marker (not heavily used here)
+    let mut group = c.benchmark_group("gpu_metal_probe");
+    group.bench_function("noop", |b| b.iter(|| 1));
+    group.finish();
+}
+
+criterion_group!(benches, bench_gpu);
+criterion_main!(benches);

--- a/roles/test-utils/mining-device/gpu/sha256d_kernel.metal
+++ b/roles/test-utils/mining-device/gpu/sha256d_kernel.metal
@@ -1,0 +1,115 @@
+using namespace metal;
+
+// Minimal, not constant-time; tuned for readability first.
+// Each thread takes a starting nonce and stride and computes double-SHA256,
+// comparing against a target (little-endian) to mark a found result.
+
+struct GpuParams {
+    uint  midstate[8];      // SHA-256 state after first 64 bytes
+    uint  block1_template[16]; // 64-byte block as 16 u32 words; time and nonce fields will be updated per-thread
+    uint  target_le[8];     // target words, little-endian (u32)
+    uint  time;             // header time
+    uint  start_nonce;      // thread 0 nonce base
+    uint  stride;           // stride between consecutive nonces per-threadgroup
+    uint  count;            // number of nonces per thread
+};
+
+inline uint rotr32(uint x, uint n) { return (x >> n) | (x << (32 - n)); }
+inline uint ch(uint x, uint y, uint z) { return (x & y) ^ (~x & z); }
+inline uint maj(uint x, uint y, uint z) { return (x & y) ^ (x & z) ^ (y & z); }
+inline uint bsig0(uint x) { return rotr32(x, 2) ^ rotr32(x, 13) ^ rotr32(x, 22); }
+inline uint bsig1(uint x) { return rotr32(x, 6) ^ rotr32(x, 11) ^ rotr32(x, 25); }
+inline uint ssig0(uint x) { return rotr32(x, 7) ^ rotr32(x, 18) ^ (x >> 3); }
+inline uint ssig1(uint x) { return rotr32(x, 17) ^ rotr32(x, 19) ^ (x >> 10); }
+
+constant uint K[64] = {
+    0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+    0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+    0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+    0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+    0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+    0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+    0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+    0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
+inline void sha256_compress(uint state[8], thread uint w[64]) {
+    uint a=state[0], b=state[1], c=state[2], d=state[3], e=state[4], f=state[5], g=state[6], h=state[7];
+    for (uint t=0; t<64; ++t) {
+        uint T1 = h + bsig1(e) + ch(e,f,g) + K[t] + w[t];
+        uint T2 = bsig0(a) + maj(a,b,c);
+        h=g; g=f; f=e; e=d + T1; d=c; c=b; b=a; a=T1 + T2;
+    }
+    state[0]+=a; state[1]+=b; state[2]+=c; state[3]+=d; state[4]+=e; state[5]+=f; state[6]+=g; state[7]+=h;
+}
+
+kernel void sha256d_scan(device const GpuParams*        params  [[ buffer(0) ]],
+                         device atomic_uint*            found   [[ buffer(1) ]],
+                         device uint2*                  result  [[ buffer(2) ]],
+                         uint3                          tid     [[ thread_position_in_grid ]]) {
+    const uint idx = tid.x;
+    const uint count = params->count;
+    const uint stride = params->stride;
+    const uint base = params->start_nonce + idx * stride * count;
+
+    for (uint i = 0; i < count; ++i) {
+        uint nonce = base + i * stride;
+
+        // First SHA256: use provided midstate and 64-byte block with time/nonce updated
+        uint w[64];
+        // Prepare message schedule for chunk1 (16 words) from template
+    for (uint t=0; t<16; ++t) { w[t] = params->block1_template[t]; }
+    // SHA-256 operates over big-endian words. Our template is BE; ensure time/nonce are written as BE words.
+    uint t_be = ((params->time & 0x000000FF) << 24) |
+            ((params->time & 0x0000FF00) << 8)  |
+            ((params->time & 0x00FF0000) >> 8)  |
+            ((params->time & 0xFF000000) >> 24);
+    uint n_be = ((nonce & 0x000000FF) << 24) |
+            ((nonce & 0x0000FF00) << 8)  |
+            ((nonce & 0x00FF0000) >> 8)  |
+            ((nonce & 0xFF000000) >> 24);
+    w[1] = t_be;      // offset 4..8 (time)
+    w[3] = n_be;      // offset 12..16 (nonce)
+        for (uint t=16; t<64; ++t) { w[t] = ssig1(w[t-2]) + w[t-7] + ssig0(w[t-15]) + w[t-16]; }
+
+        uint st1[8];
+        for (uint j=0;j<8;++j) st1[j] = params->midstate[j];
+        sha256_compress(st1, w);
+
+        // Second SHA256: build block [digest(32)] + [0x80] + zeros + [len=256]
+        uint w2[64];
+        // st1 words are big-endian words already per spec; reuse directly as 8 words (which is 32 bytes)
+        for (uint t=0; t<8; ++t) w2[t] = st1[t];
+        w2[8] = 0x80000000; // 0x80 then zeros
+        for (uint t=9; t<15; ++t) w2[t] = 0;
+        w2[15] = 256; // length in bits
+        for (uint t=16; t<64; ++t) { w2[t] = ssig1(w2[t-2]) + w2[t-7] + ssig0(w2[t-15]) + w2[t-16]; }
+
+        uint st2[8] = { 0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19 };
+        sha256_compress(st2, w2);
+
+        // Compare little-endian 256-bit hash (Bitcoin-style); st2 words are big-endian, so reverse bytes here
+        // We compare in u32 LE words: reverse each word and then compare from high to low (7..0)
+        bool below = false;
+        bool equal = true;
+        for (int k = 7; k >= 0; --k) {
+            // Manual byte swap (bswap32)
+            uint v = st2[k];
+            uint hw = ((v & 0x000000FF) << 24) |
+                      ((v & 0x0000FF00) << 8)  |
+                      ((v & 0x00FF0000) >> 8)  |
+                      ((v & 0xFF000000) >> 24);
+            uint tw = params->target_le[k];
+            if (hw < tw) { below = true; equal = false; break; }
+            if (hw > tw) { below = false; equal = false; break; }
+        }
+        if (below || equal) {
+            if (atomic_exchange_explicit(found, 1u, memory_order_relaxed) == 0u) {
+                // store nonce and thread index
+                result[0] = uint2(nonce, idx);
+            }
+            return;
+        }
+        if (atomic_load_explicit(found, memory_order_relaxed) != 0u) return;
+    }
+}

--- a/roles/test-utils/mining-device/src/gpu_metal.rs
+++ b/roles/test-utils/mining-device/src/gpu_metal.rs
@@ -1,0 +1,103 @@
+#![cfg(all(target_os = "macos", feature = "gpu-metal"))]
+
+use metal::*;
+use std::mem;
+use std::time::Instant;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct GpuParams {
+    midstate: [u32; 8],
+    block1_template: [u32; 16],
+    target_le: [u32; 8],
+    time: u32,
+    start_nonce: u32,
+    stride: u32,
+    count: u32,
+}
+
+fn u32_from_be_bytes(b: [u8; 4]) -> u32 { u32::from_be_bytes(b) }
+fn u32_from_le_bytes(b: [u8; 4]) -> u32 { u32::from_le_bytes(b) }
+
+pub fn measure_gpu_mhps(
+    midstate: [u32; 8],
+    block1: [u8; 64],
+    target_le: [u8; 32],
+    time_val: u32,
+    start_nonce: u32,
+    threads: u32,
+    per_thread: u32,
+) -> anyhow::Result<f64> {
+    // Prepare Metal device and pipeline
+    let device = Device::system_default().ok_or_else(|| anyhow::anyhow!("No Metal device"))?;
+    let src = include_str!("../gpu/sha256d_kernel.metal");
+    let opts = CompileOptions::new();
+    let lib = device.new_library_with_source(src, &opts)?;
+    let func = lib.get_function("sha256d_scan", None)?;
+    let pipe = device.new_compute_pipeline_state(&func)?;
+
+    let queue = device.new_command_queue();
+
+    // Build GpuParams
+    let mut tmpl_u32 = [0u32; 16];
+    for i in 0..16 {
+        let mut w = [0u8; 4];
+        w.copy_from_slice(&block1[i * 4..i * 4 + 4]);
+        // block words are big-endian as per SHA-256 schedule
+        tmpl_u32[i] = u32_from_be_bytes(w);
+    }
+    let mut tgt_le_u32 = [0u32; 8];
+    for i in 0..8 {
+        let mut w = [0u8; 4];
+        w.copy_from_slice(&target_le[i * 4..i * 4 + 4]);
+        tgt_le_u32[i] = u32_from_le_bytes(w);
+    }
+    let params = GpuParams {
+        midstate,
+        block1_template: tmpl_u32,
+        target_le: tgt_le_u32,
+        time: time_val,
+        start_nonce,
+        stride: 1,
+        count: per_thread,
+    };
+
+    // Buffers
+    let params_buf = device.new_buffer_with_data(
+        &params as *const _ as *const _,
+        mem::size_of::<GpuParams>() as u64,
+        MTLResourceOptions::CPUCacheModeDefaultCache,
+    );
+    let found_buf = device.new_buffer(
+        mem::size_of::<u32>() as u64,
+        MTLResourceOptions::StorageModeShared,
+    );
+    unsafe { *(found_buf.contents() as *mut u32) = 0; }
+    let result_buf = device.new_buffer(
+        mem::size_of::<[u32; 2]>() as u64,
+        MTLResourceOptions::StorageModeShared,
+    );
+
+    // Dispatch
+    let total_threads = threads as usize;
+    let grid = MTLSize { width: total_threads, height: 1, depth: 1 };
+    let tg_size = MTLSize { width: pipe.thread_execution_width() as usize, height: 1, depth: 1 };
+
+    let start = Instant::now();
+    let cmd = queue.new_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+    enc.set_compute_pipeline_state(&pipe);
+    enc.set_buffer(0, Some(&params_buf), 0);
+    enc.set_buffer(1, Some(&found_buf), 0);
+    enc.set_buffer(2, Some(&result_buf), 0);
+    enc.dispatch_threads(grid, tg_size);
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+    let elapsed = start.elapsed();
+
+    let total_hashes = (threads as u64) * (per_thread as u64);
+    let secs = elapsed.as_secs_f64().max(1e-9);
+    let mhps = (total_hashes as f64) / secs / 1_000_000.0;
+    Ok(mhps)
+}

--- a/roles/test-utils/mining-device/src/lib/gpu_metal.rs
+++ b/roles/test-utils/mining-device/src/lib/gpu_metal.rs
@@ -1,0 +1,236 @@
+#![cfg(all(target_os = "macos", feature = "gpu-metal"))]
+
+use anyhow::Result;
+use metal::*;
+use std::{mem, time::Instant};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct GpuParams {
+    midstate: [u32; 8],
+    block1_template: [u32; 16],
+    target_le: [u32; 8],
+    time: u32,
+    start_nonce: u32,
+    stride: u32,
+    count: u32,
+}
+
+#[inline]
+fn u32_from_be_bytes(b: [u8; 4]) -> u32 {
+    u32::from_be_bytes(b)
+}
+#[inline]
+fn u32_from_le_bytes(b: [u8; 4]) -> u32 {
+    u32::from_le_bytes(b)
+}
+
+pub struct GpuContext {
+    device: Device,
+    pipe: ComputePipelineState,
+    queue: CommandQueue,
+}
+
+impl GpuContext {
+    pub fn new() -> Result<Self> {
+        let device = Device::system_default().ok_or_else(|| anyhow::anyhow!("No Metal device"))?;
+        let src = include_str!("../../gpu/sha256d_kernel.metal");
+        let opts = CompileOptions::new();
+        let lib = device
+            .new_library_with_source(src, &opts)
+            .map_err(|e| anyhow::anyhow!("Failed to compile Metal shader source: {}", e))?;
+        let func = lib
+            .get_function("sha256d_scan", None)
+            .map_err(|e| anyhow::anyhow!("Failed to get function 'sha256d_scan': {}", e))?;
+        let pipe = device
+            .new_compute_pipeline_state_with_function(&func)
+            .map_err(|e| anyhow::anyhow!("Failed to create compute pipeline state: {}", e))?;
+        let queue = device.new_command_queue();
+        Ok(Self {
+            device,
+            pipe,
+            queue,
+        })
+    }
+
+    fn build_common_buffers(
+        &self,
+        midstate: [u32; 8],
+        block1: [u8; 64],
+        target_le: [u8; 32],
+        time_val: u32,
+        start_nonce: u32,
+        count: u32,
+    ) -> (Buffer, Buffer, Buffer) {
+        let mut tmpl_u32 = [0u32; 16];
+        for i in 0..16 {
+            let mut w = [0u8; 4];
+            w.copy_from_slice(&block1[i * 4..i * 4 + 4]);
+            tmpl_u32[i] = u32_from_be_bytes(w);
+        }
+        let mut tgt_le_u32 = [0u32; 8];
+        for i in 0..8 {
+            let mut w = [0u8; 4];
+            w.copy_from_slice(&target_le[i * 4..i * 4 + 4]);
+            tgt_le_u32[i] = u32_from_le_bytes(w);
+        }
+        let params = GpuParams {
+            midstate,
+            block1_template: tmpl_u32,
+            target_le: tgt_le_u32,
+            time: time_val,
+            start_nonce,
+            stride: 1,
+            count,
+        };
+        let params_buf = self.device.new_buffer_with_data(
+            &params as *const _ as *const _,
+            mem::size_of::<GpuParams>() as u64,
+            MTLResourceOptions::CPUCacheModeDefaultCache,
+        );
+        let found_buf = self.device.new_buffer(
+            mem::size_of::<u32>() as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+        unsafe {
+            *(found_buf.contents() as *mut u32) = 0;
+        }
+        let result_buf = self.device.new_buffer(
+            mem::size_of_val(&[0u32; 2]) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+        (params_buf, found_buf, result_buf)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn scan_for_share(
+        &self,
+        midstate: [u32; 8],
+        block1: [u8; 64],
+        target_le: [u8; 32],
+        time_val: u32,
+        start_nonce: u32,
+        threads: u32,
+        per_thread: u32,
+    ) -> Result<Option<(u32, u32)>> {
+        let (params_buf, found_buf, result_buf) = self.build_common_buffers(
+            midstate,
+            block1,
+            target_le,
+            time_val,
+            start_nonce,
+            per_thread,
+        );
+        let total_threads = threads as u64;
+        let grid = MTLSize {
+            width: total_threads,
+            height: 1,
+            depth: 1,
+        };
+        let tg_width = self.pipe.thread_execution_width();
+        let tg_size = MTLSize {
+            width: tg_width,
+            height: 1,
+            depth: 1,
+        };
+
+        let cmd = self.queue.new_command_buffer();
+        let enc = cmd.new_compute_command_encoder();
+        enc.set_compute_pipeline_state(&self.pipe);
+        enc.set_buffer(0, Some(&params_buf), 0);
+        enc.set_buffer(1, Some(&found_buf), 0);
+        enc.set_buffer(2, Some(&result_buf), 0);
+        enc.dispatch_threads(grid, tg_size);
+        enc.end_encoding();
+        cmd.commit();
+        cmd.wait_until_completed();
+
+        let found = unsafe { *(found_buf.contents() as *const u32) };
+        if found != 0 {
+            let vals = unsafe { *(result_buf.contents() as *const [u32; 2]) };
+            Ok(Some((vals[0], vals[1])))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn measure_gpu_mhps(
+        &self,
+        midstate: [u32; 8],
+        block1: [u8; 64],
+        target_le: [u8; 32],
+        time_val: u32,
+        start_nonce: u32,
+        threads: u32,
+        per_thread: u32,
+    ) -> Result<f64> {
+        let (params_buf, found_buf, result_buf) = self.build_common_buffers(
+            midstate,
+            block1,
+            target_le,
+            time_val,
+            start_nonce,
+            per_thread,
+        );
+        let total_threads = threads as u64;
+        let grid = MTLSize {
+            width: total_threads,
+            height: 1,
+            depth: 1,
+        };
+        let tg_width = self.pipe.thread_execution_width();
+        let tg_size = MTLSize {
+            width: tg_width,
+            height: 1,
+            depth: 1,
+        };
+
+        let start = Instant::now();
+        let cmd = self.queue.new_command_buffer();
+        let enc = cmd.new_compute_command_encoder();
+        enc.set_compute_pipeline_state(&self.pipe);
+        enc.set_buffer(0, Some(&params_buf), 0);
+        enc.set_buffer(1, Some(&found_buf), 0);
+        enc.set_buffer(2, Some(&result_buf), 0);
+        enc.dispatch_threads(grid, tg_size);
+        enc.end_encoding();
+        cmd.commit();
+        cmd.wait_until_completed();
+        let elapsed = start.elapsed();
+
+        let total_hashes = (threads as u64) * (per_thread as u64);
+        let secs = elapsed.as_secs_f64().max(1e-9);
+        let mhps = (total_hashes as f64) / secs / 1_000_000.0;
+        Ok(mhps)
+    }
+}
+
+pub fn measure_gpu_mhps(
+    midstate: [u32; 8],
+    block1: [u8; 64],
+    target_le: [u8; 32],
+    time_val: u32,
+    start_nonce: u32,
+    threads: u32,
+    per_thread: u32,
+) -> Result<f64> {
+    let ctx = GpuContext::new()?;
+    ctx.measure_gpu_mhps(
+        midstate,
+        block1,
+        target_le,
+        time_val,
+        start_nonce,
+        threads,
+        per_thread,
+    )
+}
+
+pub fn device_info() -> Result<(u64, u64)> {
+    let ctx = GpuContext::new()?;
+    Ok((
+        ctx.pipe.thread_execution_width(),
+        ctx.pipe.max_total_threads_per_threadgroup(),
+    ))
+}

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -92,9 +92,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -122,29 +122,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arraydeque"
@@ -188,18 +188,18 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.6"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
+checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -433,18 +433,19 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20"
@@ -497,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -507,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -519,14 +520,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -713,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -804,12 +805,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -830,15 +831,21 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fixed-hash"
@@ -939,7 +946,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1002,7 +1009,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1023,9 +1030,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1075,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hashlink"
@@ -1178,13 +1185,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1192,6 +1200,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1199,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1240,17 +1249,17 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -1278,7 +1287,7 @@ dependencies = [
  "minreq",
  "once_cell",
  "pool_sv2",
- "rand 0.9.1",
+ "rand 0.9.2",
  "stratum-common",
  "sv1_api",
  "tar",
@@ -1290,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1411,15 +1420,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -1428,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -1444,17 +1453,17 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1473,6 +1482,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "mining_device"
 version = "0.1.3"
 dependencies = [
+ "anyhow",
  "async-channel",
  "async-recursion 0.3.2",
  "buffer_sv2",
@@ -1515,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.4"
+version = "12.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1eeb3bbebc87062b99fbb8c9067d30dab85469f4cf12248a2667777cc86b282"
+checksum = "487906208f38448e186e3deb02f2b8ef046a9078b0de00bdb28bf4fb9b76951c"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1601,12 +1611,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1685,12 +1694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,7 +1718,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1761,15 +1764,15 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1778,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1788,22 +1791,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -1888,18 +1891,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.6",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1938,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -1986,56 +1989,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
+name = "regex-automata"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "ring"
@@ -2109,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hex"
@@ -2121,15 +2097,15 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2156,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2224,34 +2200,45 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2314,18 +2301,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -2335,12 +2322,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2395,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2443,14 +2430,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2462,22 +2449,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2500,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2516,7 +2503,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2527,14 +2514,14 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2551,8 +2538,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2565,6 +2552,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,8 +2569,29 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
  "winnow",
 ]
 
@@ -2609,7 +2626,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2635,14 +2652,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -2659,7 +2676,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2719,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2786,11 +2803,20 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2809,32 +2835,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-registry"
@@ -2842,7 +2852,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -2853,7 +2863,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2862,7 +2872,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2889,7 +2899,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2910,10 +2929,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -3022,21 +3042,18 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wyz"
@@ -3060,22 +3077,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/test/integration-tests/Cargo.toml
+++ b/test/integration-tests/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 async-channel = { version = "1.5.1", default-features = false }
 corepc-node = { version = "0.7.0", default-features = false, features = ["28_0"] }
 flate2 = { version = "1.1.0", default-features = false, features = ["rust_backend"] }
-minreq = { version = "2.12.0", default-features = false, features = ["https"] }
+minreq = { version = "=2.13.0", default-features = false, features = ["https"] }
 once_cell = { version = "1.19.0", default-features = false }
 rand = { version = "0.9.0", default-features = false, features = ["thread_rng"] }
 tar = { version = "0.4.41", default-features = false }


### PR DESCRIPTION
Make laptops hot again! 🔥

Only for macOS. Off by default, can be enabled with `--features gpu-metal`.

On my M4 MacBook Pro I get about **627 MH/s from the GPU** and **221 MH/s from the CPU**. 

Impressive, given that the CPU has dedicated sha256 instructions. That said, after #1901 I can live with just the CPU performance.

Nonce space is divided between GPU and CPU.

This add `nTime` rolling (one second per wall clock second) to not run out of nonce space when template updates are sparse.

Mostly vibe coded with OpenAI GPT-5.