### PR TITLE
bump `derive_codec_sv2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "derive_codec_sv2"
-version = "1.1.2"
+version = "1.1.3"
 
 [[package]]
 name = "digest"

--- a/sv2/binary-sv2/derive_codec/Cargo.toml
+++ b/sv2/binary-sv2/derive_codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_codec_sv2"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"


### PR DESCRIPTION
missed in #2185 + #2186