### PR TITLE
buffer_sv2: expose POOL_CAPACITY

### DIFF
--- a/sv2/buffer-sv2/src/lib.rs
+++ b/sv2/buffer-sv2/src/lib.rs
@@ -53,7 +53,7 @@ use alloc::vec::Vec;
 
 pub use crate::buffer::BufferFromSystemMemory;
 pub use aes_gcm::aead::Buffer as AeadBuffer;
-pub use buffer_pool::BufferPool;
+pub use buffer_pool::{BufferPool, POOL_CAPACITY};
 pub use slice::Slice;
 
 /// Represents errors that can occur while writing data into a buffer.


### PR DESCRIPTION
## Summary
- Re-export `buffer_pool::POOL_CAPACITY` from the `buffer_sv2` crate root.
- Allows benchmarks and external users to access `buffer_sv2::POOL_CAPACITY` without reaching into the private `buffer_pool` module.

Closes #2130.

## Tests
- `cargo fmt --check`
- `cargo check -p buffer_sv2`
- `git diff --check`