### PR TITLE
mining-device-sv1 removal from `coverage-roles.sh` script 

### DIFF
--- a/scripts/coverage-roles.sh
+++ b/scripts/coverage-roles.sh
@@ -12,7 +12,6 @@ tarpaulin
 crates=(
   "pool"
   "test-utils/mining-device"
-  "test-utils/mining-device-sv1"
   "translator"
   "jd-client"
   "jd-server"


### PR DESCRIPTION
Follow up to PR #1937.

Without this, we got the following error on CI: github.com/stratum-mining/stratum/actions/runs/18377549925/job/52355241440