### PR TITLE
accelerate CI via `cargo binstall`

### DIFF
--- a/.github/workflows/fuzz_tests.yaml
+++ b/.github/workflows/fuzz_tests.yaml
@@ -25,8 +25,18 @@ jobs:
         run: |
           rustup override set ${{ steps.toolchain.outputs.name }}
 
+      # Install cargo-binstall so tool installs below use prebuilt binaries.
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.20.0
+        with:
+          version: "1.20.0"
+
+      # Install cargo-fuzz via cargo-binstall (no source build).
+      # Keep quick-install disabled to only use upstream release artifacts.
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo binstall --no-confirm --disable-telemetry --disable-strategies quick-install --locked cargo-fuzz
 
       - name: Checkout fuzzing corpus
         uses: actions/checkout@v4
@@ -36,6 +46,16 @@ jobs:
 
       - name: Run fuzz regressions
         run: |
+          # cargo-fuzz binaries installed via cargo-binstall can default to a
+          # musl target triple; derive the runner's rustc host triple so
+          # sanitizer builds run against the native target instead.
+          HOST_TARGET="$(rustc -vV | sed -n 's/^host: //p')"
+
+          if [ -z "$HOST_TARGET" ]; then
+            echo "Failed to detect rustc host target" >&2
+            exit 1
+          fi
+
           for TARGET in $(cargo fuzz list); do
             CORPUS_DIR="fuzz/repo-corpus/corpus/$TARGET"
 
@@ -47,6 +67,7 @@ jobs:
             fi
 
             echo "==> Running fuzz target: $TARGET"
-            cargo fuzz run "$TARGET" "$CORPUS_DIR" -- -runs=0 -max_total_time=30
+            # Keep target explicit to avoid sanitizer/libc mismatches when
+            # cargo-fuzz's bundled default target differs from the runner.
+            cargo fuzz run --target "$HOST_TARGET" "$TARGET" "$CORPUS_DIR" -- -runs=0 -max_total_time=30
           done
-

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -67,10 +67,19 @@ jobs:
         run: |
           brew install capnp
 
+      # Install cargo-binstall so tool installs below use prebuilt binaries.
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.20.0
+        with:
+          version: "1.20.0"
+
+      # Install cargo-nextest via cargo-binstall (no source build).
+      # Keep quick-install disabled to only use upstream release artifacts.
       - name: Install cargo-nextest
-        run: cargo install cargo-nextest --version 0.9.100 --locked
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo binstall --no-confirm --disable-telemetry --disable-strategies quick-install --locked cargo-nextest@0.9.100
 
       - name: Run Integration Tests Script
         if: steps.detect.outputs.should_run_integration_test == 'true'
         run: ./scripts/run-integration-tests.sh
-

--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -43,8 +43,18 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake
 
+      # Install cargo-binstall so tool installs below use prebuilt binaries.
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.20.0
+        with:
+          version: "1.20.0"
+
+      # Install cargo-semver-checks via cargo-binstall (no source build).
+      # Keep quick-install disabled to only use upstream release artifacts.
       - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --version 0.37.0 --locked
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo binstall --no-confirm --disable-telemetry --disable-strategies quick-install --locked cargo-semver-checks@0.37.0
 
       - name: Run semver checks for sv2/buffer-sv2
         working-directory: sv2/buffer-sv2
@@ -109,4 +119,3 @@ jobs:
       - name: Run semver checks for stratum-core
         working-directory: stratum-core
         run: cargo semver-checks
-


### PR DESCRIPTION
accelerate CI via [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall)

instead of compiling `cargo-nextest`, `cargo-semver-checks`, and `cargo-fuzz` on every run, we install pre-built binaries via `cargo-binstall`.

additional hardening:
- disable `quick-install` option to only use upstream release artifacts (instead of third-party quick-install artifacts)
- pass `GITHUB_TOKEN` to `cargo-binstall` to avoid unauthenticated GitHub API rate-limit fallback
- use `--locked` for deterministic fallback behavior if source install is ever needed
- run fuzz with an explicit rustc host target to avoid sanitizer/libc mismatches

estimated impact (latest successful PR run vs median of 5 recent comparable successful PR runs on the same workflows/jobs):

- `ci (ubuntu-latest)`:
  - tool install: `~2m33s -> ~2s` (**~99% reduction**)
  - total job: `~31m27s -> ~29m05s` (**~2m22s faster**, ~8%)
- `ci (macos-latest)`:
  - tool install: `~2m18s -> ~4s` (**~97% reduction**)
  - total job: `~30m16s -> ~29m01s` (**~1m15s faster**, ~4%)
- `semver-check`:
  - tool install: `~3m53s -> ~2s` (**~99% reduction**)
  - total job: `~7m12s -> ~3m17s` (**~3m55s faster**, ~54%)
- `fuzz`:
  - tool install: `~20s -> ~2s` (**~90% reduction**)
  - total job: `~1m14s -> ~1m01s` (**~13s faster**, ~18%)

critical-path wall clock improves (`~31m27s -> ~29m05s`, ~2m22s), while matrix jobs still run in parallel.