### PR TITLE
feat(channels): add blocks_found metric to ShareAccounting

### DIFF
--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -568,6 +568,7 @@ impl<'a> ExtendedChannel<'a> {
         if network_target.is_met_by(share_hash) {
             self.share_accounting
                 .track_validated_share(share.sequence_number, share_hash.to_raw_hash());
+            self.share_accounting.increment_blocks_found();
             return Ok(ShareValidationResult::BlockFound(share_hash.to_raw_hash()));
         }
 
@@ -859,6 +860,7 @@ mod tests {
         let res = channel.validate_share(share_valid_block);
 
         assert!(matches!(res, Ok(ShareValidationResult::BlockFound(_))));
+        assert_eq!(channel.get_share_accounting().get_blocks_found(), 1);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/client/share_accounting.rs
+++ b/sv2/channels-sv2/src/client/share_accounting.rs
@@ -52,6 +52,7 @@ pub enum ShareValidationError {
 /// **Acceptance phase** (updated by the application layer via [`on_share_acknowledgement`]):
 /// - total accepted shares (confirmed by upstream [`SubmitSharesSuccess`])
 /// - cumulative work from accepted shares
+/// - number of blocks found
 ///
 /// [`validate_share`]: super::extended::ExtendedChannel::validate_share
 /// [`track_validated_share`]: ShareAccounting::track_validated_share
@@ -64,6 +65,7 @@ pub struct ShareAccounting {
     share_work_sum: f64,
     seen_shares: HashSet<Hash>,
     best_diff: f64,
+    blocks_found: u32,
 }
 
 impl Default for ShareAccounting {
@@ -81,6 +83,7 @@ impl ShareAccounting {
             share_work_sum: 0.0,
             seen_shares: HashSet::new(),
             best_diff: 0.0,
+            blocks_found: 0,
         }
     }
 
@@ -149,5 +152,15 @@ impl ShareAccounting {
         if diff > self.best_diff {
             self.best_diff = diff;
         }
+    }
+
+    /// Increments the blocks found counter.
+    pub fn increment_blocks_found(&mut self) {
+        self.blocks_found += 1;
+    }
+
+    /// Returns the total number of blocks found on this channel.
+    pub fn get_blocks_found(&self) -> u32 {
+        self.blocks_found
     }
 }

--- a/sv2/channels-sv2/src/client/standard.rs
+++ b/sv2/channels-sv2/src/client/standard.rs
@@ -349,6 +349,7 @@ impl<'a> StandardChannel<'a> {
         if network_target.is_met_by(share_hash) {
             self.share_accounting
                 .track_validated_share(share.sequence_number, share_hash.to_raw_hash());
+            self.share_accounting.increment_blocks_found();
             return Ok(ShareValidationResult::BlockFound(share_hash.to_raw_hash()));
         }
 
@@ -567,6 +568,7 @@ mod tests {
         let res = channel.validate_share(share_valid_block);
 
         assert!(matches!(res, Ok(ShareValidationResult::BlockFound(_))));
+        assert_eq!(channel.get_share_accounting().get_blocks_found(), 1);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -749,6 +749,7 @@ where
                 share.sequence_number,
                 share_hash.to_raw_hash(),
             );
+            self.share_accounting.increment_blocks_found();
 
             let mut coinbase = vec![];
             coinbase.extend(job.get_coinbase_tx_prefix_with_bip141());
@@ -1274,6 +1275,7 @@ mod tests {
             res,
             Ok(ShareValidationResult::BlockFound(_, _, _))
         ));
+        assert_eq!(channel.get_share_accounting().get_blocks_found(), 1);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/share_accounting.rs
+++ b/sv2/channels-sv2/src/server/share_accounting.rs
@@ -79,6 +79,7 @@ pub struct ShareAccounting {
     share_batch_size: usize,
     seen_shares: HashSet<Hash>,
     best_diff: f64,
+    blocks_found: u32,
 }
 
 impl ShareAccounting {
@@ -95,6 +96,7 @@ impl ShareAccounting {
             share_batch_size,
             seen_shares: HashSet::new(),
             best_diff: 0.0,
+            blocks_found: 0,
         }
     }
 
@@ -187,5 +189,15 @@ impl ShareAccounting {
         if diff > self.best_diff {
             self.best_diff = diff;
         }
+    }
+
+    /// Increments the blocks found counter.
+    pub fn increment_blocks_found(&mut self) {
+        self.blocks_found += 1;
+    }
+
+    /// Returns the total number of blocks found on this channel.
+    pub fn get_blocks_found(&self) -> u32 {
+        self.blocks_found
     }
 }

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -641,6 +641,7 @@ where
                 share.sequence_number,
                 share_hash.to_raw_hash(),
             );
+            self.share_accounting.increment_blocks_found();
 
             let op_pushbytes_pool_miner_tag = self
                 .job_factory
@@ -1061,6 +1062,10 @@ mod tests {
             res,
             Ok(ShareValidationResult::BlockFound(_, _, _))
         ));
+        assert_eq!(
+            standard_channel.get_share_accounting().get_blocks_found(),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add blocks_found counter to both server and client ShareAccounting to track the number of blocks found per channel. The counter is incremented in validate_share when ShareValidationResult::BlockFound is returned.

Changes:
- Add blocks_found field to server and client ShareAccounting
- Increment blocks_found in all validate_share BlockFound branches (server extended/standard, client extended/standard)
- Add get_blocks_found() and increment_blocks_found() methods
- Add test assertions verifying blocks_found increments correctly