### PR TITLE
channels_sv2: reject undersized BIP141 coinbase parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "channels_sv2"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "binary_sv2",
  "bitcoin",

--- a/stratum-core/Cargo.toml
+++ b/stratum-core/Cargo.toml
@@ -20,7 +20,7 @@ framing_sv2 = { path = "../sv2/framing-sv2", version = "^7.0.0" }
 noise_sv2 = { path = "../sv2/noise-sv2", version = "^1.0.0" }
 parsers_sv2 = { path = "../sv2/parsers-sv2", version = "^0.5.0" }
 handlers_sv2 = { path = "../sv2/handlers-sv2", version = "^0.5.0" }
-channels_sv2 = { path = "../sv2/channels-sv2", version = "^7.0.0" }
+channels_sv2 = { path = "../sv2/channels-sv2", version = "^8.0.0" }
 common_messages_sv2 = { path = "../sv2/subprotocols/common-messages", version = "^8.0.0" }
 mining_sv2 = { path = "../sv2/subprotocols/mining", version = "^11.0.0" }
 template_distribution_sv2 = { path = "../sv2/subprotocols/template-distribution", version = "^6.0.0" }

--- a/stratum-core/stratum-translation/Cargo.toml
+++ b/stratum-core/stratum-translation/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 binary_sv2 = { path = "../../sv2/binary-sv2", version = "^6.0.0" }
 mining_sv2 = { path = "../../sv2/subprotocols/mining", version = "^11.0.0" }
-channels_sv2 = { path = "../../sv2/channels-sv2", version = "^7.0.0" }
+channels_sv2 = { path = "../../sv2/channels-sv2", version = "^8.0.0" }
 v1 = { path = "../../sv1", package = "sv1_api", version = "^5.0.0" }
 tracing = { workspace = true }
 bitcoin = { workspace = true }

--- a/sv2/channels-sv2/Cargo.toml
+++ b/sv2/channels-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "channels_sv2"
-version = "7.0.1"
+version = "8.0.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"

--- a/sv2/channels-sv2/src/bip141.rs
+++ b/sv2/channels-sv2/src/bip141.rs
@@ -11,6 +11,9 @@ const WITNESS_COUNT_LEN: usize = 1;
 const WITNESS_LEN_LEN: usize = 1;
 const WITNESS_DATA_LEN: usize = 32;
 const LOCKTIME_LEN: usize = 4;
