### PR TITLE
fix integration-test script patch

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -53,7 +53,10 @@ cat >> Cargo.toml << 'EOF'
 
 # Override dependencies with local paths
 [patch.crates-io] 
-stratum-core = {path = "../../../stratum-core"} 
+stratum-core = {path = "../../../stratum-core"}
+
+[patch."https://github.com/stratum-mining/stratum"]
+stratum-core = {path = "../../../stratum-core"}
 EOF
 
 echo "✅ Updated Cargo.toml to use local dependencies"


### PR DESCRIPTION
as a follow-up to https://github.com/stratum-mining/sv2-apps/pull/133

now that **sv2-apps** is pulling **stratum-core** from GitHub again, we should update the patch applied by `run-integration-test.sh`.

I’ve added patches for both the GitHub and crates.io sources to avoid any future back-and-forth.
