### PR TITLE
adjust hex conversion on sv1 to use `bitcoin::hashes::hex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,15 +145,6 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "bitcoin_hashes"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
@@ -1276,7 +1267,7 @@ name = "sv1_api"
 version = "5.0.0"
 dependencies = [
  "binary_sv2",
- "bitcoin_hashes 0.3.2",
+ "bitcoin",
  "byteorder",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ exclude = [
 [workspace.dependencies]
 aes-gcm = { version = "0.10.2", default-features = false, features = ["alloc", "aes"] }
 bitcoin = "0.32.5"
-bitcoin_hashes = "0.3.2"
 byteorder = "1.2.7"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["alloc"] }
 criterion = "0.3"

--- a/sv1/Cargo.toml
+++ b/sv1/Cargo.toml
@@ -16,8 +16,6 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 [dependencies]
 binary_sv2 = { path = "../sv2/binary-sv2", version = "^6.0.0" }
 bitcoin = { workspace = true }
-# TODO: remove bitcoin_hashes
-bitcoin_hashes = { workspace = true }
 byteorder = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/sv1/Cargo.toml
+++ b/sv1/Cargo.toml
@@ -15,6 +15,8 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 
 [dependencies]
 binary_sv2 = { path = "../sv2/binary-sv2", version = "^6.0.0" }
+bitcoin = { workspace = true }
+# TODO: remove bitcoin_hashes
 bitcoin_hashes = { workspace = true }
 byteorder = { workspace = true }
 serde = { workspace = true }

--- a/sv1/src/error.rs
+++ b/sv1/src/error.rs
@@ -2,14 +2,13 @@ use crate::{
     methods::{Method, MethodError},
     utils::HexU32Be,
 };
-
+use bitcoin::hashes::hex::HexToBytesError;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error<'a> {
     BadBytesConvert(binary_sv2::Error),
-    BTCHashError(bitcoin_hashes::Error),
     /// Errors on bad hex decode/encode.
-    HexError(bitcoin_hashes::Error),
+    HexError(HexToBytesError),
     /// Errors if `ClientStatus` is in an unexpected state when a message is received. For example,
     /// if a `mining.subscribed` is received when the `ClientStatus` is in the `Init` state.
     IncorrectClientStatus(String),
@@ -44,8 +43,7 @@ impl std::fmt::Display for Error<'_> {
                 f,
                 "Bad U256 or B032 conversion (U256 length must be exactly 32 bytes; B032 length must be <= 32 bytes): {e:?}"
             ),
-            Error::BTCHashError(ref e) => write!(f, "Bitcoin Hashes Error: `{e:?}`"),
-            Error::HexError(ref e) => write!(f, "Bad hex encode/decode: `{e:?}`"),
+            Error::HexError(ref e) => write!(f, "Bad hex encode/decode: `{e}`"),
             Error::InvalidHexLen(ref val) => write!(f, "Hex string length is invalid: `{val}`"),
             Error::IncorrectClientStatus(s) => {
                 write!(f, "Client status is incompatible with message: `{s}`")
@@ -80,9 +78,9 @@ impl std::fmt::Display for Error<'_> {
     }
 }
 
-impl From<bitcoin_hashes::Error> for Error<'_> {
-    fn from(e: bitcoin_hashes::Error) -> Self {
-        Error::BTCHashError(e)
+impl From<HexToBytesError> for Error<'_> {
+    fn from(e: HexToBytesError) -> Self {
+        Error::HexError(e)
     }
 }
 

--- a/sv1/src/lib.rs
+++ b/sv1/src/lib.rs
@@ -42,7 +42,7 @@ pub mod json_rpc;
 pub mod methods;
 pub mod utils;
 
-use bitcoin_hashes::hex::FromHex;
+use crate::utils::hex_decode;
 use std::convert::{TryFrom, TryInto};
 use tracing::debug;
 
@@ -383,9 +383,7 @@ pub trait IsClient<'a> {
                     .subscribe(
                         server_id,
                         configure.id,
-                        Some(Extranonce::try_from(
-                            Vec::<u8>::from_hex("08000002").map_err(Error::HexError)?,
-                        )?),
+                        Some(Extranonce::try_from(hex_decode("08000002")?)?),
                     )
                     .ok();
                 Ok(subscribe)
@@ -760,7 +758,7 @@ mod tests {
 
     #[test]
     fn test_server_handle_invalid_message() {
-        let extranonce1 = Extranonce::try_from(Vec::<u8>::from_hex("08000002").unwrap()).unwrap();
+        let extranonce1 = Extranonce::try_from(hex_decode("08000002").unwrap()).unwrap();
         let mut server = TestServer::new(extranonce1, 4);
 
         // Create an invalid message (response)

--- a/sv1/src/methods/client_to_server.rs
+++ b/sv1/src/methods/client_to_server.rs
@@ -1,4 +1,5 @@
-use bitcoin_hashes::hex::{FromHex, ToHex};
+use crate::utils::hex_decode;
+use bitcoin::hashes::hex::DisplayHex;
 use serde_json::{
     Value,
     Value::{Array as JArrary, Null, Number as JNumber, String as JString},
@@ -168,7 +169,7 @@ impl Submit<'_> {
 
 impl From<Submit<'_>> for Message {
     fn from(submit: Submit) -> Self {
-        let ex: String = submit.extra_nonce2.0.inner_as_ref().to_hex();
+        let ex: String = submit.extra_nonce2.0.inner_as_ref().to_lower_hex_string();
         let mut params: Vec<Value> = vec![
             submit.user_name.into(),
             submit.job_id.into(),
@@ -200,7 +201,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JNumber(d), JNumber(e), JString(f)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
+                        Extranonce::try_from(hex_decode(c)?)?,
                         HexU32Be(d.as_u64().unwrap() as u32),
                         HexU32Be(e.as_u64().unwrap() as u32),
                         Some((f.as_str()).try_into()?),
@@ -208,7 +209,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JString(d), JString(e), JString(f)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
+                        Extranonce::try_from(hex_decode(c)?)?,
                         (d.as_str()).try_into()?,
                         (e.as_str()).try_into()?,
                         Some((f.as_str()).try_into()?),
@@ -216,7 +217,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JNumber(d), JNumber(e)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
+                        Extranonce::try_from(hex_decode(c)?)?,
                         HexU32Be(d.as_u64().unwrap() as u32),
                         HexU32Be(e.as_u64().unwrap() as u32),
                         None,
@@ -224,7 +225,7 @@ impl TryFrom<StandardRequest> for Submit<'_> {
                     [JString(a), JString(b), JString(c), JString(d), JString(e)] => (
                         a.into(),
                         b.into(),
-                        Extranonce::try_from(Vec::<u8>::from_hex(c)?)?,
+                        Extranonce::try_from(hex_decode(c)?)?,
                         (d.as_str()).try_into()?,
                         (e.as_str()).try_into()?,
                         None,
@@ -334,7 +335,7 @@ impl<'a> TryFrom<Subscribe<'a>> for Message {
 
     fn try_from(subscribe: Subscribe) -> Result<Self, Error> {
         let params = match (subscribe.agent_signature, subscribe.extranonce1) {
-            (a, Some(b)) => vec![a, b.0.inner_as_ref().to_hex()],
+            (a, Some(b)) => vec![a, b.0.inner_as_ref().to_lower_hex_string()],
             (a, None) => vec![a],
         };
         Ok(Message::StandardRequest(StandardRequest {

--- a/sv1/src/methods/mod.rs
+++ b/sv1/src/methods/mod.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use bitcoin_hashes::Error as BTCHashError;
+use bitcoin::hashes::hex::HexToBytesError;
 use std::convert::{TryFrom, TryInto};
 
 pub mod client_to_server;
@@ -23,9 +23,9 @@ pub enum MethodError<'a> {
     NotARequest,
 }
 
-impl From<BTCHashError> for ParsingMethodError {
-    fn from(btc_err: BTCHashError) -> Self {
-        ParsingMethodError::BTCHashError(Box::new(btc_err))
+impl From<HexToBytesError> for ParsingMethodError {
+    fn from(btc_err: HexToBytesError) -> Self {
+        ParsingMethodError::HexError(btc_err)
     }
 }
 
@@ -38,9 +38,7 @@ impl From<binary_sv2::Error> for ParsingMethodError {
 #[derive(Debug)]
 pub enum ParsingMethodError {
     BadU256Convert(Box<binary_sv2::Error>),
-    HexError(Box<BTCHashError>),
-    #[allow(clippy::upper_case_acronyms)]
-    BTCHashError(Box<BTCHashError>),
+    HexError(HexToBytesError),
     ValueNotAnArray(Box<serde_json::Value>),
     WrongArgs(Box<serde_json::Value>),
     ValueNotAString(Box<serde_json::Value>),
@@ -60,8 +58,7 @@ pub enum ParsingMethodError {
 impl From<Error<'_>> for ParsingMethodError {
     fn from(inner: Error) -> Self {
         match inner {
-            Error::HexError(e) => ParsingMethodError::HexError(Box::new(e)),
-            Error::BTCHashError(e) => ParsingMethodError::BTCHashError(Box::new(e)),
+            Error::HexError(e) => ParsingMethodError::HexError(e),
             Error::InvalidHexLen(s) => {
                 ParsingMethodError::InvalidHexLen(Box::new(serde_json::Value::String(s)))
             }

--- a/sv1/src/methods/server_to_client.rs
+++ b/sv1/src/methods/server_to_client.rs
@@ -1,4 +1,3 @@
-use bitcoin_hashes::hex::FromHex;
 use serde_json::{
     Value,
     Value::{Array as JArrary, Bool as JBool, Number as JNumber, String as JString},
@@ -10,7 +9,7 @@ use crate::{
     error::Error,
     json_rpc::{Message, Notification, Response},
     methods::ParsingMethodError,
-    utils::{Extranonce, HexBytes, HexU32Be, MerkleNode, PrevHash},
+    utils::{hex_decode, Extranonce, HexBytes, HexU32Be, MerkleNode, PrevHash},
 };
 
 // client.get_version()
@@ -268,7 +267,7 @@ impl TryFrom<Notification> for SetExtranonce<'_> {
             .ok_or_else(|| ParsingMethodError::not_array_from_value(msg.params.clone()))?;
         let (extra_nonce1, extra_nonce2_size) = match &params[..] {
             [JString(a), JNumber(b)] => (
-                Extranonce::try_from(Vec::<u8>::from_hex(a)?)?,
+                Extranonce::try_from(hex_decode(a)?)?,
                 b.as_u64()
                     .ok_or_else(|| ParsingMethodError::not_unsigned_from_value(b.clone()))?
                     as usize,

--- a/sv1/src/methods/server_to_client.rs
+++ b/sv1/src/methods/server_to_client.rs
@@ -728,6 +728,23 @@ fn subscribe_response_crash_on_object_in_subscriptions() {
     assert!(result.is_err());
 }
 
+#[test]
+fn subscribe_response_crash_on_non_ascii_hex_extranonce() {
+    let json = r#"{
+      "id": 0,
+      "error": null,
+      "result": [
+        ["mining.notify", "1"],
+        "55555ʛ",
+        4
+      ]
+    }"#;
+
+    let response: crate::json_rpc::Response = serde_json::from_str(json).unwrap();
+    let result = crate::methods::Server2ClientResponse::try_from(response);
+    assert!(result.is_err(), "{:?}", result);
+}
+
 impl VersionRollingParams {
     pub fn new(
         version_rolling_mask: HexU32Be,

--- a/sv1/src/utils.rs
+++ b/sv1/src/utils.rs
@@ -68,7 +68,7 @@ pub fn hex_decode_with_padding(s: &str) -> Result<Vec<u8>, Error<'static>> {
         s
     };
 
-    Ok(hex_decode(s)?)
+    hex_decode(s)
 }
 
 impl<'a> TryFrom<&str> for Extranonce<'a> {

--- a/sv1/src/utils.rs
+++ b/sv1/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::error::{self, Error};
 use binary_sv2::{B032, U256};
-use bitcoin_hashes::hex::{FromHex, ToHex};
+use bitcoin::hashes::hex::{DisplayHex, FromHex};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -15,7 +15,7 @@ pub struct Extranonce<'a>(pub B032<'a>);
 
 impl fmt::Display for Extranonce<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0.inner_as_ref().to_hex())
+        f.write_str(&self.0.inner_as_ref().to_lower_hex_string())
     }
 }
 
@@ -47,27 +47,41 @@ impl<'a> From<Extranonce<'a>> for Value {
     }
 }
 
-/// fix for error on odd-length hex sequences
-/// FIXME: find a nicer solution
-fn hex_decode(s: &str) -> Result<Vec<u8>, Error<'static>> {
-    if s.len() % 2 != 0 {
-        Vec::<u8>::from_hex(&format!("0{s}")).map_err(Error::HexError)
+/// Decodes a hexadecimal string into bytes.
+///
+/// Returns an error if the input has an odd length or contains
+/// non-hexadecimal characters.
+pub(crate) fn hex_decode(s: &str) -> Result<Vec<u8>, Error<'static>> {
+    Ok(Vec::<u8>::from_hex(s)?)
+}
+
+/// Decodes a hexadecimal string into bytes.
+///
+/// Odd-length inputs are left-padded with `0`.
+pub fn hex_decode_with_padding(s: &str) -> Result<Vec<u8>, Error<'static>> {
+    let padded;
+
+    let s = if s.len() % 2 != 0 {
+        padded = format!("0{s}");
+        &padded
     } else {
-        Vec::<u8>::from_hex(s).map_err(Error::HexError)
-    }
+        s
+    };
+
+    Ok(hex_decode(s)?)
 }
 
 impl<'a> TryFrom<&str> for Extranonce<'a> {
     type Error = error::Error<'a>;
 
     fn try_from(value: &str) -> Result<Self, Error<'a>> {
-        Ok(Extranonce(B032::try_from(hex_decode(value)?)?))
+        Ok(Extranonce(B032::try_from(hex_decode_with_padding(value)?)?))
     }
 }
 
 impl<'a> From<Extranonce<'a>> for String {
     fn from(bytes: Extranonce<'a>) -> String {
-        bytes.0.inner_as_ref().to_hex()
+        bytes.0.inner_as_ref().to_lower_hex_string()
     }
 }
 
@@ -122,7 +136,9 @@ impl TryFrom<&str> for HexU32Be {
             prefix.push('0');
         }
         prefix.push_str(value);
-        let parsed_bytes: [u8; 4] = FromHex::from_hex(&prefix)?;
+        let parsed_bytes: [u8; 4] = hex_decode(&prefix)?
+            .try_into()
+            .map_err(|_| Error::InvalidHexLen(prefix.clone()))?;
         Ok(HexU32Be(u32::from_be_bytes(parsed_bytes)))
     }
 }
@@ -130,7 +146,7 @@ impl TryFrom<&str> for HexU32Be {
 /// Helper Serializer
 impl From<HexU32Be> for String {
     fn from(v: HexU32Be) -> Self {
-        v.0.to_be_bytes().to_hex()
+        v.0.to_be_bytes().to_lower_hex_string()
     }
 }
 
@@ -146,7 +162,7 @@ impl Serialize for HexU32Be {
     where
         S: serde::Serializer,
     {
-        let serialized_string = self.0.to_be_bytes().to_hex();
+        let serialized_string = self.0.to_be_bytes().to_lower_hex_string();
         serializer.serialize_str(&serialized_string)
     }
 }
@@ -235,7 +251,7 @@ impl From<PrevHash<'_>> for String {
                 .write_u32::<BigEndian>(prev_hash_word)
                 .expect("Internal error: Could not write buffer");
         }
-        prev_hash_stratum_cursor.into_inner().to_hex()
+        prev_hash_stratum_cursor.into_inner().to_lower_hex_string()
     }
 }
 
@@ -265,7 +281,7 @@ pub struct MerkleNode<'a>(pub U256<'a>);
 
 impl fmt::Display for MerkleNode<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.inner_as_ref().to_hex())
+        write!(f, "{}", self.0.inner_as_ref().to_lower_hex_string())
     }
 }
 
@@ -314,7 +330,7 @@ impl<'a> TryFrom<&str> for MerkleNode<'a> {
 
 impl<'a> From<MerkleNode<'a>> for String {
     fn from(bytes: MerkleNode<'a>) -> String {
-        bytes.0.inner_as_ref().to_hex()
+        bytes.0.inner_as_ref().to_lower_hex_string()
     }
 }
 
@@ -326,7 +342,7 @@ pub struct HexBytes(Vec<u8>);
 
 impl fmt::Display for HexBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.to_hex())
+        write!(f, "{}", self.0.to_lower_hex_string())
     }
 }
 
@@ -374,7 +390,7 @@ impl TryFrom<&str> for HexBytes {
 
 impl From<HexBytes> for String {
     fn from(bytes: HexBytes) -> String {
-        bytes.0.to_hex()
+        bytes.0.to_lower_hex_string()
     }
 }
 
@@ -409,7 +425,7 @@ mod tests {
     #[quickcheck_macros::quickcheck]
     fn test_prev_hash(mut bytes: Vec<u8>) -> bool {
         bytes.resize(32, 0);
-        let be_hex = bytes.to_hex();
+        let be_hex = bytes.to_lower_hex_string();
         let me = PrevHash::try_from(be_hex.clone().as_str()).unwrap();
         let back_to_hex = String::from(me.clone());
         let back_to_hex_value = Value::from(me.clone());


### PR DESCRIPTION
closes #2201.

This PR replaces the use of `bitcoin_hashes@0.3.2`, which can panic when processing certain multibyte characters, with `bitcoin::hashes::hex`.

It also centralizes hex decoding behind a single utility function, `crate::utils::hex_decode`. Prior to this change, there were multiple hex conversion implementations scattered throughout the codebase, making behavior harder to reason about and maintain consistently.

While working on this issue, I also noticed inconsistent handling of odd-length hex strings. Some call sites would pad the input before decoding, while others would not.

After investigating the historical context (see #896), I introduced a dedicated wrapper named `hex_decode_with_padding`. The goal is to make padding an explicit and deliberate choice rather than an implicit side effect hidden within the decoding logic.

At the moment, `hex_decode_with_padding` is only used in the `TryFrom` implementation for `Extranonce`, which is the use case discussed in #896. The padding behavior for `Extranonce` also appears to be required to satisfy the unit test introduced in #1791.
