### PR TITLE
ci: detect companion PR changes and conditionally trigger integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,33 +1,68 @@
+name: Integration Tests
+
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches:
       - main
-
-name: Integration Tests
+  workflow_dispatch:
 
 jobs:
   ci:
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Use stable toolchain
-        uses: actions/checkout@v4
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Install capnproto
+      - name: Detect companion line
+        id: detect
+        env:
+          BODY_NEW: ${{ github.event.pull_request.body }}
+          BODY_OLD: ${{ github.event.changes.body.from || '' }}
+          ACTION: ${{ github.event.action }}
         run: |
-          sudo apt-get update && sudo apt-get install -y capnproto libcapnp-dev
+          OLD_COMPANION=$(printf "%s" "$BODY_OLD" \
+            | grep -Eo 'companion https://github\.com/stratum-mining/sv2-apps/pull/[0-9]+' \
+            || true)
+
+          NEW_COMPANION=$(printf "%s" "$BODY_NEW" \
+            | grep -Eo 'companion https://github\.com/stratum-mining/sv2-apps/pull/[0-9]+' \
+            || true)
+
+          if [ "$ACTION" = "edited" ]; then
+            if [ "$OLD_COMPANION" != "$NEW_COMPANION" ]; then
+              echo "should_run_integration_test=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_run_integration_test=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "should_run_integration_test=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          COMPANION_NUM=$(printf "%s" "$NEW_COMPANION" | grep -Eo '[0-9]+$' || true)
+          echo "COMPANION_PR_NUMBER=${COMPANION_NUM:-}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.85
+
+      - name: Install capnproto (Ubuntu)
+        if: steps.detect.outputs.should_run_integration_test == 'true' && matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y capnproto libcapnp-dev
+
+      - name: Install capnproto (macOS)
+        if: steps.detect.outputs.should_run_integration_test == 'true' && matrix.os == 'macos-latest'
+        run: |
+          brew install capnp
+
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --version 0.9.100 --locked
 
       - name: Run Integration Tests Script
-        run: |
-          ./scripts/run-integration-tests.sh
+        if: steps.detect.outputs.should_run_integration_test == 'true'
+        run: ./scripts/run-integration-tests.sh
+


### PR DESCRIPTION
closes #2022.

This PR updates `./scripts/run-integration-tests.sh` and `./.github/workflows/integration-tests.yaml` to support the feature described in the issue #2022.

From now on, whenever you open a PR in this repo and realize the changes should also be reflected in the `https://github.com/stratum-mining/sv2-apps` repo, you can simply add a line to this PR’s description.

Example (as shown in the image below):
```
<keyword> <pr_link>
```
<img width="2088" height="872" alt="image" src="https://github.com/user-attachments/assets/18e60d6b-5c84-48e6-bf78-8381716ec7d2" />

This will re-trigger the integration tests, but this time they’ll run against the specified PR in `sv2-apps`.
