### PR TITLE
Fix extranonce size during client side channel initialization

### DIFF
--- a/roles/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/roles/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -140,7 +140,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
                     msg.target.into(),
                     hashrate,
                     true,
-                    min_extranonce_size,
+                    msg.extranonce_size,
                 );
 
                 if let Some(ref mut prevhash) = data.last_new_prev_hash {


### PR DESCRIPTION
We were using min_extranonce during client side channel initialization, which is not correct. Use the extranonce size from upstream message as rollable extranonce.