### PR TITLE
feat(channels): add set_nominal_hashrate to client ExtendedChannel

### DIFF
--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -182,6 +182,11 @@ impl<'a> ExtendedChannel<'a> {
         self.nominal_hashrate
     }
 
+    /// Sets the nominal hashrate for the channel, in h/s.
+    pub fn set_nominal_hashrate(&mut self, hashrate: f32) {
+        self.nominal_hashrate = hashrate;
+    }
+
     /// Returns a reference to the currently active job, if any.
     pub fn get_active_job(&self) -> Option<&ExtendedJob<'a>> {
         self.active_job.as_ref()


### PR DESCRIPTION
Add a setter for `nominal_hashrate` on the client-side `ExtendedChannel`. This allows downstream consumers (e.g. tProxy) to update the locally tracked hashrate when the downstream vardiff produces an `UpdateChannel` message, keeping it consistent with actual miner performance.

See: [stratum-mining/sv2-apps#242](https://github.com/stratum-mining/sv2-apps/issues/242)

companion https://github.com/stratum-mining/sv2-apps/pull/245