### PR TITLE
`channels_sv2`: harden arithmetic against overflow, underflow and division by zero

### DIFF
--- a/sv2/channels-sv2/src/client/share_accounting.rs
+++ b/sv2/channels-sv2/src/client/share_accounting.rs
@@ -109,6 +109,9 @@ impl ShareAccounting {
     /// Updates acceptance accounting based on a [`SubmitSharesSuccess`](mining_sv2::SubmitSharesSuccess) message from the
     /// upstream server.
     ///
+    /// Both `acknowledged_shares` and `acknowledged_work_sum` saturate at their respective
+    /// maximum values.
+    ///
     /// This should be called by the application layer when it receives upstream confirmation
     /// that shares were accepted. It is intentionally **not** called from `validate_share` —
     /// local validation only tracks the share for duplicate detection (via
@@ -118,7 +121,9 @@ impl ShareAccounting {
         new_submits_accepted_count: u32,
         new_shares_sum: u64,
     ) {
-        self.acknowledged_shares += new_submits_accepted_count;
+        self.acknowledged_shares = self
+            .acknowledged_shares
+            .saturating_add(new_submits_accepted_count);
         self.acknowledged_work_sum = self.acknowledged_work_sum.saturating_add(new_shares_sum);
     }
 
@@ -126,10 +131,12 @@ impl ShareAccounting {
     /// server.
     ///
     /// One call corresponds to one rejected share.
+    ///
+    /// Saturates at `u32::MAX`.
     pub fn on_share_rejection(&mut self, error_code: String) {
         self.rejected_shares
             .entry(error_code)
-            .and_modify(|v| *v += 1)
+            .and_modify(|v| *v = v.saturating_add(1))
             .or_insert(1);
     }
 
@@ -139,6 +146,8 @@ impl ShareAccounting {
     /// number. Called from `validate_share` — does **not** count the share as accepted.
     /// Acceptance accounting is deferred to [`on_share_acknowledgement`](Self::on_share_acknowledgement), which should be
     /// called when the upstream server confirms via [`SubmitSharesSuccess`](mining_sv2::SubmitSharesSuccess).
+    ///
+    /// `validated_shares` saturates at `u32::MAX`.
     pub fn track_validated_share(
         &mut self,
         share_sequence_number: u32,
@@ -146,7 +155,7 @@ impl ShareAccounting {
         share_work: f64,
     ) {
         self.last_share_sequence_number = share_sequence_number;
-        self.validated_shares += 1;
+        self.validated_shares = self.validated_shares.saturating_add(1);
         self.validated_work_sum += share_work;
         self.seen_shares.insert(share_hash);
     }
@@ -180,8 +189,13 @@ impl ShareAccounting {
     }
 
     /// Returns the total number of rejected shares across all error codes.
+    ///
+    /// Saturates at `u32::MAX`.
     pub fn get_rejected_shares_count(&self) -> u32 {
-        self.rejected_shares.values().copied().sum()
+        self.rejected_shares
+            .values()
+            .copied()
+            .fold(0, u32::saturating_add)
     }
 
     /// Returns an iterator over rejected shares by error code.
@@ -222,12 +236,66 @@ impl ShareAccounting {
     }
 
     /// Increments the blocks found counter.
+    ///
+    /// Saturates at `u32::MAX`.
     pub fn increment_blocks_found(&mut self) {
-        self.blocks_found += 1;
+        self.blocks_found = self.blocks_found.saturating_add(1);
     }
 
     /// Returns the total number of blocks found on this channel.
     pub fn get_blocks_found(&self) -> u32 {
         self.blocks_found
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShareAccounting;
+    use bitcoin::hashes::Hash as _;
+
+    #[test]
+    fn counters_saturate_at_u32_max() {
+        let mut accounting = ShareAccounting::new();
+
+        accounting.validated_shares = u32::MAX;
+        accounting.acknowledged_shares = u32::MAX - 1;
+        accounting.blocks_found = u32::MAX;
+
+        accounting.track_validated_share(0, bitcoin::hashes::sha256d::Hash::all_zeros(), 1.0);
+        assert_eq!(accounting.validated_shares, u32::MAX);
+        accounting.track_validated_share(1, bitcoin::hashes::sha256d::Hash::all_zeros(), 1.0);
+        assert_eq!(accounting.validated_shares, u32::MAX);
+
+        accounting.on_share_acknowledgement(1, 0);
+        assert_eq!(accounting.acknowledged_shares, u32::MAX);
+        accounting.on_share_acknowledgement(1, 0);
+        assert_eq!(accounting.acknowledged_shares, u32::MAX);
+
+        accounting.increment_blocks_found();
+        assert_eq!(accounting.blocks_found, u32::MAX);
+        accounting.increment_blocks_found();
+        assert_eq!(accounting.blocks_found, u32::MAX);
+    }
+
+    #[test]
+    fn rejected_shares_count_saturates() {
+        let mut accounting = ShareAccounting::new();
+
+        accounting.rejected_shares.insert("a".to_string(), u32::MAX);
+        accounting.rejected_shares.insert("b".to_string(), 1);
+
+        assert_eq!(accounting.get_rejected_shares_count(), u32::MAX);
+    }
+
+    #[test]
+    fn on_share_rejection_saturates() {
+        let mut accounting = ShareAccounting::new();
+
+        accounting
+            .rejected_shares
+            .insert("err".to_string(), u32::MAX);
+        accounting.on_share_rejection("err".to_string());
+
+        assert_eq!(accounting.rejected_shares.get("err"), Some(&u32::MAX));
     }
 }

--- a/sv2/channels-sv2/src/server/share_accounting.rs
+++ b/sv2/channels-sv2/src/server/share_accounting.rs
@@ -116,9 +116,11 @@ impl ShareAccounting {
     /// Intended to be called by channel validation paths when returning a
     /// [`ShareValidationError`] variant that carries an `error_code`.
     /// Validation errors that do not map to `SubmitShares.Error` should not be counted here.
+    ///
+    /// Saturates at `u32::MAX`.
     pub fn increment_rejected_shares(&mut self, error_code: &str) {
         if let Some(count) = self.rejected_shares.get_mut(error_code) {
-            *count += 1;
+            *count = count.saturating_add(1);
         } else {
             self.rejected_shares.insert(error_code.to_string(), 1);
         }
@@ -126,8 +128,9 @@ impl ShareAccounting {
 
     /// Updates internal accounting for a newly accepted share.
     ///
-    /// - Increments total shares accepted and work sum.
-    /// - Increments last batch accepted and work sum, resetting when a new batch starts.
+    /// - Increments total shares accepted (saturates at `u32::MAX`) and work sum.
+    /// - Increments last batch accepted (saturates at `u32::MAX`) and work sum,
+    ///   resetting when a new batch starts.
     /// - Updates last accepted sequence number.
     /// - Records the share hash to detect duplicates.
     pub fn update_share_accounting(
@@ -137,7 +140,7 @@ impl ShareAccounting {
         share_hash: Hash,
     ) {
         self.last_share_sequence_number = share_sequence_number;
-        self.shares_accepted += 1;
+        self.shares_accepted = self.shares_accepted.saturating_add(1);
         self.share_work_sum += share_work;
         self.seen_shares.insert(share_hash);
 
@@ -146,7 +149,7 @@ impl ShareAccounting {
             self.last_batch_work_sum = share_work;
             self.batch_acknowledged = false;
         } else {
-            self.last_batch_accepted += 1;
+            self.last_batch_accepted = self.last_batch_accepted.saturating_add(1);
             self.last_batch_work_sum += share_work;
         }
     }
@@ -198,8 +201,13 @@ impl ShareAccounting {
     }
 
     /// Returns the total number of rejected shares on this channel.
+    ///
+    /// Saturates at `u32::MAX`.
     pub fn get_rejected_shares_count(&self) -> u32 {
-        self.rejected_shares.values().copied().sum()
+        self.rejected_shares
+            .values()
+            .copied()
+            .fold(0, u32::saturating_add)
     }
 
     /// Returns the sum of work contributed by all accepted shares.
@@ -238,8 +246,10 @@ impl ShareAccounting {
     }
 
     /// Increments the blocks found counter.
+    ///
+    /// Saturates at `u32::MAX`.
     pub fn increment_blocks_found(&mut self) {
-        self.blocks_found += 1;
+        self.blocks_found = self.blocks_found.saturating_add(1);
     }
 
     /// Marks the current batch as acknowledged so the next accepted share starts a fresh batch.
@@ -260,6 +270,7 @@ impl ShareAccounting {
 #[cfg(test)]
 mod tests {
     use super::ShareAccounting;
+    use bitcoin::hashes::Hash as _;
 
     #[test]
     fn rejected_shares_are_tracked_by_error_code() {
@@ -278,5 +289,49 @@ mod tests {
             accounting.get_rejected_shares_error_count("duplicate-share"),
             1
         );
+    }
+
+    #[test]
+    fn counters_saturate_at_u32_max() {
+        let mut accounting = ShareAccounting::new(10);
+
+        accounting.shares_accepted = u32::MAX - 1;
+        accounting.blocks_found = u32::MAX;
+        accounting.last_batch_accepted = u32::MAX - 1;
+
+        accounting.update_share_accounting(1.0, 0, bitcoin::hashes::sha256d::Hash::all_zeros());
+        assert_eq!(accounting.shares_accepted, u32::MAX);
+        assert_eq!(accounting.last_batch_accepted, u32::MAX);
+
+        accounting.update_share_accounting(1.0, 1, bitcoin::hashes::sha256d::Hash::all_zeros());
+        assert_eq!(accounting.shares_accepted, u32::MAX);
+        assert_eq!(accounting.last_batch_accepted, u32::MAX);
+
+        accounting.increment_blocks_found();
+        assert_eq!(accounting.blocks_found, u32::MAX);
+        accounting.increment_blocks_found();
+        assert_eq!(accounting.blocks_found, u32::MAX);
+    }
+
+    #[test]
+    fn rejected_shares_count_saturates() {
+        let mut accounting = ShareAccounting::new(10);
+
+        accounting.rejected_shares.insert("a".to_string(), u32::MAX);
+        accounting.rejected_shares.insert("b".to_string(), 1);
+
+        assert_eq!(accounting.get_rejected_shares_count(), u32::MAX);
+    }
+
+    #[test]
+    fn increment_rejected_shares_saturates() {
+        let mut accounting = ShareAccounting::new(10);
+
+        accounting
+            .rejected_shares
+            .insert("err".to_string(), u32::MAX);
+        accounting.increment_rejected_shares("err");
+
+        assert_eq!(accounting.rejected_shares.get("err"), Some(&u32::MAX));
     }
 }

--- a/sv2/channels-sv2/src/target.rs
+++ b/sv2/channels-sv2/src/target.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloc::string::String;
 use binary_sv2::U256Owned;
 use bitcoin::{hash_types::BlockHash, hashes::Hash, Target};
-use core::{cmp::max, fmt::Write, ops::Div};
+use core::{fmt::Write, ops::Div};
 use primitive_types::U256 as U256Primitive;
 
 /// Converts a `u256` to a [`BlockHash`] type.
@@ -101,7 +101,7 @@ pub fn hash_rate_to_target(
     // this means that the denominator can never be zero
     // we add 100 in place of 1 because h*s is actually h*s*100, we in order to simplify later we
     // must calculate (h*s+1)*100
-    let h_times_s_plus_one = max(h_times_s, h_times_s + 1);
+    let h_times_s_plus_one = h_times_s.saturating_add(1);
 
     let h_times_s_plus_one = from_u128_to_u256(h_times_s_plus_one);
     let denominator = h_times_s_plus_one;
@@ -161,6 +161,12 @@ pub enum InputError {
 /// - `h`: Mining device hashrate (H/s).
 /// - `t`: Target threshold.
 /// - `s`: Shares per minute.
+///
+/// ## Errors
+/// - [`InputError::DivisionByZero`] if `share_per_min` is zero.
+/// - [`InputError::NegativeInput`] if `share_per_min` is negative.
+/// - [`InputError::ArithmeticOverflow`] if `target` is zero (the numerator `2^256` is not
+///   representable), or if the denominator overflows.
 pub fn hash_rate_from_target(target: U256Owned, share_per_min: f64) -> Result<f64, InputError> {
     // checks that we are not dividing by zero
     if share_per_min == 0.0 {
@@ -178,7 +184,12 @@ pub fn hash_rate_from_target(target: U256Owned, share_per_min: f64) -> Result<f6
     // note that [255_u8,;32] actually is 2^256 -1, but 2^256 -t = (2^256-1) - (t-1)
     let max_target = [255_u8; 32];
     let max_target = U256Primitive::from_big_endian(max_target.as_ref());
-    let numerator = max_target - (target - U256Primitive::one());
+    // `target == 0` would underflow here; it is also not representable
+    // (the true numerator would be 2^256), so reject it rather than panic.
+    let target_minus_one = target
+        .checked_sub(U256Primitive::one())
+        .ok_or(InputError::ArithmeticOverflow)?;
+    let numerator = max_target - target_minus_one;
     // now we calculate the denominator s(t+1)
     // *100 here to move the fractional bit up so we can make this an int later
     let shares_occurrency_frequence = 60_f64 / (share_per_min) * 100.0;
@@ -199,4 +210,24 @@ pub fn hash_rate_from_target(target: U256Owned, share_per_min: f64) -> Result<f6
     let result = numerator.div(denominator).low_u128();
     // we multiply back by 100 so that it cancels with the same factor at the denominator
     Ok(result as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hash_rate_from_target, hash_rate_to_target, InputError, U256Owned};
+
+    #[test]
+    fn zero_target_is_rejected_not_panic() {
+        let zero: U256Owned = [0u8; 32].into();
+        assert!(matches!(
+            hash_rate_from_target(zero, 10.0),
+            Err(InputError::ArithmeticOverflow)
+        ));
+    }
+
+    #[test]
+    fn huge_hashrate_does_not_overflow() {
+        // f64 -> u128 `as` casts saturate, so this drives h_times_s to u128::MAX.
+        assert!(hash_rate_to_target(f64::MAX, 1.0).is_ok());
+    }
 }

--- a/sv2/channels-sv2/src/vardiff/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/classic.rs
@@ -32,11 +32,20 @@ impl VardiffState {
     /// Creates a new `VardiffState` with a specific minimum hashrate.
     ///
     /// # Arguments
-    /// * `min_allowed_hashrate` - The minimum hashrate to enforce.
+    /// * `min_allowed_hashrate` - The minimum hashrate to enforce. A non-positive or non-finite
+    ///   value is meaningless as a floor (and would reintroduce the division-by-zero that
+    ///   [`Vardiff::try_vardiff`] guards against), so it falls back to the default.
     pub fn new_with_min(min_allowed_hashrate: f32) -> Result<Self, VardiffError> {
         let timestamp_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs();
+
+        let min_allowed_hashrate = if min_allowed_hashrate.is_finite() && min_allowed_hashrate > 0.0
+        {
+            min_allowed_hashrate
+        } else {
+            DEFAULT_MIN_HASHRATE
+        };
 
         Ok(VardiffState {
             shares_since_last_update: 0,
@@ -128,6 +137,35 @@ impl Vardiff for VardiffState {
             return Ok(None);
         }
 
+        // `min_allowed_hashrate` is validated in `new_with_min`, but the field is `pub`,
+        // so direct assignment can still plant a non-finite or non-positive floor;
+        // sanitize it here as well before relying on it.
+        let min_hashrate =
+            if self.min_allowed_hashrate.is_finite() && self.min_allowed_hashrate > 0.0 {
+                self.min_allowed_hashrate
+            } else {
+                DEFAULT_MIN_HASHRATE
+            };
+
+        // `hashrate` is the channel's nominal hashrate, which originates from the
+        // miner-supplied `nominal_hash_rate` and is only checked for negativity upstream.
+        // It is the divisor for the delta percentage below and the base every special-case
+        // cap scales (`hashrate * 10.0`, `hashrate / 1.5`), so a value at or below the floor
+        // just pins the result back to that floor instead of converging, and `0.0`/`NaN`
+        // produce `inf`/`NaN` percentages that disable every `should_update` arm outright.
+        // The output is already clamped to the floor below, so clamp the baseline to the
+        // same floor. `is_finite` is still needed: `inf` survives a plain `max()` and makes
+        // the percentage `inf / inf == NaN`.
+        let hashrate = if hashrate.is_finite() {
+            hashrate.max(min_hashrate)
+        } else {
+            debug!(
+                target: "vardiff",
+                "Prior hashrate {hashrate} unusable; using minimum {min_hashrate}",
+            );
+            min_hashrate
+        };
+
         let realized_share_per_min =
             self.shares_since_last_update as f64 / (delta_time as f64 / 60.0);
 
@@ -198,14 +236,14 @@ impl Vardiff for VardiffState {
                 _ => hashrate * 3.0,
             };
         }
-        if new_hashrate < self.min_allowed_hashrate {
+        if new_hashrate < min_hashrate {
             debug!(
                 target: "vardiff",
                 "New hashrate {:.2} H/s below minimum threshold {:.2} H/s — clamping",
                 new_hashrate,
-                self.min_allowed_hashrate
+                min_hashrate
             );
-            new_hashrate = self.min_allowed_hashrate;
+            new_hashrate = min_hashrate;
         }
         self.reset_counter()?;
 

--- a/sv2/channels-sv2/src/vardiff/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/classic.rs
@@ -104,7 +104,25 @@ impl Vardiff for VardiffState {
             .map_err(VardiffError::TimeError)?
             .as_secs();
 
-        let delta_time = now - self.timestamp_of_last_update;
+        let delta_time = match now.checked_sub(self.timestamp_of_last_update) {
+            Some(delta_time) => delta_time,
+            None => {
+                // The clock stepped backwards (e.g. NTP correction), leaving the recorded
+                // timestamp in the future, so elapsed time is unmeasurable. Re-anchor the
+                // window to `now` and skip just this round: the `delta_time <= 15` guard
+                // below returns before `reset_counter()` runs, so without re-anchoring here
+                // every later round would measure against the same stale future timestamp
+                // and vardiff would stall for the whole length of the backwards step.
+                debug!(
+                    target: "vardiff",
+                    "Clock stepped backwards (recorded {}, now {}); re-anchoring vardiff window",
+                    self.timestamp_of_last_update,
+                    now
+                );
+                self.reset_counter()?;
+                return Ok(None);
+            }
+        };
 
         if delta_time <= 15 {
             return Ok(None);

--- a/sv2/channels-sv2/src/vardiff/test/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/test/classic.rs
@@ -5,8 +5,8 @@ use crate::vardiff::test::{
 use crate::{target::hash_rate_to_target, vardiff::VardiffError, VardiffState};
 
 use super::{
-    test_increment_and_reset_shares, test_try_vardiff_low_hashrate_decrease_target,
-    test_try_vardiff_no_shares_30_to_60s_decrease,
+    test_backwards_clock_step_reanchors_window, test_increment_and_reset_shares,
+    test_try_vardiff_low_hashrate_decrease_target, test_try_vardiff_no_shares_30_to_60s_decrease,
     test_try_vardiff_no_shares_less_than_30s_decrease,
     test_try_vardiff_no_shares_more_than_60s_decrease,
     test_try_vardiff_stable_hashrate_minimal_change_or_no_change,
@@ -30,6 +30,12 @@ fn test_initialization_and_getters() {
 fn test_increment_and_reset_shares_classic() {
     let mut vardiff = new_test_vardiff_state().expect("Failed to create VardiffState");
     test_increment_and_reset_shares(&mut vardiff)
+}
+
+#[test]
+fn test_backwards_clock_step_reanchors_window_classic() {
+    let mut vardiff = new_test_vardiff_state().expect("Failed to create VardiffState");
+    test_backwards_clock_step_reanchors_window(&mut vardiff);
 }
 
 #[test]

--- a/sv2/channels-sv2/src/vardiff/test/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/test/classic.rs
@@ -121,3 +121,70 @@ fn test_try_vardiff_hashrate_clamps_to_minimum() {
     );
     assert_eq!(vardiff.shares_since_last_update(), 0);
 }
+
+// Every unusable prior hashrate must fall back to the configured floor. `hashrate` is
+// the divisor for the delta percentage and the base every special-case cap scales, so
+// without the fallback: `0.0` pins to the floor forever (`0.0 * 10.0` is absorbing),
+// a value below the floor pins to it for the round, `NaN` makes every `should_update`
+// arm compare false, and `inf` makes the percentage `inf / inf == NaN` with the same
+// effect. A miner picks this value via `nominal_hash_rate` at channel open.
+#[test]
+fn test_try_vardiff_unusable_prior_hashrate_falls_back_to_floor() {
+    for bad in [0.0_f32, 0.01, -5.0, f32::NAN, f32::INFINITY] {
+        let mut vardiff = VardiffState::new_with_min(TEST_MIN_ALLOWED_HASHRATE)
+            .expect("Failed to create VardiffState");
+
+        let target = hash_rate_to_target(1000.0_f64, TEST_SHARES_PER_MINUTE.into()).unwrap();
+
+        // 1000 shares in 16s => 3750 shares/min, far above TEST_SHARES_PER_MINUTE.
+        simulate_shares_and_wait(&mut vardiff, 1000, 16);
+
+        match vardiff.try_vardiff(bad, &target, TEST_SHARES_PER_MINUTE) {
+            Ok(Some(v)) => assert!(
+                v.is_finite() && v > TEST_MIN_ALLOWED_HASHRATE * 1.5,
+                "prior hashrate {bad} pinned difficulty to the floor: {v}"
+            ),
+            other => panic!("prior hashrate {bad} silently disabled vardiff: {other:?}"),
+        }
+    }
+}
+
+// `min_allowed_hashrate` is a `pub` field, so the validation in `new_with_min` can be
+// bypassed by direct assignment; `try_vardiff` must sanitize the floor itself before
+// relying on it as the fallback baseline and the output clamp.
+#[test]
+fn test_try_vardiff_sanitizes_unusable_floor() {
+    for bad_floor in [0.0_f32, -5.0, f32::NAN, f32::INFINITY] {
+        let mut vardiff = VardiffState::new_with_min(TEST_MIN_ALLOWED_HASHRATE)
+            .expect("Failed to create VardiffState");
+        vardiff.min_allowed_hashrate = bad_floor;
+
+        let target = hash_rate_to_target(1000.0_f64, TEST_SHARES_PER_MINUTE.into()).unwrap();
+
+        // 1000 shares in 16s => 3750 shares/min, far above TEST_SHARES_PER_MINUTE.
+        simulate_shares_and_wait(&mut vardiff, 1000, 16);
+
+        // prior hashrate 0.0 forces the fallback onto the (unusable) floor
+        match vardiff.try_vardiff(0.0, &target, TEST_SHARES_PER_MINUTE) {
+            Ok(Some(v)) => assert!(
+                v.is_finite() && v > 0.0,
+                "floor {bad_floor} produced unusable hashrate {v}"
+            ),
+            other => panic!("floor {bad_floor} silently disabled vardiff: {other:?}"),
+        }
+    }
+}
+
+// The floor itself is the fallback baseline used by `try_vardiff`, so a non-positive or
+// non-finite `min_allowed_hashrate` would reintroduce the division by zero.
+#[test]
+fn test_new_with_min_rejects_unusable_floor() {
+    for bad in [0.0_f32, -5.0, f32::NAN, f32::INFINITY] {
+        let vardiff = VardiffState::new_with_min(bad).expect("Failed to create VardiffState");
+        let min = vardiff.min_allowed_hashrate();
+        assert!(
+            min.is_finite() && min > 0.0,
+            "min_allowed_hashrate {min} from input {bad} is unusable as a baseline"
+        );
+    }
+}

--- a/sv2/channels-sv2/src/vardiff/test/mod.rs
+++ b/sv2/channels-sv2/src/vardiff/test/mod.rs
@@ -55,6 +55,36 @@ pub fn test_increment_and_reset_shares<V: Vardiff>(vardiff: &mut V) {
     );
 }
 
+// A backwards clock step (e.g. an NTP correction) leaves the recorded timestamp in the
+// future. `try_vardiff` must decline to adjust rather than panic on the elapsed-time
+// subtraction, and it must re-anchor the window: the `delta_time <= 15` early return runs
+// before `reset_counter()`, so leaving the future timestamp in place would stall vardiff
+// for the entire length of the clock step, not just one round.
+pub fn test_backwards_clock_step_reanchors_window<V: Vardiff>(vardiff: &mut V) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    // Pretend the last update happened an hour in the future.
+    vardiff.set_timestamp_of_last_update(now + 3600);
+
+    let target =
+        hash_rate_to_target(TEST_INITIAL_HASHRATE.into(), TEST_SHARES_PER_MINUTE.into()).unwrap();
+
+    assert!(matches!(
+        vardiff.try_vardiff(TEST_INITIAL_HASHRATE, &target, TEST_SHARES_PER_MINUTE),
+        Ok(None)
+    ));
+
+    assert!(
+        vardiff.last_update_timestamp() <= now + 1,
+        "window not re-anchored (timestamp still {}, now {}): vardiff would stall for the \
+         full length of the clock step",
+        vardiff.last_update_timestamp(),
+        now
+    );
+}
+
 // Ensures that `try_vardiff` results in a minimal or no change when the hashrate is stable.
 pub fn test_try_vardiff_stable_hashrate_minimal_change_or_no_change<V: Vardiff>(vardiff: &mut V) {
     let initial_hashrate = TEST_INITIAL_HASHRATE;


### PR DESCRIPTION
close #2238 
close https://github.com/project-loupe/audit-stratum/issues/54
close https://github.com/project-loupe/audit-stratum/issues/12
close https://github.com/project-loupe/audit-stratum/issues/75
close https://github.com/project-loupe/audit-stratum/issues/38
close https://github.com/project-loupe/audit-stratum/issues/74
close https://github.com/project-loupe/audit-stratum/issues/36
close https://github.com/project-loupe/audit-stratum/issues/16
close https://github.com/project-loupe/audit-stratum/issues/40