### PR TITLE
Fix `stratum-common` v4.0.0 and `rpc_sv2` v1.1.0 version conflict

### DIFF
--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "async-channel",
  "codec_sv2",
@@ -1155,7 +1155,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-common"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "network_helpers_sv2",
  "roles_logic_sv2",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratum-common"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 description = "SV2 pool role"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/stratum-mining/stratum"
 
 [dependencies]
 roles_logic_sv2 = { path = "../protocols/v2/roles-logic-sv2", version = "4.0.0" }
-network_helpers_sv2 = { path = "../roles/roles-utils/network-helpers", version = "4.0.0", features = ["with_buffer_pool"], optional = true }
+network_helpers_sv2 = { path = "../roles/roles-utils/network-helpers", version = "4.0.1", features = ["with_buffer_pool"], optional = true }
 
 [features]
 with_network_helpers = ["dep:network_helpers_sv2"]

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-std",
@@ -2970,7 +2970,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-common"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "network_helpers_sv2",
  "roles_logic_sv2",

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "rpc_sv2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.21.7",
  "hex",

--- a/roles/roles-utils/network-helpers/Cargo.toml
+++ b/roles/roles-utils/network-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network_helpers_sv2"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Networking utils for SV2 roles"
@@ -18,7 +18,7 @@ async-std = { version = "1.8.0", optional = true }
 async-channel = { version = "1.8.0", optional = true }
 tokio = { version = "1.44.1", features = ["full"] }
 codec_sv2 = { path = "../../../protocols/v2/codec-sv2", version = "^3.0.0", features=["noise_sv2"], optional = true }
-sv1_api = { path = "../../../protocols/v1/", version = "^2.0.0", optional = true }
+sv1_api = { path = "../../../protocols/v1/", version = "^2.1.0", optional = true }
 tracing = { version = "0.1" }
 futures = "0.3.28"
 tokio-util = { version = "0.7.10", default-features = false, features = ["codec"], optional = true }

--- a/roles/roles-utils/rpc/Cargo.toml
+++ b/roles/roles-utils/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc_sv2"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV2 JD Server RPC"
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stratum-common = { path = "../../../common", version = "4.0.0" }
+stratum-common = { path = "../../../common", version = "4.0.1" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc","raw_value"] }
 hex = "0.4.3"

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "network_helpers_sv2"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "async-channel",
  "codec_sv2",
@@ -2331,7 +2331,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-common"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "network_helpers_sv2",
  "roles_logic_sv2",

--- a/test/integration-tests/Cargo.lock
+++ b/test/integration-tests/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "rpc_sv2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.21.7",
  "hex",

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -1197,7 +1197,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-common"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "roles_logic_sv2",
 ]


### PR DESCRIPTION
- Bump network_helpers_sv2 to v4.0.1 with sv1_api ^2.1.0 dependency
- Bump stratum-common to v4.0.1 to use compatible dependencies
- Resolves codec_sv2 version conflict between v2.1.0 and v3.0.1