### PR TITLE
channels_sv2: keep failed group channel additions atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "channels_sv2"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "binary_sv2",
  "bitcoin",

--- a/sv2/channels-sv2/Cargo.toml
+++ b/sv2/channels-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "channels_sv2"
-version = "7.0.0"
+version = "7.0.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"

--- a/sv2/channels-sv2/src/client/group.rs
+++ b/sv2/channels-sv2/src/client/group.rs
@@ -62,8 +62,6 @@ impl<'a> GroupChannel<'a> {
         channel_id: u32,
         full_extranonce_size: usize,
     ) -> Result<(), GroupChannelError> {
-        self.channel_ids.insert(channel_id);
-
         match self.full_extranonce_size {
             // if the full extranonce size is already set, check if it matches the new full extranonce size
             Some(existing_size) => {
@@ -77,6 +75,7 @@ impl<'a> GroupChannel<'a> {
             }
         }
 
+        self.channel_ids.insert(channel_id);
         Ok(())
     }
 
@@ -195,5 +194,8 @@ mod tests {
         // add a third channel with a different full extranonce size
         // this should return an error
         assert!(group_channel.add_channel_id(3, 12).is_err());
+        assert_eq!(group_channel.get_channel_ids_count(), 2);
+        assert!(!group_channel.has_channel_id(3));
+        assert_eq!(group_channel.get_full_extranonce_size(), Some(10));
     }
 }

--- a/sv2/channels-sv2/src/server/group.rs
+++ b/sv2/channels-sv2/src/server/group.rs
@@ -154,12 +154,11 @@ impl<'a> GroupChannel<'a> {
         channel_id: u32,
         full_extranonce_size: usize,
     ) -> Result<(), GroupChannelError> {
-        self.channel_ids.insert(channel_id);
-
         if self.full_extranonce_size != full_extranonce_size {
             return Err(GroupChannelError::FullExtranonceSizeMismatch);
         }
 
+        self.channel_ids.insert(channel_id);
         Ok(())
     }
 
@@ -627,6 +626,8 @@ mod tests {
         assert!(group_channel
             .add_channel_id(3, new_full_extranonce_size)
             .is_err());
+        assert_eq!(group_channel.get_channel_ids_count(), 2);
+        assert!(!group_channel.has_channel_id(3));
 
         // set the full extranonce size to a new value
         group_channel.set_full_extranonce_size(new_full_extranonce_size);
@@ -647,5 +648,7 @@ mod tests {
         // add a fifth channel with the old full extranonce size
         // this should return an error because the full extranonce size is now set to 24
         assert!(group_channel.add_channel_id(5, 32).is_err());
+        assert_eq!(group_channel.get_channel_ids_count(), 1);
+        assert!(!group_channel.has_channel_id(5));
     }
 }


### PR DESCRIPTION
## What changed

- validate `full_extranonce_size` before inserting a channel ID in both client and server `GroupChannel`
- add regression assertions that rejected channel IDs do not remain in group state
- bump `channels_sv2` from `7.0.0` to `7.0.1`

## Why

Both `add_channel_id` implementations inserted into `channel_ids` before validating the requested full extranonce size. On mismatch they returned `FullExtranonceSizeMismatch`, but the rejected ID remained in the group, so a failed operation partially committed invalid state.

The regression assertions reproduced this on the previous implementation in both paths: after starting with two valid channels, a rejected third channel produced a count of `3` instead of `2`.

The fix preserves the existing API and validates before mutating the channel set.

## Validation

- regression test before the fix: both client and server assertions failed with actual count `3`, expected `2`
- `cargo +1.75.0 test -p channels_sv2`
- `cargo +1.75.0 check -p channels_sv2 --no-default-features --features no_std`
- `cargo +1.89.0 clippy --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`

Fixes #2233
