### PR TITLE
implements the Display trait for sv1 messages

### DIFF
--- a/stratum-core/stratum-translation/src/sv2_to_sv1.rs
+++ b/stratum-core/stratum-translation/src/sv2_to_sv1.rs
@@ -87,7 +87,7 @@ pub fn build_sv1_notify_from_sv2(
         time,
         clean_jobs,
     };
-    debug!("\nNextMiningNotify: {:?}\n", notify_response);
+    debug!("\nNextMiningNotify: {}\n", notify_response);
     Ok(notify_response)
 }
 

--- a/sv1/src/utils.rs
+++ b/sv1/src/utils.rs
@@ -4,6 +4,7 @@ use bitcoin_hashes::hex::{FromHex, ToHex};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
 use std::{convert::TryFrom, mem::size_of, ops::BitAnd};
 
 /// Helper type that allows simple serialization and deserialization of byte vectors
@@ -11,6 +12,12 @@ use std::{convert::TryFrom, mem::size_of, ops::BitAnd};
 /// Extranonce must be less than or equal to 32 bytes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Extranonce<'a>(pub B032<'a>);
+
+impl fmt::Display for Extranonce<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0.inner_as_ref()))
+    }
+}
 
 impl Extranonce<'_> {
     pub fn len(&self) -> usize {
@@ -81,6 +88,12 @@ impl<'a> From<B032<'a>> for Extranonce<'a> {
 /// Big-endian alternative of the HexU32
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HexU32Be(pub u32);
+
+impl fmt::Display for HexU32Be {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:08x}", self.0)
+    }
+}
 
 impl HexU32Be {
     pub fn check_mask(&self, mask: &HexU32Be) -> bool {
@@ -153,6 +166,14 @@ impl<'de> Deserialize<'de> for HexU32Be {
 /// into big endian. Therefore, we need a special type for it
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrevHash<'a>(pub U256<'a>);
+
+impl fmt::Display for PrevHash<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Reuse the Stratum V1 serialization logic
+        let s = String::from(self.clone());
+        f.write_str(&s)
+    }
+}
 
 impl<'a> From<PrevHash<'a>> for Vec<u8> {
     fn from(p_hash: PrevHash<'a>) -> Self {
@@ -238,6 +259,12 @@ impl AsRef<[u8]> for Extranonce<'_> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MerkleNode<'a>(pub U256<'a>);
 
+impl fmt::Display for MerkleNode<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
 impl MerkleNode<'_> {
     pub fn is_empty(&self) -> bool {
         self.0.inner_as_ref().is_empty()
@@ -292,6 +319,12 @@ impl<'a> From<MerkleNode<'a>> for String {
 /// HexBytes must be less than or equal to 32 bytes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HexBytes(Vec<u8>);
+
+impl fmt::Display for HexBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
 
 impl HexBytes {
     pub fn len(&self) -> usize {


### PR DESCRIPTION
closes #2045;

now the log showed in the issue will be presented as:
```bash
NextMiningNotify: Notify { job_id: 1, prev_hash: 562240c9f7660692ff611c16059836be9a6639ab0001c9590000000000000000, coin_base1: 02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2903a4370e00162f5374726174756d2056322053524920506f6f6c2f2f0c, coin_base2: feffffff027704a5120000000016001458806074c426bedea9376ac34685eca699f4e90f0000000000000000266a24aa21a9ed52276aaa774a9f5a24b90713467ddeaea62772299cc7138906003d6ccc0953f7a3370e00, merkle_branch: [20f5cec09db7794061cb816cc6322bb0c02752711fdb20c670d8fb3d634431ce, ..., 64f5ac53a5f9a271aa7342e6f898716a115ea62834a3c15d0dca34f5120c2dfa] (13 nodes), version: 20000000, bits: 1701ebf2, time: 6962998e, clean_jobs: true }
```

Also, took the chance to impl the Display trait to the other messages.