### PR TITLE
channels_sv2: clamp target to max_target instead of erroring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "channels_sv2"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "binary_sv2",
  "bitcoin",

--- a/stratum-core/Cargo.toml
+++ b/stratum-core/Cargo.toml
@@ -20,7 +20,7 @@ framing_sv2 = { path = "../sv2/framing-sv2", version = "^6.0.0" }
 noise_sv2 = { path = "../sv2/noise-sv2", version = "^1.0.0" }
 parsers_sv2 = { path = "../sv2/parsers-sv2", version = "^0.2.0" }
 handlers_sv2 = { path = "../sv2/handlers-sv2", version = "^0.2.0" }
-channels_sv2 = { path = "../sv2/channels-sv2", version = "^4.0.0" }
+channels_sv2 = { path = "../sv2/channels-sv2", version = "^5.0.0" }
 common_messages_sv2 = { path = "../sv2/subprotocols/common-messages", version = "^7.0.0" }
 mining_sv2 = { path = "../sv2/subprotocols/mining", version = "^8.0.0" }
 template_distribution_sv2 = { path = "../sv2/subprotocols/template-distribution", version = "^5.0.0" }

--- a/stratum-core/stratum-translation/Cargo.toml
+++ b/stratum-core/stratum-translation/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 binary_sv2 = { path = "../../sv2/binary-sv2", version = "^5.0.0" }
 mining_sv2 = { path = "../../sv2/subprotocols/mining", version = "^8.0.0" }
-channels_sv2 = { path = "../../sv2/channels-sv2", version = "^4.0.0" }
+channels_sv2 = { path = "../../sv2/channels-sv2", version = "^5.0.0" }
 v1 = { path = "../../sv1", package = "sv1_api", version = "^4.0.0" }
 tracing = { workspace = true }
 bitcoin = { workspace = true }

--- a/sv2/channels-sv2/Cargo.toml
+++ b/sv2/channels-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "channels_sv2"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"

--- a/sv2/channels-sv2/src/server/error.rs
+++ b/sv2/channels-sv2/src/server/error.rs
@@ -6,7 +6,6 @@ use crate::server::jobs::error::JobFactoryError;
 pub enum ExtendedChannelError {
     JobFactoryError(JobFactoryError),
     InvalidNominalHashrate,
-    RequestedMaxTargetOutOfRange,
     ChainTipNotSet,
     TemplateIdNotFound,
     JobIdNotFound,
@@ -29,7 +28,6 @@ pub enum GroupChannelError {
 pub enum StandardChannelError {
     TemplateIdNotFound,
     InvalidNominalHashrate,
-    RequestedMaxTargetOutOfRange,
     ExtranoncePrefixTooLarge,
     JobFactoryError(JobFactoryError),
     ChainTipNotSet,

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -346,8 +346,13 @@ where
 
     /// Updates channel configuration with a new nominal hashrate.
     ///
-    /// Adjusts target difficulty and internal state. Returns an error if
-    /// any input parameters are invalid or constraints are violated.
+    /// Recomputes target difficulty and updates channel state.
+    ///
+    /// If the recomputed target is easier than the effective `requested_max_target`,
+    /// the target is clamped to `requested_max_target`.
+    ///
+    /// Returns [`ExtendedChannelError::InvalidNominalHashrate`] when
+    /// `new_nominal_hashrate` cannot be converted into a valid target.
     ///
     /// This can be used in two scenarios:
     /// - Client sent `UpdateChannel` message, which contains a `requested_max_target` parameter

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -208,11 +208,10 @@ where
                 }
             };
 
-        if target > max_target {
-            println!("target: {:?}", target.to_be_bytes());
-            println!("max_target: {:?}", max_target.to_be_bytes());
-            return Err(ExtendedChannelError::RequestedMaxTargetOutOfRange);
-        }
+        // Clamp to max_target rather than error. The client declared max_target as
+        // an acceptable difficulty floor, so using it when the initial target would
+        // otherwise exceed it is always valid.
+        let target = target.min(max_target);
 
         if extranonce_prefix.len() > MAX_EXTRANONCE_PREFIX_LEN {
             return Err(ExtendedChannelError::ExtranoncePrefixTooLarge);
@@ -396,11 +395,10 @@ where
             bytes_to_hex(&max_target_bytes)
         );
 
-        let new_target: Target = target;
-
-        if new_target > *requested_max_target {
-            return Err(ExtendedChannelError::RequestedMaxTargetOutOfRange);
-        }
+        // Clamp to max_target rather than error. The client declared max_target as
+        // an acceptable difficulty floor, so using it when vardiff would otherwise
+        // exceed it is always valid.
+        let new_target = target.min(*requested_max_target);
 
         self.nominal_hashrate = new_nominal_hashrate;
         self.target = new_target;
@@ -1604,17 +1602,15 @@ mod tests {
             0xff, 0xff, 0xff, 0x00,
         ]);
 
