### PR TITLE
Return Header from Sv2Frame::get_header

### DIFF
--- a/sv2/codec-sv2/examples/encrypted.rs
+++ b/sv2/codec-sv2/examples/encrypted.rs
@@ -228,9 +228,7 @@ fn main() {
     }
 
     // Parse the decoded frame header and payload
-    let decoded_frame_header = decoded_frame
-        .get_header()
-        .expect("Failed to get the frame header");
+    let decoded_frame_header = decoded_frame.get_header();
 
     let decoded_msg: CustomMessage = binary_sv2::from_bytes(decoded_frame.payload())
         .expect("Failed to extract the message from the payload");

--- a/sv2/codec-sv2/examples/unencrypted.rs
+++ b/sv2/codec-sv2/examples/unencrypted.rs
@@ -80,9 +80,7 @@ fn main() {
     let mut decoded_frame = receiver_side(stream_receiver);
 
     // Parse the decoded frame header and payload
-    let decoded_frame_header = decoded_frame
-        .get_header()
-        .expect("Failed to get the frame header");
+    let decoded_frame_header = decoded_frame.get_header();
     let decoded_msg: CustomMessage = binary_sv2::from_bytes(decoded_frame.payload())
         .expect("Failed to extract the message from the payload");
 

--- a/sv2/codec-sv2/src/decoder.rs
+++ b/sv2/codec-sv2/src/decoder.rs
@@ -515,7 +515,7 @@ mod prop_tests {
                 None => return TestResult::discard(),
             };
 
-        let expected_ext_type = frame.get_header().unwrap().ext_type();
+        let expected_ext_type = frame.get_header().ext_type();
 
         let mut encoder = Encoder::<TestMessage>::new();
         let encoded = match encoder.encode(frame) {
@@ -526,10 +526,7 @@ mod prop_tests {
         let mut decoder = StandardDecoder::<TestMessage>::new();
         match decode_frame(&mut decoder, encoded.as_ref(), None) {
             Some(mut decoded_frame) => {
-                let header = match decoded_frame.get_header() {
-                    Some(h) => h,
-                    None => return TestResult::failed(),
-                };
+                let header = decoded_frame.get_header();
                 let actual_msg_type = header.msg_type();
                 let actual_ext_type = header.ext_type();
                 let decoded_msg: TestMessage = match binary_sv2::from_bytes(decoded_frame.payload())
@@ -725,7 +722,7 @@ mod prop_tests {
                 Some(f) => f,
                 None => return TestResult::discard(),
             };
-        let expected_ext = sv2_frame.get_header().unwrap().ext_type();
+        let expected_ext = sv2_frame.get_header().ext_type();
         let frame = Frame::Sv2(sv2_frame);
 
         let mut encoder = NoiseEncoder::<TestMessage>::new();
@@ -738,10 +735,7 @@ mod prop_tests {
         let encrypted_bytes: &[u8] = encrypted.as_ref();
         match decode_noise_frame(&mut decoder, &mut receiver_state, encrypted_bytes) {
             Some(mut decoded) => {
-                let header = match decoded.get_header() {
-                    Some(h) => h,
-                    None => return TestResult::failed(),
-                };
+                let header = decoded.get_header();
                 let decoded_msg: TestMessage = match binary_sv2::from_bytes(decoded.payload()) {
                     Ok(m) => m,
                     Err(_) => return TestResult::failed(),

--- a/sv2/framing-sv2/examples/sv2_frame.rs
+++ b/sv2/framing-sv2/examples/sv2_frame.rs
@@ -51,9 +51,7 @@ fn main() {
         .expect("Failed to deserialize frame");
 
     // Assert that deserialized header has the original content
-    let deserialized_header = deserialized_frame
-        .get_header()
-        .expect("Frame has no header");
+    let deserialized_header = deserialized_frame.get_header();
     assert_eq!(deserialized_header.msg_type(), MSG_TYPE);
     assert_eq!(deserialized_header.ext_type(), EXT_TYPE);
 

--- a/sv2/framing-sv2/src/framing.rs
+++ b/sv2/framing-sv2/src/framing.rs
@@ -108,9 +108,9 @@ impl<T: Serialize + GetSize, B: AsMut<[u8]> + AsRef<[u8]>> Sv2Frame<T, B> {
         }
     }
 
-    /// [`Sv2Frame`] always returns `Some(self.header)`.
-    pub fn get_header(&self) -> Option<crate::header::Header> {
-        Some(self.header)
+    /// Returns the [`Header`] for this [`Sv2Frame`].
+    pub fn get_header(&self) -> crate::header::Header {
+        self.header
     }
 
     /// Tries to build a [`Sv2Frame`] from raw bytes.
@@ -414,9 +414,7 @@ mod tests {
         let deserialized = Sv2Frame::<TestMessage, Vec<u8>>::from_bytes(buffer)
             .expect("Deserialization should succeed");
 
-        let header = deserialized
-            .get_header()
-            .expect("Sv2Frame should always have header");
+        let header = deserialized.get_header();
         assert_eq!(
             header.msg_type(),
             msg_type,
@@ -486,9 +484,7 @@ mod tests {
         )
         .unwrap();
 
-        let header = frame
-            .get_header()
-            .expect("Sv2Frame should always have header");
+        let header = frame.get_header();
         assert_eq!(
             header.channel_msg(),
             channel_msg,
@@ -498,7 +494,7 @@ mod tests {
     }
 
     #[quickcheck]
-    fn prop_sv2frame_get_header_always_some(msg: TestMessage) {
+    fn prop_sv2frame_get_header_returns_header(msg: TestMessage) {
         let msg_type = 0x01u8;
         let extension_type = 0x0000u16;
 
@@ -506,10 +502,9 @@ mod tests {
             Sv2Frame::<TestMessage, Vec<u8>>::from_message(msg, msg_type, extension_type, false)
                 .unwrap();
 
-        assert!(
-            frame.get_header().is_some(),
-            "Sv2Frame::get_header() should always return Some"
-        );
+        let header: Header = frame.get_header();
+        assert_eq!(header.msg_type(), msg_type);
+        assert_eq!(header.ext_type(), extension_type);
     }
 
     #[quickcheck]


### PR DESCRIPTION
## Summary
- Change `Sv2Frame::get_header()` to return `Header` directly instead of `Option<Header>`.
- Update related tests and examples to remove impossible `None` handling.

Fixes #2112.
companion https://github.com/stratum-mining/sv2-apps/pull/584

## Verification
- `cargo fmt --all --check`
- `cargo test -p framing_sv2`
- `cargo test -p codec_sv2`
- `cargo check --workspace --all-targets`
- `git diff --check`

Companion verification:
- `cargo fmt --all --check` in `integration-tests`, `miner-apps`, `pool-apps`, and `stratum-apps`
- `cargo check --manifest-path integration-tests/Cargo.toml` with `stratum-core` patched to this PR checkout
