### PR TITLE
sv1: remove third-party hex crate dependency

### DIFF
--- a/sv1/Cargo.toml
+++ b/sv1/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 bitcoin_hashes = "0.3.2"
 byteorder = "1.2.7"
-hex = "0.4.3"
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 tracing = {version = "0.1"}

--- a/sv1/src/error.rs
+++ b/sv1/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error<'a> {
     BadBytesConvert(binary_sv2::Error),
     BTCHashError(bitcoin_hashes::Error),
     /// Errors on bad hex decode/encode.
-    HexError(hex::FromHexError),
+    HexError(bitcoin_hashes::Error),
     /// Errors if `ClientStatus` is in an unexpected state when a message is received. For example,
     /// if a `mining.subscribed` is received when the `ClientStatus` is in the `Init` state.
     IncorrectClientStatus(String),
@@ -80,12 +80,6 @@ impl std::fmt::Display for Error<'_> {
 impl From<bitcoin_hashes::Error> for Error<'_> {
     fn from(e: bitcoin_hashes::Error) -> Self {
         Error::BTCHashError(e)
-    }
-}
-
-impl From<hex::FromHexError> for Error<'_> {
-    fn from(e: hex::FromHexError) -> Self {
-        Error::HexError(e)
     }
 }
 

--- a/sv1/src/lib.rs
+++ b/sv1/src/lib.rs
@@ -42,6 +42,7 @@ pub mod json_rpc;
 pub mod methods;
 pub mod utils;
 
+use bitcoin_hashes::hex::FromHex;
 use std::convert::{TryFrom, TryInto};
 use tracing::debug;
 
@@ -373,7 +374,9 @@ pub trait IsClient<'a> {
                     .subscribe(
                         server_id,
                         configure.id,
-                        Some(Extranonce::try_from(hex::decode("08000002")?)?),
+                        Some(Extranonce::try_from(
+                            Vec::<u8>::from_hex("08000002").map_err(Error::HexError)?,
+                        )?),
                     )
                     .ok();
                 Ok(subscribe)