-        // Try to update with a hashrate that would result in a target exceeding the max_target
-        // new target: 2492492492492492492492492492492492492492492492492492492492492491
-        // max target: 00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        // Update with a hashrate that would compute a target exceeding max_target.
+        // The channel should clamp to not_so_permissive_max_target instead of erroring.
+        // calculated target: 2492492492492492492492492492492492492492492492492492492492492491
+        // max target:        00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
         let very_small_hashrate = 0.1;
         let result =
             channel.update_channel(very_small_hashrate, Some(not_so_permissive_max_target));
-        assert!(result.is_err());
-        assert!(matches!(
-            result,
-            Err(ExtendedChannelError::RequestedMaxTargetOutOfRange)
-        ));
+        assert!(result.is_ok());
+        assert_eq!(channel.get_target(), &not_so_permissive_max_target);
 
         // Test successful update with not_so_permissive_max_target
         // new target: 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -1532,6 +1532,48 @@ mod tests {
     }
 
     #[test]
+    fn test_new_clamps_target_to_max_target() {
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [0, 0, 0, 1].to_vec();
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = 4u16;
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+        let very_small_hashrate = 0.1;
+        let job_store = DefaultJobStore::new();
+
+        // less permissive max_target to exercise constructor clamp path
+        let not_so_permissive_max_target = Target::from_le_bytes([
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0x00,
+        ]);
+
+        let channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            not_so_permissive_max_target,
+            very_small_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+            job_store,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            channel.get_requested_max_target(),
+            &not_so_permissive_max_target
+        );
+        assert_eq!(channel.get_target(), &not_so_permissive_max_target);
+    }
+
+    #[test]
     fn test_update_channel() {
         let channel_id = 1;
         let user_identity = "user_identity".to_string();

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -195,11 +195,10 @@ where
                 }
             };
 
-        let target: Target = calculated_target;
-
-        if target > requested_max_target {
-            return Err(StandardChannelError::RequestedMaxTargetOutOfRange);
-        }
+        // Clamp to max_target rather than error. The client declared max_target as
+        // an acceptable difficulty floor, so using it when the initial target would
+        // otherwise exceed it is always valid.
+        let target = calculated_target.min(requested_max_target);
 
         if extranonce_prefix.len() > MAX_EXTRANONCE_PREFIX_LEN {
             return Err(StandardChannelError::ExtranoncePrefixTooLarge);
@@ -344,11 +343,10 @@ where
             bytes_to_hex(&max_target_bytes)
         );
 
-        let new_target: Target = target;
-
-        if new_target > requested_max_target {
-            return Err(StandardChannelError::RequestedMaxTargetOutOfRange);
-        }
+        // Clamp to max_target rather than error. The client declared max_target as
+        // an acceptable difficulty floor, so using it when vardiff would otherwise
+        // exceed it is always valid.
+        let new_target = target.min(requested_max_target);
 
         self.target = new_target;
         self.nominal_hashrate = nominal_hashrate;
@@ -1368,17 +1366,15 @@ mod tests {
             0xff, 0xff, 0xff, 0x00,
         ]);
 
-        // Try to update with a hashrate that would result in a target exceeding the max_target
-        // new target: 2492492492492492492492492492492492492492492492492492492492492491
-        // max target: 00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        // Update with a hashrate that would compute a target exceeding max_target.
+        // The channel should clamp to not_so_permissive_max_target instead of erroring.
+        // calculated target: 2492492492492492492492492492492492492492492492492492492492492491
+        // max target:        00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
         let very_small_hashrate = 0.1;
         let result =
             channel.update_channel(very_small_hashrate, Some(not_so_permissive_max_target));
