### PR TITLE
feat: add user_identity to ShareAccounting

### DIFF
--- a/protocols/v2/channels-sv2/src/client/extended.rs
+++ b/protocols/v2/channels-sv2/src/client/extended.rs
@@ -90,7 +90,7 @@ impl<'a> ExtendedChannel<'a> {
     ) -> Self {
         Self {
             channel_id,
-            user_identity,
+            user_identity: user_identity.clone(),
             extranonce_prefix,
             rollable_extranonce_size,
             target,
@@ -100,7 +100,7 @@ impl<'a> ExtendedChannel<'a> {
             active_job: None,
             past_jobs: HashMap::new(),
             stale_jobs: HashMap::new(),
-            share_accounting: ShareAccounting::new(),
+            share_accounting: ShareAccounting::new(user_identity),
             chain_tip: None,
         }
     }

--- a/protocols/v2/channels-sv2/src/client/share_accounting.rs
+++ b/protocols/v2/channels-sv2/src/client/share_accounting.rs
@@ -53,23 +53,26 @@ pub struct ShareAccounting {
     share_work_sum: u64,
     seen_shares: HashSet<Hash>,
     best_diff: f64,
+    user_identity: String,
 }
 
 impl Default for ShareAccounting {
     fn default() -> Self {
-        Self::new()
+        Self::new(String::new())
     }
 }
 
 impl ShareAccounting {
     /// Creates a new [`ShareAccounting`] instance, initializing all statistics to zero.
-    pub fn new() -> Self {
+    /// `user_identity` is the identity string associated with the channel.
+    pub fn new(user_identity: String) -> Self {
         Self {
             last_share_sequence_number: 0,
             shares_accepted: 0,
             share_work_sum: 0,
             seen_shares: HashSet::new(),
             best_diff: 0.0,
+            user_identity,
         }
     }
 
@@ -128,5 +131,10 @@ impl ShareAccounting {
         if diff > self.best_diff {
             self.best_diff = diff;
         }
+    }
+
+    /// Returns the user identity string associated with this channel.
+    pub fn get_user_identity(&self) -> &String {
+        &self.user_identity
     }
 }

--- a/protocols/v2/channels-sv2/src/client/standard.rs
+++ b/protocols/v2/channels-sv2/src/client/standard.rs
@@ -68,7 +68,7 @@ impl<'a> StandardChannel<'a> {
     ) -> Self {
         Self {
             channel_id,
-            user_identity,
+            user_identity: user_identity.clone(),
             extranonce_prefix,
             target,
             nominal_hashrate,
@@ -76,7 +76,7 @@ impl<'a> StandardChannel<'a> {
             active_job: None,
             past_jobs: HashMap::new(),
             stale_jobs: HashMap::new(),
-            share_accounting: ShareAccounting::new(),
+            share_accounting: ShareAccounting::new(user_identity),
             chain_tip: None,
         }
     }

--- a/protocols/v2/channels-sv2/src/server/extended.rs
+++ b/protocols/v2/channels-sv2/src/server/extended.rs
@@ -225,7 +225,7 @@ where
 
         Ok(Self {
             channel_id,
-            user_identity,
+            user_identity: user_identity.clone(),
             extranonce_prefix,
             rollable_extranonce_size: available_rollable_extranonce_size,
             requested_max_target: max_target,
@@ -233,7 +233,7 @@ where
             nominal_hashrate,
             job_store,
             job_factory: JobFactory::new(version_rolling_allowed, pool_tag, miner_tag),
-            share_accounting: ShareAccounting::new(share_batch_size),
+            share_accounting: ShareAccounting::new(share_batch_size, user_identity),
             expected_share_per_minute,
             chain_tip: None,
             phantom: PhantomData,

--- a/protocols/v2/channels-sv2/src/server/share_accounting.rs
+++ b/protocols/v2/channels-sv2/src/server/share_accounting.rs
@@ -86,13 +86,15 @@ pub struct ShareAccounting {
     share_batch_size: usize,
     seen_shares: HashSet<Hash>,
     best_diff: f64,
+    user_identity: String,
 }
 
 impl ShareAccounting {
     /// Constructs a new `ShareAccounting` instance for a channel.
     ///
     /// `share_batch_size` controls how many accepted shares trigger a batch acknowledgment.
-    pub fn new(share_batch_size: usize) -> Self {
+    /// `user_identity` is the identity string associated with the channel.
+    pub fn new(share_batch_size: usize, user_identity: String) -> Self {
         Self {
             last_share_sequence_number: 0,
             shares_accepted: 0,
@@ -100,6 +102,7 @@ impl ShareAccounting {
             share_batch_size,
             seen_shares: HashSet::new(),
             best_diff: 0.0,
+            user_identity,
         }
     }
 
@@ -168,5 +171,10 @@ impl ShareAccounting {
         if diff > self.best_diff {
             self.best_diff = diff;
         }
+    }
+
+    /// Returns the user identity string associated with this channel.
+    pub fn get_user_identity(&self) -> &String {
+        &self.user_identity
     }
 }

--- a/protocols/v2/channels-sv2/src/server/standard.rs
+++ b/protocols/v2/channels-sv2/src/server/standard.rs
@@ -205,12 +205,12 @@ where
 
         Ok(Self {
             channel_id,
-            user_identity,
+            user_identity: user_identity.clone(),
             extranonce_prefix,
             requested_max_target,
             target,
             nominal_hashrate,
-            share_accounting: ShareAccounting::new(share_batch_size),
+            share_accounting: ShareAccounting::new(share_batch_size, user_identity),
             expected_share_per_minute,
             job_factory: JobFactory::new(true, pool_tag_string, miner_tag_string),
             chain_tip: None,


### PR DESCRIPTION
Channels are aware of user_identity, this Draft adds a field to ShareAccounting populated by the user_identity from the channel.

Since this is related to #1902, I am marking Draft for now since I would have to refactor #1902 to accommodate these changes.