### PR TITLE
Remove profile from workspace toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,3 @@ exclude = [
     "integration-test-framework",
     "fuzz"
 ]
-
-[profile.dev]
-# Required by super_safe_lock
-opt-level = 1
-
-[profile.test]
-# Required by super_safe_lock
-opt-level = 1


### PR DESCRIPTION
This PR removes profile from workspace cargo toml, earlier we required it because of super-safe-lock which has now moved to stratum-apps.