### PR TITLE
feat(common-messages): add has_declare_tx_data helper function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "common_messages_sv2"
-version = "7.0.0"
+version = "7.1.0"
 dependencies = [
  "binary_sv2",
  "quickcheck",

--- a/sv2/subprotocols/common-messages/Cargo.toml
+++ b/sv2/subprotocols/common-messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common_messages_sv2"
-version = "7.0.0"
+version = "7.1.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"

--- a/sv2/subprotocols/common-messages/src/lib.rs
+++ b/sv2/subprotocols/common-messages/src/lib.rs
@@ -28,8 +28,8 @@ use quickcheck::{Arbitrary, Gen};
 pub use channel_endpoint_changed::ChannelEndpointChanged;
 pub use reconnect::Reconnect;
 pub use setup_connection::{
-    has_requires_std_job, has_version_rolling, has_work_selection, Protocol, SetupConnection,
-    SetupConnectionError, SetupConnectionSuccess,
+    has_declare_tx_data, has_requires_std_job, has_version_rolling, has_work_selection, Protocol,
+    SetupConnection, SetupConnectionError, SetupConnectionSuccess,
 };
 
 // Discriminants for Stratum V2 (sub)protocols

--- a/sv2/subprotocols/common-messages/src/setup_connection.rs
+++ b/sv2/subprotocols/common-messages/src/setup_connection.rs
@@ -197,6 +197,11 @@ pub fn has_work_selection(flags: u32) -> bool {
     flag != 0
 }
 
+/// Helper function to check if `DECLARE_TX_DATA` bit flag present.
+pub fn has_declare_tx_data(flags: u32) -> bool {
+    flags & 0b1 != 0
+}
+
 /// Message used by an upstream role to accept a connection setup request from a downstream role.
 ///
 /// This message is sent in response to a [`SetupConnection`] message.
@@ -389,6 +394,21 @@ mod test {
         assert!(has_work_selection(flags));
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0001;
         assert!(!has_work_selection(flags));
+    }
+
+    #[test]
+    fn test_has_declare_tx_data() {
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0001;
+        assert!(has_declare_tx_data(flags));
+
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0010;
+        assert!(!has_declare_tx_data(flags));
+
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0000_1111;
+        assert!(has_declare_tx_data(flags));
+
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0000;
+        assert!(!has_declare_tx_data(flags));
     }
 
     fn create_setup_connection() -> SetupConnection<'static> {

--- a/sv2/subprotocols/common-messages/src/setup_connection.rs
+++ b/sv2/subprotocols/common-messages/src/setup_connection.rs
@@ -225,9 +225,7 @@ pub fn has_work_selection(flags: u32) -> bool {
 /// assert!(!has_declare_tx_data(0b_0000_0000_0000_0000_0000_0010));
 /// ```
 pub fn has_declare_tx_data(flags: u32) -> bool {
-    let flags = flags.reverse_bits();
-    let flag = flags >> 31;
-    flag != 0
+    flags & 0b1 != 0
 }
 
 /// Message used by an upstream role to accept a connection setup request from a downstream role.

--- a/sv2/subprotocols/common-messages/src/setup_connection.rs
+++ b/sv2/subprotocols/common-messages/src/setup_connection.rs
@@ -197,6 +197,39 @@ pub fn has_work_selection(flags: u32) -> bool {
     flag != 0
 }
 
+/// Helper function to check if `DECLARE_TX_DATA` bit flag present.
+///
+/// This flag is used in the Job Declaration Protocol to indicate that JDC
+/// (Job Declarator Client) agrees to reveal the template's txdata via
+/// `DeclareMiningJob` and `ProvideMissingTransactions`.
+///
+/// The `DECLARE_TX_DATA` flag is located at bit 0 (the least significant bit).
+///
+/// # Arguments
+///
+/// * `flags` - A `u32` representing the flags field from a `SetupConnection` message.
+///
+/// # Returns
+///
+/// Returns `true` if the `DECLARE_TX_DATA` flag (bit 0) is set, `false` otherwise.
+///
+/// # Example
+///
+/// ```
+/// use common_messages_sv2::has_declare_tx_data;
+///
+/// // Bit 0 is set
+/// assert!(has_declare_tx_data(0b_0000_0000_0000_0000_0000_0000_0000_0001));
+///
+/// // Bit 0 is not set
+/// assert!(!has_declare_tx_data(0b_0000_0000_0000_0000_0000_0010));
+/// ```
+pub fn has_declare_tx_data(flags: u32) -> bool {
+    let flags = flags.reverse_bits();
+    let flag = flags >> 31;
+    flag != 0
+}
+
 /// Message used by an upstream role to accept a connection setup request from a downstream role.
 ///
 /// This message is sent in response to a [`SetupConnection`] message.
@@ -389,6 +422,21 @@ mod test {
         assert!(has_work_selection(flags));
         let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0001;
         assert!(!has_work_selection(flags));
+    }
+
+    #[test]
+    fn test_has_declare_tx_data() {
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0001;
+        assert!(has_declare_tx_data(flags));
+
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0010;
+        assert!(!has_declare_tx_data(flags));
+
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0000_1111;
+        assert!(has_declare_tx_data(flags));
+
+        let flags = 0b_0000_0000_0000_0000_0000_0000_0000_0000;
+        assert!(!has_declare_tx_data(flags));
     }
 
     fn create_setup_connection() -> SetupConnection<'static> {

--- a/sv2/subprotocols/common-messages/src/setup_connection.rs
+++ b/sv2/subprotocols/common-messages/src/setup_connection.rs
@@ -198,32 +198,6 @@ pub fn has_work_selection(flags: u32) -> bool {
 }
 
 /// Helper function to check if `DECLARE_TX_DATA` bit flag present.
-///
-/// This flag is used in the Job Declaration Protocol to indicate that JDC
-/// (Job Declarator Client) agrees to reveal the template's txdata via
-/// `DeclareMiningJob` and `ProvideMissingTransactions`.
-///
-/// The `DECLARE_TX_DATA` flag is located at bit 0 (the least significant bit).
-///
-/// # Arguments
-///
-/// * `flags` - A `u32` representing the flags field from a `SetupConnection` message.
-///
-/// # Returns
-///
-/// Returns `true` if the `DECLARE_TX_DATA` flag (bit 0) is set, `false` otherwise.
-///
-/// # Example
-///
-/// ```
-/// use common_messages_sv2::has_declare_tx_data;
-///
-/// // Bit 0 is set
-/// assert!(has_declare_tx_data(0b_0000_0000_0000_0000_0000_0000_0000_0001));
-///
-/// // Bit 0 is not set
-/// assert!(!has_declare_tx_data(0b_0000_0000_0000_0000_0000_0010));
-/// ```
 pub fn has_declare_tx_data(flags: u32) -> bool {
     flags & 0b1 != 0
 }


### PR DESCRIPTION
Add helper function to check DECLARE_TX_DATA flag in SetupConnection.flags for Job Declaration Protocol, following the same pattern as existing helpers (has_requires_std_job, has_version_rolling, has_work_selection). Closes #2117