-        assert!(result.is_err());
-        assert!(matches!(
-            result,
-            Err(StandardChannelError::RequestedMaxTargetOutOfRange)
-        ));
+        assert!(result.is_ok());
+        assert_eq!(channel.get_target(), &not_so_permissive_max_target);
 
         // Test successful update with not_so_permissive_max_target
         // new target: 0001179d9861a761ffdadd11c307c4fc04eea3a418f7d687584e4434af158205

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -1301,6 +1301,44 @@ mod tests {
     }
 
     #[test]
+    fn test_new_clamps_target_to_max_target() {
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [0, 0, 0, 1].to_vec();
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+        let very_small_hashrate = 0.1;
+        let job_store = DefaultJobStore::<StandardJob>::new();
+
+        // less permissive max_target to exercise constructor clamp path
+        let not_so_permissive_max_target = Target::from_le_bytes([
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0x00,
+        ]);
+
+        let channel = StandardChannel::new(
+            channel_id,
+            user_identity,
+            extranonce_prefix,
+            not_so_permissive_max_target,
+            very_small_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+            job_store,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            channel.get_requested_max_target(),
+            &not_so_permissive_max_target
+        );
+        assert_eq!(channel.get_target(), &not_so_permissive_max_target);
+    }
+
+    #[test]
     fn test_update_channel() {
         let channel_id = 1;
         let user_identity = "user_identity".to_string();

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -295,8 +295,13 @@ where
 
     /// Updates channel configuration with a new nominal hashrate.
     ///
-    /// Adjusts target difficulty and internal state. Returns an error if
-    /// any input parameters are invalid or constraints are violated.
+    /// Recomputes target difficulty and updates channel state.
+    ///
+    /// If the recomputed target is easier than the effective `requested_max_target`,
+    /// the target is clamped to `requested_max_target`.
+    ///
+    /// Returns [`StandardChannelError::InvalidNominalHashrate`] when
+    /// `nominal_hashrate` cannot be converted into a valid target.
     ///
     /// This can be used in two scenarios:
     /// - Client sent `UpdateChannel` message, which contains a `requested_max_target` parameter


### PR DESCRIPTION
## Problem

When a pool's vardiff computes a target easier than the client's declared
`max_target`, `update_channel()` returns `Err(RequestedMaxTargetOutOfRange)`.
This silently breaks vardiff for the affected channel: the error is swallowed by
the caller, no difficulty update is applied, and the miner is permanently stuck
at its last successfully-set difficulty. The pool logs a `WARN` roughly every
60 seconds per affected channel while mining continues at the wrong difficulty.

This is not a hypothetical edge case. It triggers reliably for low-hashrate
miners whose natural vardiff target overshoots their declared `max_target`.

## Root Cause

The `max_target` field in `OpenExtendedMiningChannel` means *"the easiest
difficulty I will accept."* When vardiff computes a target easier than
`max_target`, the correct response is to assign exactly `max_target` — the
client has already declared that difficulty acceptable. The current code errors
instead, which is both incorrect per the spec and operationally harmful.

## Fix

Replace the `RequestedMaxTargetOutOfRange` error path with a clamp in four
places:

- `ExtendedChannel::new()` — channel creation
- `ExtendedChannel::update_channel()` — vardiff updates
- `StandardChannel::new()` — channel creation
- `StandardChannel::update_channel()` — vardiff updates

Also removes two stray `println!` debug statements from `ExtendedChannel::new()`.

## Tests

The existing `test_update_channel` tests in both `extended.rs` and `standard.rs`
already exercise this path (`very_small_hashrate = 0.1`). They previously
asserted `is_err()` / `RequestedMaxTargetOutOfRange`. They now assert `is_ok()`
and verify the channel target was clamped to `not_so_permissive_max_target`.
All 50 unit tests pass.

## Notes

- `RequestedMaxTargetOutOfRange` is preserved in both error enums — it remains
reachable from the `UpdateChannel` message handler path where the client itself
sends a bad `max_target`.
- No API surface changes (no new public types, no signature changes).

## Pre-existing CI failure

`cargo clippy` currently fails on upstream `main` due to `needless_lifetimes` in
`binary_sv2` — unrelated to this PR.

---

companion https://github.com/stratum-mining/sv2-apps/pull/447