### PR TITLE
ci: migrate from deprecated macos-13 to macos-latest ARM64 runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-latest
           - ubuntu-latest
         include:
-          - os: macos-13
-            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
 


### PR DESCRIPTION
This PR updates the macos version used by the workflow defined in `test.yaml` from `macos-13` to `macos-latest`.

I opened this PR after reading an email by GitHub about this deprecation, more info here: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/