### PR TITLE
use rust 1.85 in `release-libs` workflow

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -23,8 +23,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install Rust (1.75)
-        uses: dtolnay/rust-toolchain@1.75
+      - name: Install Rust (1.85)
+        uses: dtolnay/rust-toolchain@1.85
 
       - name: Login
         run: cargo login ${{ secrets.CRATES_IO_DEPLOY_KEY }}
@@ -107,4 +107,3 @@ jobs:
       - name: Publish crate stratum-core
         run: |
           ./scripts/release-libs.sh stratum-core
-


### PR DESCRIPTION
Fix for https://github.com/stratum-mining/stratum/actions/runs/25380601487