### PR TITLE
fuzz: fix wrong `clone` when calling `to_bytes`

### DIFF
--- a/fuzz/fuzz_targets/deserialize_setup_connection.rs
+++ b/fuzz/fuzz_targets/deserialize_setup_connection.rs
@@ -6,8 +6,8 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: Vec<u8>| {
     let mut data1 = data.clone();
     if let Ok(setup_msg) = SetupConnection::from_bytes(&mut data1) {
-        let dst = vec![0u8; setup_msg.get_size()];
-        setup_msg.to_bytes(&mut dst.clone()).unwrap();
+        let mut dst = vec![0u8; setup_msg.get_size()];
+        setup_msg.to_bytes(&mut dst).unwrap();
 
         let mut data2 = dst.clone();
 


### PR DESCRIPTION
closes #1998