### PR TITLE
Optimize Extranonce cloning in hot path (Fixes #2076)

### DIFF
--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -677,8 +677,8 @@ where
 
         let extranonce_prefix = job.get_extranonce_prefix();
         let mut full_extranonce = vec![];
-        full_extranonce.extend(extranonce_prefix.clone());
-        full_extranonce.extend(share.extranonce.inner_as_ref());
+        full_extranonce.extend_from_slice(extranonce_prefix);
+        full_extranonce.extend_from_slice(share.extranonce.as_ref());
 
         // calculate the merkle root from:
         // - job coinbase_tx_prefix

--- a/sv2/subprotocols/mining/src/lib.rs
+++ b/sv2/subprotocols/mining/src/lib.rs
@@ -127,6 +127,12 @@ pub struct Extranonce {
     extranonce: alloc::vec::Vec<u8>,
 }
 
+impl AsRef<[u8]> for Extranonce {
+    fn as_ref(&self) -> &[u8] {
+        &self.extranonce
+    }
+}
+
 // this function converts a U256 type in little endian to Extranonce type
 impl<'a> From<U256<'a>> for Extranonce {
     fn from(v: U256<'a>) -> Self {


### PR DESCRIPTION
## Description
This PR addresses issue #2076 by optimizing memory usage during share validation.

## Changes
- Implemented `AsRef<[u8]>` for the `Extranonce` struct in `sv2/subprotocols/mining/src/lib.rs`.
- Refactored `validate_share` in `sv2/channels-sv2/src/server/extended.rs` to use `extend_from_slice` instead of `clone()` + `extend()`.

## Impact
This optimization removes unnecessary heap allocations on the "hot path" of share validation, improving performance for the mining server.

## Verification
- Ran `cargo test -p mining_sv2` (Verified trait implementation)
- Ran `cargo test -p channels_sv2` (Verified share validation logic remains correct)
- Ran `cargo test` (Verified all tests pass across the workspace)