### PR TITLE
Remove deprecated actions-rs from workflow

### DIFF
--- a/.github/workflows/clippy-lint.yaml
+++ b/.github/workflows/clippy-lint.yaml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+
+      - name: Install Rust (1.89) + Clippy
+        uses: dtolnay/rust-toolchain@1.89
         with:
-          profile: minimal
-          toolchain: 1.89
-          override: true
           components: clippy
+          
       - name: Run Clippy
         run: |
           cargo clippy --all-features -- -D warnings

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,10 +19,9 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Rust Docs crate stratum-core
         run: |

--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -21,11 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - name: Install nightly Rust + rustfmt
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: rustfmt
       - name: Run fmt in different workspaces and crates
         run: |

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.75.0
-            override: true
+
+      - name: Install Rust (1.75)
+        uses: dtolnay/rust-toolchain@1.75
+
       - name: Login
         run: cargo login ${{ secrets.CRATES_IO_DEPLOY_KEY }}
 

--- a/.github/workflows/rust-msrv.yaml
+++ b/.github/workflows/rust-msrv.yaml
@@ -11,17 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        rust:
-          - 1.75.0 # MSRV
 
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v1.2.0
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
+
+      - name: Install Rust (1.75)
+        uses: dtolnay/rust-toolchain@1.75
+
       - name: Build Workspace
         run: cargo build
 

--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -13,11 +13,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.85
-          override: true
+      - name: Install Rust (1.85)
+        uses: dtolnay/rust-toolchain@1.85
 
       - name: Cache Cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,12 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v3
@@ -53,12 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Build
         run: |


### PR DESCRIPTION
This PR migrates all CI jobs from the deprecated actions-rs/toolchain to the officially supported dtolnay/rust-toolchain action.