### PR TITLE
Remove unreachable macro and add share validation error variant in Pool

### DIFF
--- a/roles/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/roles/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -636,7 +636,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(e) => {
-                        return Err(PoolError::ShareValidationError(e));
+                        return Err(e)?;
                     }
                 }
 
@@ -805,7 +805,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(e) => {
-                        return Err(PoolError::ShareValidationError(e));
+                        return Err(e)?;
                     }
                 }
 

--- a/roles/pool/src/lib/error.rs
+++ b/roles/pool/src/lib/error.rs
@@ -28,6 +28,7 @@ pub enum ChannelSv2Error {
     StandardChannelServerSide(StandardChannelError),
     GroupChannelServerSide(GroupChannelError),
     ExtranonceError(ExtendedExtranonceError),
+    ShareValidationError(ShareValidationError),
 }
 
 /// Represents various errors that can occur in the pool implementation.
@@ -88,8 +89,6 @@ pub enum PoolError {
     ParseInt(std::num::ParseIntError),
     /// Failed to create group channel
     FailedToCreateGroupChannel(GroupChannelError),
-    /// Share validation failed
-    ShareValidationError(ShareValidationError),
 }
 
 impl std::fmt::Display for PoolError {
@@ -139,9 +138,6 @@ impl std::fmt::Display for PoolError {
             }
             FailedToCreateGroupChannel(ref e) => {
                 write!(f, "Failed to create group channel: {e:?}")
-            }
-            ShareValidationError(ref e) => {
-                write!(f, "Share validation failed: {e:?}")
             }
         }
     }
@@ -266,6 +262,6 @@ impl From<ParserError> for PoolError {
 
 impl From<ShareValidationError> for PoolError {
     fn from(value: ShareValidationError) -> Self {
-        PoolError::ShareValidationError(value)
+        PoolError::ChannelSv2(ChannelSv2Error::ShareValidationError(value))
     }
 }


### PR DESCRIPTION
We had unreachable macro in pool, this PR removes that and adds additional and improved logs.

Part of: stratum-mining/sv2-apps#42