### PR TITLE
chore(IT): remove unused imports in integration test

### DIFF
--- a/test/integration-tests/tests/jd_integration.rs
+++ b/test/integration-tests/tests/jd_integration.rs
@@ -1,6 +1,6 @@
 // This file contains integration tests for the `JDC/S` module.
 use integration_tests_sv2::{
-    interceptor::{IgnoreMessage, MessageDirection, ReplaceMessage},
+    interceptor::{MessageDirection, ReplaceMessage},
     template_provider::DifficultyLevel,
     *,
 };

--- a/test/integration-tests/tests/translator_integration.rs
+++ b/test/integration-tests/tests/translator_integration.rs
@@ -1,10 +1,6 @@
 // This file contains integration tests for the `TranslatorSv2` module.
 use integration_tests_sv2::{interceptor::MessageDirection, template_provider::DifficultyLevel, *};
-use stratum_common::roles_logic_sv2::{
-    common_messages_sv2::*,
-    mining_sv2::*,
-    parsers_sv2::{AnyMessage, CommonMessages, Mining},
-};
+use stratum_common::roles_logic_sv2::{common_messages_sv2::*, mining_sv2::*};
 
 // This test runs an sv2 translator between an sv1 mining device and a pool. the connection between
 // the translator and the pool is intercepted by a sniffer. The test checks if the translator and


### PR DESCRIPTION
These imports pollute startup logs when we run `cargo test` in IT. This PR just removes them.