### PR TITLE
fix validate_share panic after on_set_new_prev_hash in custom-work mode

### DIFF
--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -569,15 +569,21 @@ where
         &mut self,
         set_new_prev_hash: SetNewPrevHashTdp<'a>,
     ) -> Result<(), ExtendedChannelError> {
-        // clear the job id to target mapping
-        self.job_id_to_target.clear();
-
         // extended channels dedicated to custom work don't need to keep track of future jobs
         match self.job_store.has_future_jobs() {
             false => {
+                // demote the previously-active job to past so that the subsequent
+                // mark_past_jobs_as_stale call moves it into the stale set. without this,
+                // a late share for the still-active old job would skip the stale check in
+                // validate_share and panic on the missing job_id_to_target entry that we
+                // just cleared.
+                self.job_store.deactivate_job();
                 // explicitly mark past jobs as stale, because we're not going to
                 // do it implicitly via activate_future_job in case this extended channel is doing custom work
                 self.job_store.mark_past_jobs_as_stale();
+                // there is no active job in this branch, so any previous job target
+                // mappings are obsolete after the chain tip update.
+                self.job_id_to_target.clear();
             }
             true => {
                 // try to activate the future job, and also mark past jobs as stale
@@ -587,7 +593,9 @@ where
                 ) {
                     return Err(ExtendedChannelError::TemplateIdNotFound);
                 }
-
+                // clear the job id to target mapping only after a successful activation,
+                // so that an early-return error path does not corrupt channel state.
+                self.job_id_to_target.clear();
                 // associate the new active job with the current target
                 let job_id = self
                     .job_store
@@ -700,10 +708,13 @@ where
                 .get_stale_job(job_id)
                 .expect("stale job must exist")
         };
-        let job_target = self
-            .job_id_to_target
-            .get(&job_id)
-            .expect("job target must exist");
+        let Some(job_target) = self.job_id_to_target.get(&job_id) else {
+            self.share_accounting
+                .increment_rejected_shares(ERROR_CODE_SUBMIT_SHARES_INVALID_JOB_ID);
+            return Err(ShareValidationError::InvalidJobId(
+                ERROR_CODE_SUBMIT_SHARES_INVALID_JOB_ID,
+            ));
+        };
 
         let extranonce_size = share.extranonce.inner_as_ref().len();
         if extranonce_size != self.rollable_extranonce_size as usize {
@@ -2073,5 +2084,122 @@ mod tests {
             result.unwrap_err(),
             ExtendedChannelError::InvalidJobOrigin
         ));
+    }
+
+    #[test]
+    fn test_set_new_prev_hash_without_future_jobs_marks_active_as_stale() {
+        // Regression test: when on_set_new_prev_hash takes the no-future-jobs branch,
+        // the previously-active job must be moved to stale so that late shares are
+        // rejected as Stale instead of panicking on a missing job_id_to_target entry.
+        let channel_id = 1;
+        let user_identity = "user_identity".to_string();
+        let extranonce_prefix = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = Target::from_le_bytes([0xff; 32]);
+        let expected_share_per_minute = 1.0;
+        let nominal_hashrate = 100.0;
+        let version_rolling_allowed = true;
+        let rollable_extranonce_size = 8u16;
+        let share_batch_size = 100;
+        let job_store = DefaultJobStore::new();
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            user_identity,
+            ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
+            max_target,
+            nominal_hashrate,
+            version_rolling_allowed,
+            rollable_extranonce_size,
+            share_batch_size,
+            expected_share_per_minute,
+            job_store,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let template_id = 1;
+        let template = NewTemplate {
+            template_id,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![82, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0];
+        script_bytes.push(20);
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        let ntime = 1745596910;
+        let prev_hash = [
+            154, 124, 239, 231, 221, 122, 160, 173, 164, 175, 87, 33, 74, 214, 191, 107, 73, 34, 0,
+            162, 227, 16, 44, 40, 33, 73, 0, 0, 0, 0, 0, 0,
+        ]
+        .into();
+        let n_bits = 453040064;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+        channel.set_chain_tip(chain_tip);
+
+        channel
+            .on_new_template(template.clone(), coinbase_reward_outputs)
+            .unwrap();
+
+        let active_job_id = channel.get_active_job().unwrap().get_job_id();
+        assert!(!channel.job_store.has_future_jobs());
+
+        // Chain tip flip with no matching future job (typical of custom-work / JD flow
+        // where the channel never queues future jobs from a TDP NewTemplate).
+        let new_prev_hash = SetNewPrevHash {
+            template_id: 999,
+            prev_hash: [
+                200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144,
+                205, 88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+            ]
+            .into(),
+            header_timestamp: ntime + 600,
+            n_bits,
+            target: [0xff; 32].into(),
+        };
+
+        channel.on_set_new_prev_hash(new_prev_hash).unwrap();
+
+        // A miner's in-flight share for the now-old job arrives after the tip flip.
+        let late_share = SubmitSharesExtended {
+            channel_id,
+            sequence_number: 0,
+            job_id: active_job_id,
+            nonce: 0,
+            ntime: 1745596971,
+            version: 536870912,
+            extranonce: vec![1, 0, 0, 0, 0, 0, 0, 0].try_into().unwrap(),
+        };
+
+        let res = channel.validate_share(late_share);
+        assert!(matches!(res, Err(ShareValidationError::Stale(_))));
     }
 }

