### PR TITLE
add `rust-analyzer` to `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.75.0"
-components = [ "rustfmt", "clippy" ]
+components = [ "rustfmt", "clippy", "rust-analyzer" ]


### PR DESCRIPTION
to avoid this annoying warning on my IDE

<img width="700" height="886" alt="image" src="https://github.com/user-attachments/assets/fc6050b5-e159-4b2c-b63b-1cd898d6408a" />
