### PR TITLE
bump sv1-api dependent crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "stratum_translation"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "binary_sv2",
  "bitcoin",

--- a/stratum-core/Cargo.toml
+++ b/stratum-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratum-core"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"
@@ -26,7 +26,7 @@ mining_sv2 = { path = "../sv2/subprotocols/mining", version = "^8.0.0" }
 template_distribution_sv2 = { path = "../sv2/subprotocols/template-distribution", version = "^5.0.0" }
 job_declaration_sv2 = { path = "../sv2/subprotocols/job-declaration", version = "^7.0.0" }
 sv1_api = { path = "../sv1", version = "^4.0.0", optional = true }
-stratum_translation = { path = "stratum-translation", version = "^0.1.0", optional = true }
+stratum_translation = { path = "stratum-translation", version = "^0.2.0", optional = true }
 bitcoin = { workspace = true }
 
 [features]

--- a/stratum-core/stratum-translation/Cargo.toml
+++ b/stratum-core/stratum-translation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratum_translation"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Stratum V1 ↔ Stratum V2 translation utilities for reuse across proxies, apps, and firmware"


### PR DESCRIPTION
I forgot to bump sv1-api dependent crates here: https://github.com/stratum-mining/stratum/pull/2134, this PR does that.