--- a/sv2/channels-sv2/src/server/jobs/job_store.rs
+++ b/sv2/channels-sv2/src/server/jobs/job_store.rs
@@ -39,6 +39,11 @@ pub trait JobStore<T: Job>: Send + Sync + Debug {
     /// Returns `true` if successful, `false` if not found.
     fn activate_future_job(&mut self, template_id: u64, prev_hash_header_timestamp: u32) -> bool;
 
+    /// Moves the active job (if any) into past jobs.
+    ///
+    /// Default impl is a no-op.
+    fn deactivate_job(&mut self) {}
+
     /// Marks all past jobs as stale, so that shares can be rejected with the appropriate error
     /// code
     fn mark_past_jobs_as_stale(&mut self);
@@ -147,6 +152,12 @@ impl<T: Job + Clone + Debug> JobStore<T> for DefaultJobStore<T> {
         self.mark_past_jobs_as_stale();
 
         true
+    }
+
+    fn deactivate_job(&mut self) {
+        if let Some(active_job) = self.active_job.take() {
+            self.past_jobs.insert(active_job.get_job_id(), active_job);
+        }
     }
 
     fn mark_past_jobs_as_stale(&mut self) {

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -533,9 +533,6 @@ where
         &mut self,
         set_new_prev_hash: SetNewPrevHash<'a>,
     ) -> Result<(), StandardChannelError> {
-        // clear the job id to target mapping
-        self.job_id_to_target.clear();
-
         match self.job_store.has_future_jobs() {
             false => {
                 return Err(StandardChannelError::TemplateIdNotFound);
@@ -548,6 +545,10 @@ where
                 ) {
                     return Err(StandardChannelError::TemplateIdNotFound);
                 }
+
+                // clear the job id to target mapping only after a successful activation,
+                // so that an early-return error path does not corrupt channel state.
+                self.job_id_to_target.clear();
 
                 // associate the new active job with the current target
                 let job_id = self
@@ -621,10 +622,13 @@ where
                 .expect("stale job must exist")
         };
 
-        let job_target = self
-            .job_id_to_target
-            .get(&job_id)
-            .expect("job target must exist");
+        let Some(job_target) = self.job_id_to_target.get(&job_id) else {
+            self.share_accounting
+                .increment_rejected_shares(ERROR_CODE_SUBMIT_SHARES_INVALID_JOB_ID);
+            return Err(ShareValidationError::InvalidJobId(
+                ERROR_CODE_SUBMIT_SHARES_INVALID_JOB_ID,
+            ));
+        };
 
         let merkle_root: [u8; 32] = job
             .get_merkle_root()
@@ -1537,6 +1541,127 @@ mod tests {
         assert!(matches!(
             ExtranoncePrefix::from_wire(new_extranonce_prefix_too_long),
             Err(ExtranoncePrefixError::ExceedsMaxLength)
+        ));
+    }
+
+    #[test]
+    fn test_set_new_prev_hash_without_future_jobs_preserves_state() {
+        // Regression test: when on_set_new_prev_hash is called with no future jobs to
+        // activate, it must return an error WITHOUT corrupting channel state. Previously
+        // the function cleared job_id_to_target before checking for future jobs, so a
+        // caller that treated the error as recoverable would crash on the next share at
+        // the `expect("job target must exist")` site.
+        let standard_channel_id = 1;
+        let user_identity = "user_identity".to_string();
+
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = Target::from_le_bytes([0xff; 32]);
+        let nominal_hashrate = 100.0;
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+        let job_store = DefaultJobStore::<StandardJob>::new();
+
+        let mut standard_channel = StandardChannel::new(
+            standard_channel_id,
+            user_identity,
+            ExtranoncePrefix::from_wire(extranonce_prefix.clone()).unwrap(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+            job_store,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967294,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 158,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0];
+        script_bytes.push(20);
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        let ntime = 1745596910;
+        let prev_hash = [
+            154, 124, 239, 231, 221, 122, 160, 173, 164, 175, 87, 33, 74, 214, 191, 107, 73, 34, 0,
+            162, 227, 16, 44, 40, 33, 73, 0, 0, 0, 0, 0, 0,
+        ]
+        .into();
+        let n_bits = 453040064;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        standard_channel.set_chain_tip(chain_tip);
+        standard_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs)
+            .unwrap();
+
+        let active_standard_job = standard_channel.get_active_job().unwrap();
+        let active_job_id = active_standard_job.get_job_id();
+        assert!(!standard_channel.job_store.has_future_jobs());
+
+        // No future jobs available -> on_set_new_prev_hash must return Err.
+        let snph = SetNewPrevHashTdp {
+            template_id: 999,
+            prev_hash: [
+                200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144,
+                205, 88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+            ]
+            .into(),
+            header_timestamp: ntime + 600,
+            n_bits,
+            target: [0xff; 32].into(),
+        };
+        let res = standard_channel.on_set_new_prev_hash(snph);
+        assert!(matches!(res, Err(StandardChannelError::TemplateIdNotFound)));
+
+        // Channel state must be preserved: active job still active, target entry intact.
+        // A subsequent share submission for the still-active job must NOT panic on a
+        // missing job_id_to_target entry. The share itself does not meet target, so we
+        // expect DoesNotMeetTarget — the load-bearing assertion is that it returns
+        // without panicking.
+        let share_low_diff = SubmitSharesStandard {
+            channel_id: standard_channel_id,
+            sequence_number: 0,
+            job_id: active_job_id,
+            nonce: 3,
+            ntime: 1745596932,
+            version: 536870912,
+        };
+        let res = standard_channel.validate_share(share_low_diff);
+        assert!(matches!(
+            res.unwrap_err(),
+            ShareValidationError::DoesNotMeetTarget(_)
         ));
     }
 }


### PR DESCRIPTION
## Body

Closes #2155.



- new `JobStore::deactivate_job` method that moves `active_job` into `past_jobs`
- `ExtendedChannel::on_set_new_prev_hash` false arm now calls `deactivate_job()` before `mark_past_jobs_as_stale()`, so the old active goes through past then stale and late shares for it return `Stale` instead of panicking
- `StandardChannel::on_set_new_prev_hash` reordered so `job_id_to_target.clear()` only runs after `activate_future_job(...)` returns true, so the error path can't corrupt state
- both `expect("job target must exist")` sites in `validate_share` (`extended.rs:675`, `standard.rs:597`) replaced with `ok_or(ShareValidationError::InvalidJobId)?`

### Two new tests

- `test_set_new_prev_hash_without_future_jobs_marks_active_as_stale` in `extended.rs` reproduces the panic from the issue and asserts `Err(Stale)` after the fix
- `test_set_new_prev_hash_without_future_jobs_preserves_state` in `standard.rs` confirms state survives the error and the next share validates without panic

Both tests fail with the original panic on unpatched code; full crate suite passes (74/74) after the fix.