+const BIP141_WITNESS_LEN: usize = WITNESS_COUNT_LEN + WITNESS_LEN_LEN + WITNESS_DATA_LEN;
+#[cfg(test)]
+const MIN_COINBASE_TX_SUFFIX_LEN: usize = BIP141_WITNESS_LEN + LOCKTIME_LEN;
 
 #[derive(Debug)]
 pub enum StripBip141Error {
@@ -18,6 +21,7 @@ pub enum StripBip141Error {
     FailedToDeserializeCoinbaseInputs,
     FailedToDeserializeCoinbaseOutputs,
     FailedToDeserializeCoinbaseLockTime,
+    FailedToDeserializeCoinbaseWitness,
 }
 
 /// Tries to strip the bip141 marker, flag and witness data from `coinbase_tx_prefix` and
@@ -29,14 +33,29 @@ pub enum StripBip141Error {
 /// If the coinbase transaction is already stripped of bip141, returns `Ok(None)`.
 /// If the coinbase transaction is not stripped, returns `Ok(Some((Vec<u8>, Vec<u8>)))` with the
 /// stripped `coinbase_tx_prefix` and `coinbase_tx_suffix`.
+///
+/// # Errors
+///
+/// Returns [`StripBip141Error::FailedToDeserializeCoinbaseInputs`] when
+/// `coinbase_tx_prefix` is too short to contain the marker and flag.
+///
+/// Returns [`StripBip141Error::FailedToDeserializeCoinbaseLockTime`] when a transaction with a
+/// bip141 marker and flag has a suffix too short to contain the lock time (suffix &lt; 4 bytes), or
+/// [`StripBip141Error::FailedToDeserializeCoinbaseWitness`] when the suffix is too short to
+/// contain the witness data and lock time (4 ≤ suffix &lt; 38 bytes).
 #[allow(clippy::type_complexity)]
 pub fn try_strip_bip141(
     coinbase_tx_prefix: &[u8],
     coinbase_tx_suffix: &[u8],
 ) -> Result<Option<(Vec<u8>, Vec<u8>)>, StripBip141Error> {
     // https://github.com/bitcoinbook/bitcoinbook/blob/third_edition_github/ch06_transactions.adoc#extended-marker-and-flag
-    let has_bip141_marker_and_flag =
-        (coinbase_tx_prefix[MARKER_OFFSET] == 0x00) && (coinbase_tx_prefix[FLAG_OFFSET] != 0x00);
+    let (Some(&marker), Some(&flag)) = (
+        coinbase_tx_prefix.get(MARKER_OFFSET),
+        coinbase_tx_prefix.get(FLAG_OFFSET),
+    ) else {
+        return Err(StripBip141Error::FailedToDeserializeCoinbaseInputs);
+    };
+    let has_bip141_marker_and_flag = marker == 0x00 && flag != 0x00;
 
     if !has_bip141_marker_and_flag {
         return Ok(None);
@@ -48,12 +67,16 @@ pub fn try_strip_bip141(
         .extend_from_slice(&coinbase_tx_prefix[MARKER_OFFSET + MARKER_FLAG_LEN..]);
 
     // strip bip141 witness bytes from coinbase_tx_suffix
-    let locktime_position = coinbase_tx_suffix.len() - LOCKTIME_LEN;
+    let locktime_position = coinbase_tx_suffix
+        .len()
+        .checked_sub(LOCKTIME_LEN)
+        .ok_or(StripBip141Error::FailedToDeserializeCoinbaseLockTime)?;
+    let witness_position = locktime_position
+        .checked_sub(BIP141_WITNESS_LEN)
+        .ok_or(StripBip141Error::FailedToDeserializeCoinbaseWitness)?;
 
     // strip witness count, witness length and witness data
-    let mut coinbase_tx_suffix_stripped_bip141 = coinbase_tx_suffix
-        [..locktime_position - WITNESS_COUNT_LEN - WITNESS_LEN_LEN - WITNESS_DATA_LEN]
-        .to_vec();
+    let mut coinbase_tx_suffix_stripped_bip141 = coinbase_tx_suffix[..witness_position].to_vec();
     coinbase_tx_suffix_stripped_bip141.extend_from_slice(&coinbase_tx_suffix[locktime_position..]);
 
     Ok(Some((
@@ -64,6 +87,8 @@ pub fn try_strip_bip141(
 
 #[cfg(test)]
 mod tests {
+
+    use alloc::vec;
 
     use super::*;
 
@@ -164,5 +189,61 @@ mod tests {
             ]
             .to_vec()
         );
+    }
+
+    #[test]
+    fn test_try_strip_bip141_rejects_short_prefix() {
+        let coinbase_tx_suffix = [0; MIN_COINBASE_TX_SUFFIX_LEN];
+
+        for prefix_len in 0..=FLAG_OFFSET {
+            let coinbase_tx_prefix = vec![0; prefix_len];
+
+            assert!(matches!(
+                try_strip_bip141(&coinbase_tx_prefix, &coinbase_tx_suffix),
+                Err(StripBip141Error::FailedToDeserializeCoinbaseInputs)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_try_strip_bip141_rejects_short_locktime_suffix() {
+        let coinbase_tx_prefix = [0, 0, 0, 0, 0, 1];
+
+        for suffix_len in 0..LOCKTIME_LEN {
+            let coinbase_tx_suffix = vec![0; suffix_len];
+
+            assert!(matches!(
+                try_strip_bip141(&coinbase_tx_prefix, &coinbase_tx_suffix),
+                Err(StripBip141Error::FailedToDeserializeCoinbaseLockTime)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_try_strip_bip141_rejects_short_witness_suffix() {
+        let coinbase_tx_prefix = [0, 0, 0, 0, 0, 1];
+
+        for suffix_len in LOCKTIME_LEN..MIN_COINBASE_TX_SUFFIX_LEN {
+            let coinbase_tx_suffix = vec![0; suffix_len];
+
+            assert!(matches!(
+                try_strip_bip141(&coinbase_tx_prefix, &coinbase_tx_suffix),
+                Err(StripBip141Error::FailedToDeserializeCoinbaseWitness)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_try_strip_bip141_accepts_minimum_lengths() {
+        let coinbase_tx_prefix = [0, 0, 0, 0, 0, 1];
+        let mut coinbase_tx_suffix = [0; MIN_COINBASE_TX_SUFFIX_LEN];
+        coinbase_tx_suffix[0] = 1;
+        coinbase_tx_suffix[1] = WITNESS_DATA_LEN as u8;
+
+        let result = try_strip_bip141(&coinbase_tx_prefix, &coinbase_tx_suffix)
+            .expect("minimum valid bip141 parts should be accepted")
+            .expect("bip141 marker and flag should be stripped");
+
+        assert_eq!(result, (vec![0; 4], vec![0; 4]));
     }
 }


### PR DESCRIPTION
## What changed

- validate `coinbase_tx_prefix` before reading the BIP141 marker and flag
- use checked arithmetic when locating witness data and lock time in `coinbase_tx_suffix`
- return the existing `StripBip141Error` variants instead of panicking on undersized inputs
- add regression coverage for every invalid prefix/suffix length and the minimum accepted boundary
- document the new error conditions

## Why

`try_strip_bip141` indexed bytes 4 and 5 without first checking the prefix length. For BIP141 inputs, it also subtracted the fixed witness and lock-time lengths from an unchecked suffix length. Malformed `NewExtendedMiningJob` coinbase parts could therefore panic consumers of `channels_sv2`.

The valid-input path and public API remain unchanged.

Fixes #2231.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p channels_sv2` — 80 unit tests and 3 doctests passed
- `cargo clippy -p channels_sv2 --lib -- -D warnings`
- `cargo check -p channels_sv2 --no-default-features --features no_std --lib`