@@ -696,7 +699,7 @@ mod tests {
 
     #[test]
     fn test_server_handle_invalid_message() {
-        let extranonce1 = Extranonce::try_from(hex::decode("08000002").unwrap()).unwrap();
+        let extranonce1 = Extranonce::try_from(Vec::<u8>::from_hex("08000002").unwrap()).unwrap();
         let mut server = TestServer::new(extranonce1, 4);
 
         // Create an invalid message (response)

--- a/sv1/src/methods/client_to_server.rs
+++ b/sv1/src/methods/client_to_server.rs
@@ -1,4 +1,4 @@
-use bitcoin_hashes::hex::ToHex;
+use bitcoin_hashes::hex::{FromHex, ToHex};
 use serde_json::{
     Value,
     Value::{Array as JArrary, Null, Number as JNumber, String as JString},
@@ -200,7 +200,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JNumber(d), JNumber(e), JString(f)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
                         HexU32Be(d.as_u64().unwrap() as u32),
                         HexU32Be(e.as_u64().unwrap() as u32),
                         Some((f.as_str()).try_into()?),
@@ -208,7 +208,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JString(d), JString(e), JString(f)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
                         (d.as_str()).try_into()?,
                         (e.as_str()).try_into()?,
                         Some((f.as_str()).try_into()?),
@@ -216,7 +216,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JNumber(d), JNumber(e)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
                         HexU32Be(d.as_u64().unwrap() as u32),
                         HexU32Be(e.as_u64().unwrap() as u32),
                         None,
@@ -224,7 +224,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JString(d), JString(e)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(hex::decode(c)?)?,
+                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
                         (d.as_str()).try_into()?,
                         (e.as_str()).try_into()?,
                         None,

--- a/sv1/src/methods/mod.rs
+++ b/sv1/src/methods/mod.rs
@@ -1,6 +1,5 @@
 use crate::error::Error;
 use bitcoin_hashes::Error as BTCHashError;
-use hex::FromHexError;
 use std::convert::{TryFrom, TryInto};
 
 pub mod client_to_server;
@@ -24,12 +23,6 @@ pub enum MethodError<'a> {
     NotARequest,
 }
 
-impl From<FromHexError> for ParsingMethodError {
-    fn from(hex_err: FromHexError) -> Self {
-        ParsingMethodError::HexError(Box::new(hex_err))
-    }
-}
-
 impl From<BTCHashError> for ParsingMethodError {
     fn from(btc_err: BTCHashError) -> Self {
         ParsingMethodError::BTCHashError(Box::new(btc_err))
@@ -45,7 +38,7 @@ impl From<binary_sv2::Error> for ParsingMethodError {
 #[derive(Debug, Clone)]
 pub enum ParsingMethodError {
     BadU256Convert(Box<binary_sv2::Error>),
-    HexError(Box<FromHexError>),
+    HexError(Box<BTCHashError>),
     #[allow(clippy::upper_case_acronyms)]
     BTCHashError(Box<BTCHashError>),
     ValueNotAnArray(Box<serde_json::Value>),

--- a/sv1/src/methods/server_to_client.rs
+++ b/sv1/src/methods/server_to_client.rs
@@ -1,3 +1,4 @@
+use bitcoin_hashes::hex::FromHex;
 use serde_json::{
     Value,
     Value::{Array as JArrary, Bool as JBool, Number as JNumber, String as JString},
@@ -267,7 +268,7 @@ impl TryFrom<Notification> for SetExtranonce<'_> {
             .ok_or_else(|| ParsingMethodError::not_array_from_value(msg.params.clone()))?;
         let (extra_nonce1, extra_nonce2_size) = match &params[..] {
             [JString(a), JNumber(b)] => (
-                Extranonce::try_from(hex::decode(a)?)?,
+                Extranonce::try_from(Vec::<u8>::from_hex(a)?)?,
                 b.as_u64()
                     .ok_or_else(|| ParsingMethodError::not_unsigned_from_value(b.clone()))?
                     as usize,

--- a/sv1/src/utils.rs
+++ b/sv1/src/utils.rs
@@ -15,7 +15,7 @@ pub struct Extranonce<'a>(pub B032<'a>);
 
 impl fmt::Display for Extranonce<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&hex::encode(self.0.inner_as_ref()))
+        f.write_str(&self.0.inner_as_ref().to_hex())
     }
 }
 
@@ -51,9 +51,9 @@ impl<'a> From<Extranonce<'a>> for Value {
 /// FIXME: find a nicer solution
 fn hex_decode(s: &str) -> Result<Vec<u8>, Error<'static>> {
     if s.len() % 2 != 0 {
-        Ok(hex::decode(format!("0{s}"))?)
+        Vec::<u8>::from_hex(&format!("0{s}")).map_err(Error::HexError)
     } else {
-        Ok(hex::decode(s)?)
+        Vec::<u8>::from_hex(s).map_err(Error::HexError)
     }
 }
 
@@ -67,7 +67,7 @@ impl<'a> TryFrom<&str> for Extranonce<'a> {
 
 impl<'a> From<Extranonce<'a>> for String {
     fn from(bytes: Extranonce<'a>) -> String {
-        hex::encode(bytes.0)
+        bytes.0.inner_as_ref().to_hex()
     }
 }
 
@@ -231,7 +231,7 @@ impl From<PrevHash<'_>> for String {
                 .write_u32::<BigEndian>(prev_hash_word)
                 .expect("Internal error: Could not write buffer");
         }
-        hex::encode(prev_hash_stratum_cursor.into_inner())
+        prev_hash_stratum_cursor.into_inner().to_hex()
     }
 }
 
@@ -261,7 +261,7 @@ pub struct MerkleNode<'a>(pub U256<'a>);
 
 impl fmt::Display for MerkleNode<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
+        write!(f, "{}", self.0.inner_as_ref().to_hex())
     }
 }
 
@@ -310,7 +310,7 @@ impl<'a> TryFrom<&str> for MerkleNode<'a> {
 
 impl<'a> From<MerkleNode<'a>> for String {
     fn from(bytes: MerkleNode<'a>) -> String {
-        hex::encode(bytes.0)
+        bytes.0.inner_as_ref().to_hex()
     }
 }
 
@@ -322,7 +322,7 @@ pub struct HexBytes(Vec<u8>);
 
 impl fmt::Display for HexBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
+        write!(f, "{}", self.0.to_hex())
     }
 }
 
@@ -370,7 +370,7 @@ impl TryFrom<&str> for HexBytes {
 
 impl From<HexBytes> for String {
     fn from(bytes: HexBytes) -> String {
-        hex::encode(bytes.0)
+        bytes.0.to_hex()
     }
 }
 


### PR DESCRIPTION
Replace `hex` crate with `bitcoin_hashes::hex::{FromHex, ToHex}` traits
already available through existing dependency.

- `hex::decode()` → `Vec::<u8>::from_hex()`
- `hex::encode()` → `.to_hex()`
- Error types updated to wrap `bitcoin_hashes::Error`

Closes #375