### PR TITLE
add `ERROR_CODE_OPEN_MINING_CHANNEL_EXTENDED_CHANNELS_NOT_SUPPORTED_FOR_STANDARD_JOBS`

### DIFF
--- a/sv2/subprotocols/mining/src/lib.rs
+++ b/sv2/subprotocols/mining/src/lib.rs
@@ -102,6 +102,8 @@ pub const CHANNEL_BIT_SUBMIT_SHARES_SUCCESS: bool = true;
 // Commonly used OpenMiningChannelError error_code values.
 pub const ERROR_CODE_OPEN_MINING_CHANNEL_STANDARD_CHANNELS_NOT_SUPPORTED_FOR_CUSTOM_WORK: &str =
     "standard-channels-not-supported-for-custom-work";
+pub const ERROR_CODE_OPEN_MINING_CHANNEL_EXTENDED_CHANNELS_NOT_SUPPORTED_FOR_STANDARD_JOBS: &str =
+    "extended-channels-not-supported-for-standard-jobs";
 pub const ERROR_CODE_OPEN_MINING_CHANNEL_INVALID_USER_IDENTITY: &str = "invalid-user-identity";
 pub const ERROR_CODE_OPEN_MINING_CHANNEL_INVALID_NOMINAL_HASHRATE: &str =
     "invalid-nominal-hashrate";

--- a/sv2/subprotocols/mining/src/open_channel.rs
+++ b/sv2/subprotocols/mining/src/open_channel.rs
@@ -226,6 +226,7 @@ pub struct OpenMiningChannelError<'decoder> {
     /// Possible error codes:
     ///
     /// - standard-channels-not-supported-for-custom-work
+    /// - extended-channels-not-supported-for-standard-jobs
     /// - invalid-user-identity
     /// - invalid-nominal-hashrate
     /// - min-extranonce-size-too-large


### PR DESCRIPTION
pre-requisite for https://github.com/stratum-mining/sv2-apps/pull/490

follow-up to #2151 