### PR TITLE
`channels_sv2`: fix coinbase `scriptSig` size/serialization defects that yield consensus-invalid coinbases

### DIFF
--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -298,13 +298,24 @@ impl ExtendedChannel {
     /// every job created under it has become stale. This prevents the allocator from handing the
     /// same extranonce space to another live channel while those jobs still validate shares.
     ///
-    /// Returns an error if the new extranonce prefix is too large.
+    /// Returns an error if the new extranonce prefix is too large, or if it would push the
+    /// assembled coinbase `scriptSig` past its budget (see
+    /// [`JobFactory::fits_script_sig_budget`]). The channel is left unchanged in both error
+    /// cases.
     pub fn set_extranonce_prefix(
         &mut self,
         extranonce_prefix: AllocatedExtranoncePrefix,
     ) -> Result<(), ExtendedChannelError> {
         if extranonce_prefix.len() > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtendedChannelError::ExtranoncePrefixTooLarge);
+        }
+
+        // re-run the constructor's invariant: a prefix that is individually valid can still push
+        // the assembled scriptSig past the consensus cap
+        if !self.job_factory.fits_script_sig_budget(
+            extranonce_prefix.len() + self.rollable_extranonce_size as usize,
+        ) {
+            return Err(ExtendedChannelError::ScriptSigSizeTooLarge);
         }
 
         let retired_extranonce_prefix =
@@ -934,6 +945,7 @@ mod tests {
             },
             share_accounting::{ShareValidationError, ShareValidationResult},
         },
+        MAX_EXTRANONCE_LEN,
     };
     use binary_sv2::{Sv2OptionOwned as Sv2Option, U256Owned as U256};
     use bitcoin::{transaction::TxOut, Amount, ScriptBuf, Target};
@@ -1848,6 +1860,50 @@ mod tests {
             channel.unwrap_err(),
             ExtendedChannelError::ScriptSigSizeTooLarge
         ));
+    }
+
+    #[test]
+    fn test_set_extranonce_prefix_rejects_oversized_script_sig() {
+        // start well within the budget
+        let original_prefix_len = 4;
+        let mut channel =
+            new_extended_channel_with_pool_tag(POOL_TAG_AT_SCRIPT_SIG_BUDGET, original_prefix_len)
+                .unwrap();
+        let original_prefix = channel.get_extranonce_prefix().to_vec();
+
+        // growing up to the budget is allowed
+        channel
+            .set_extranonce_prefix(
+                AllocatedExtranoncePrefix::for_test(vec![
+                    0xcd;
+                    EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET
+                ])
+                .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            channel.get_extranonce_prefix().len(),
+            EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET
+        );
+
+        // go back to the original prefix, so we can assert the channel is untouched on error
+        channel
+            .set_extranonce_prefix(
+                AllocatedExtranoncePrefix::for_test(original_prefix.clone()).unwrap(),
+            )
+            .unwrap();
+
+        // a prefix that is individually valid (<= MAX_EXTRANONCE_LEN) but pushes the assembled
+        // scriptSig one byte past the budget must be rejected
+        let oversized_prefix = vec![0xcd; EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET + 1];
+        assert!(oversized_prefix.len() <= MAX_EXTRANONCE_LEN as usize);
+        let res = channel
+            .set_extranonce_prefix(AllocatedExtranoncePrefix::for_test(oversized_prefix).unwrap());
+        assert!(matches!(
+            res.unwrap_err(),
+            ExtendedChannelError::ScriptSigSizeTooLarge
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &original_prefix[..]);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -118,6 +118,10 @@ impl ExtendedChannel {
     ///
     /// For non-JD jobs, `pool_tag_string` is added to the coinbase scriptSig as
     /// `Sv2/pool_tag_string//`.
+    ///
+    /// Returns [`ExtendedChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
+    /// full extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
+    /// budget, see [`JobFactory::fits_script_sig_budget`].
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_pool(
         channel_id: u32,
@@ -156,6 +160,10 @@ impl ExtendedChannel {
     ///
     /// The `pool_tag_string` and `miner_tag_string` are added to the coinbase scriptSig as
     /// `Sv2/pool_tag_string/miner_tag_string/`.
+    ///
+    /// Returns [`ExtendedChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
+    /// full extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
+    /// budget, see [`JobFactory::fits_script_sig_budget`].
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_job_declaration_client(
         channel_id: u32,
@@ -219,17 +227,13 @@ impl ExtendedChannel {
             return Err(ExtendedChannelError::ExtranoncePrefixTooLarge);
         }
 
-        let script_sig_size = 5 + // BIP34
-            1 + // OP_PUSHBYTES
-            3 + // "Sv2"
-            3 + // `/` delimiters
-            pool_tag.as_ref().map_or(0, |s| s.len()) +
-            miner_tag.as_ref().map_or(0, |s| s.len()) +
-            1 + // OP_PUSHBYTES
-            extranonce_prefix.len() +
-            rollable_extranonce_size as usize;
+        let job_factory = JobFactory::new(version_rolling_allowed, pool_tag, miner_tag);
 
-        if script_sig_size > 100 {
+        // conservative check against the spec's worst-case `NewTemplate::coinbase_prefix`.
+        // the exact size is re-checked against each actual template in `JobFactory::coinbase`
+        if !job_factory
+            .fits_script_sig_budget(extranonce_prefix.len() + rollable_extranonce_size as usize)
+        {
             return Err(ExtendedChannelError::ScriptSigSizeTooLarge);
         }
 
@@ -244,7 +248,7 @@ impl ExtendedChannel {
             nominal_hashrate,
             stable_hashrate: false,
             job_store: JobStore::new(),
-            job_factory: JobFactory::new(version_rolling_allowed, pool_tag, miner_tag),
+            job_factory,
             share_accounting: ShareAccounting::new(share_batch_size),
             expected_share_per_minute,
             chain_tip: None,
@@ -465,6 +469,13 @@ impl ExtendedChannel {
     ///
     /// Only meant to be used if REQUIRES_CUSTOM_WORK is NOT set on the connection this channel exists on.
     /// If this flag is set, on_set_custom_mining_job should be used instead.
+    ///
+    /// Returns [`ExtendedChannelError::JobFactoryError`] wrapping
+    /// [`JobFactoryError::ScriptSigSizeTooLarge`](crate::server::jobs::error::JobFactoryError::ScriptSigSizeTooLarge)
+    /// if the template's `coinbase_prefix` pushes the assembled coinbase `scriptSig` past
+    /// its budget. The constructor can only check against the spec's worst-case prefix (see
+    /// [`JobFactory::fits_script_sig_budget`]), so this is where an out-of-spec Template Provider
+    /// is caught.
     pub fn on_new_template(
         &mut self,
         template: NewTemplateOwned,
@@ -917,7 +928,10 @@ mod tests {
         server::{
             error::ExtendedChannelError,
             extended::ExtendedChannel,
-            jobs::extended::ExtendedJob,
+            jobs::{
+                extended::ExtendedJob,
+                factory::{MAX_COINBASE_PREFIX_SIZE, MAX_SCRIPT_SIG_SIZE},
+            },
             share_accounting::{ShareValidationError, ShareValidationResult},
         },
     };
@@ -1772,6 +1786,68 @@ mod tests {
             &not_so_permissive_max_target
         );
         assert_eq!(channel.get_target(), &not_so_permissive_max_target);
+    }
+
+    // a 48 char pool tag places the worst-case scriptSig exactly on the budget:
+    // 8 (MAX_COINBASE_PREFIX_SIZE) + 1 + 3 ("Sv2") + 3 + 48 (tag) + 1 + 28 + 8 (full extranonce)
+    // = 100
+    const POOL_TAG_AT_SCRIPT_SIG_BUDGET: usize = 48;
+    const EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET: usize = 28;
+    const ROLLABLE_EXTRANONCE_SIZE_AT_SCRIPT_SIG_BUDGET: u16 = 8;
+
+    fn new_extended_channel_with_pool_tag(
+        pool_tag_len: usize,
+        extranonce_prefix_len: usize,
+    ) -> Result<ExtendedChannel, ExtendedChannelError> {
+        ExtendedChannel::new(
+            1,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(vec![0xab; extranonce_prefix_len]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            ROLLABLE_EXTRANONCE_SIZE_AT_SCRIPT_SIG_BUDGET,
+            100,
+            1.0,
+            Some("x".repeat(pool_tag_len)),
+            None,
+        )
+    }
+
+    #[test]
+    fn test_new_rejects_oversized_script_sig() {
+        // exactly on the budget
+        let channel = new_extended_channel_with_pool_tag(
+            POOL_TAG_AT_SCRIPT_SIG_BUDGET,
+            EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET,
+        )
+        .unwrap();
+        assert_eq!(
+            channel
+                .job_factory
+                .script_sig_size(MAX_COINBASE_PREFIX_SIZE, channel.get_full_extranonce_size()),
+            MAX_SCRIPT_SIG_SIZE
+        );
+
+        // one byte over the budget, via a longer tag
+        let channel = new_extended_channel_with_pool_tag(
+            POOL_TAG_AT_SCRIPT_SIG_BUDGET + 1,
+            EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET,
+        );
+        assert!(matches!(
+            channel.unwrap_err(),
+            ExtendedChannelError::ScriptSigSizeTooLarge
+        ));
+
+        // one byte over the budget, via a longer extranonce prefix
+        let channel = new_extended_channel_with_pool_tag(
+            POOL_TAG_AT_SCRIPT_SIG_BUDGET,
+            EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET + 1,
+        );
+        assert!(matches!(
+            channel.unwrap_err(),
+            ExtendedChannelError::ScriptSigSizeTooLarge
+        ));
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/group.rs
+++ b/sv2/channels-sv2/src/server/group.rs
@@ -76,6 +76,10 @@ impl GroupChannel {
     ///
     /// For non-JD jobs, `pool_tag_string` is added to the coinbase scriptSig as
     /// `Sv2/pool_tag_string//`.
+    ///
+    /// Returns [`GroupChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
+    /// extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
+    /// budget, see [`JobFactory::fits_script_sig_budget`].
     pub fn new_for_pool(
         group_channel_id: u32,
         full_extranonce_size: usize,
@@ -100,6 +104,10 @@ impl GroupChannel {
     ///
     /// The `pool_tag_string` and `miner_tag_string` are added to the coinbase scriptSig as
     /// `Sv2/pool_tag_string/miner_tag_string/`.
+    ///
+    /// Returns [`GroupChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
+    /// extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
+    /// budget, see [`JobFactory::fits_script_sig_budget`].
     pub fn new_for_job_declaration_client(
         group_channel_id: u32,
         full_extranonce_size: usize,
@@ -122,23 +130,18 @@ impl GroupChannel {
         pool_tag: Option<String>,
         miner_tag: Option<String>,
     ) -> Result<Self, GroupChannelError> {
-        let script_sig_size = 5 + // BIP34
-            1 + // OP_PUSHBYTES
-            3 + // "Sv2"
-            3 + // `/` delimiters
-            pool_tag.as_ref().map_or(0, |s| s.len()) +
-            miner_tag.as_ref().map_or(0, |s| s.len()) +
-            1 + // OP_PUSHBYTES
-            full_extranonce_size;
+        let job_factory = JobFactory::new(true, pool_tag, miner_tag);
 
-        if script_sig_size > 100 {
+        // conservative check against the spec's worst-case `NewTemplate::coinbase_prefix`.
+        // the exact size is re-checked against each actual template in `JobFactory::coinbase`
+        if !job_factory.fits_script_sig_budget(full_extranonce_size) {
             return Err(GroupChannelError::ScriptSigSizeTooLarge);
         }
 
         Ok(Self {
             group_channel_id,
             channel_ids: HashSet::new(),
-            job_factory: JobFactory::new(true, pool_tag, miner_tag),
+            job_factory,
             job_store: JobStore::new(),
             chain_tip: None,
             full_extranonce_size,
@@ -237,6 +240,13 @@ impl GroupChannel {
     /// If the template is a future template, the chain tip is not used.
     /// If the template is not a future template, the chain tip must be set.
     /// Returns an error if a non-future job cannot be created due to missing chain tip.
+    ///
+    /// Returns [`GroupChannelError::JobFactoryError`] wrapping
+    /// [`JobFactoryError::ScriptSigSizeTooLarge`](crate::server::jobs::error::JobFactoryError::ScriptSigSizeTooLarge)
+    /// if the template's `coinbase_prefix` pushes the assembled coinbase `scriptSig` past its
+    /// budget. The constructor can only check against the spec's worst-case prefix (see
+    /// [`JobFactory::fits_script_sig_budget`]), so this is where an out-of-spec Template Provider
+    /// is caught.
     pub fn on_new_template(
         &mut self,
         template: NewTemplateOwned,
@@ -322,7 +332,14 @@ impl GroupChannel {
 mod tests {
     use crate::{
         chain_tip::ChainTip,
-        server::{error::GroupChannelError, group::GroupChannel},
+        server::{
+            error::GroupChannelError,
+            group::GroupChannel,
+            jobs::{
+                error::JobFactoryError,
+                factory::{MAX_COINBASE_PREFIX_SIZE, MAX_SCRIPT_SIG_SIZE},
+            },
+        },
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
     use bitcoin::{transaction::TxOut, Amount, ScriptBuf};
@@ -735,5 +752,108 @@ mod tests {
         // the failed activation must not have corrupted channel state
         assert!(group_channel.get_chain_tip().is_none());
         assert!(group_channel.get_active_job().is_none());
+    }
+
+    // a 52 char pool tag places the worst-case scriptSig exactly on the budget:
+    // 8 (MAX_COINBASE_PREFIX_SIZE) + 1 + 3 ("Sv2") + 3 + 52 (tag) + 1 + 32 (extranonce) = 100
+    const POOL_TAG_AT_SCRIPT_SIG_BUDGET: usize = 52;
+
+    #[test]
+    fn test_new_rejects_oversized_script_sig() {
+        let full_extranonce_size = 32;
+
+        // exactly on the budget
+        let group_channel = GroupChannel::new(
+            1,
+            full_extranonce_size,
+            Some("x".repeat(POOL_TAG_AT_SCRIPT_SIG_BUDGET)),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            group_channel
+                .job_factory
+                .script_sig_size(MAX_COINBASE_PREFIX_SIZE, full_extranonce_size),
+            MAX_SCRIPT_SIG_SIZE
+        );
+
+        // one byte over the budget
+        let group_channel = GroupChannel::new(
+            1,
+            full_extranonce_size,
+            Some("x".repeat(POOL_TAG_AT_SCRIPT_SIG_BUDGET + 1)),
+            None,
+        );
+        assert!(matches!(
+            group_channel.unwrap_err(),
+            GroupChannelError::ScriptSigSizeTooLarge
+        ));
+    }
+
+    #[test]
+    fn test_on_new_template_rejects_oversized_script_sig() {
+        let group_channel_id = 1;
+        let full_extranonce_size = 32;
+        let mut group_channel = GroupChannel::new(
+            group_channel_id,
+            full_extranonce_size,
+            Some("x".repeat(POOL_TAG_AT_SCRIPT_SIG_BUDGET)),
+            None,
+        )
+        .unwrap();
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        let template = |coinbase_prefix: Vec<u8>| NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: coinbase_prefix.try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // a spec-compliant 8 byte coinbase_prefix fits exactly
+        group_channel
+            .on_new_template(
+                template(vec![0xab; MAX_COINBASE_PREFIX_SIZE]),
+                coinbase_reward_outputs.clone(),
+            )
+            .unwrap();
+
+        // an out-of-spec Template Provider sending 9 bytes overflows the budget. without this
+        // check the group channel would distribute unmineable work to every channel in the group
+        let res = group_channel.on_new_template(
+            template(vec![0xab; MAX_COINBASE_PREFIX_SIZE + 1]),
+            coinbase_reward_outputs,
+        );
+        assert!(matches!(
+            res.unwrap_err(),
+            GroupChannelError::JobFactoryError(JobFactoryError::ScriptSigSizeTooLarge)
+        ));
     }
 }

--- a/sv2/channels-sv2/src/server/group.rs
+++ b/sv2/channels-sv2/src/server/group.rs
@@ -176,12 +176,29 @@ impl GroupChannel {
 
     /// Set the full extranonce size for this group channel.
     /// Also clears all channel IDs, as no channels can belong to the same group while having different `full_extranonce_size`s.
-    pub fn set_full_extranonce_size(&mut self, full_extranonce_size: usize) {
+    ///
+    /// Returns [`GroupChannelError::ScriptSigSizeTooLarge`] if the new size would push the
+    /// assembled coinbase `scriptSig` past its budget (see
+    /// [`JobFactory::fits_script_sig_budget`]), leaving the group channel unchanged.
+    pub fn set_full_extranonce_size(
+        &mut self,
+        full_extranonce_size: usize,
+    ) -> Result<(), GroupChannelError> {
+        // re-run the constructor's invariant, before touching any state
+        if !self
+            .job_factory
+            .fits_script_sig_budget(full_extranonce_size)
+        {
+            return Err(GroupChannelError::ScriptSigSizeTooLarge);
+        }
+
         if self.full_extranonce_size != full_extranonce_size {
             self.channel_ids.clear();
         }
 
         self.full_extranonce_size = full_extranonce_size;
+
+        Ok(())
     }
 
     pub fn get_full_extranonce_size(&self) -> usize {
@@ -657,7 +674,9 @@ mod tests {
         assert!(!group_channel.has_channel_id(3));
 
         // set the full extranonce size to a new value
-        group_channel.set_full_extranonce_size(new_full_extranonce_size);
+        group_channel
+            .set_full_extranonce_size(new_full_extranonce_size)
+            .unwrap();
         assert_eq!(
             group_channel.get_full_extranonce_size(),
             new_full_extranonce_size
@@ -788,6 +807,39 @@ mod tests {
             group_channel.unwrap_err(),
             GroupChannelError::ScriptSigSizeTooLarge
         ));
+    }
+
+    #[test]
+    fn test_set_full_extranonce_size_rejects_oversized_script_sig() {
+        let group_channel_id = 1;
+        let full_extranonce_size = 16;
+        let mut group_channel = GroupChannel::new(
+            group_channel_id,
+            full_extranonce_size,
+            Some("x".repeat(POOL_TAG_AT_SCRIPT_SIG_BUDGET)),
+            None,
+        )
+        .unwrap();
+        group_channel
+            .add_channel_id(1, full_extranonce_size)
+            .unwrap();
+
+        // growing up to the budget is allowed
+        group_channel.set_full_extranonce_size(32).unwrap();
+        assert_eq!(group_channel.get_full_extranonce_size(), 32);
+        // channel ids are cleared, since the full extranonce size changed
+        assert_eq!(group_channel.get_channel_ids_count(), 0);
+
+        group_channel.add_channel_id(1, 32).unwrap();
+
+        // one byte past the budget must be rejected, leaving the channel untouched
+        let res = group_channel.set_full_extranonce_size(33);
+        assert!(matches!(
+            res.unwrap_err(),
+            GroupChannelError::ScriptSigSizeTooLarge
+        ));
+        assert_eq!(group_channel.get_full_extranonce_size(), 32);
+        assert_eq!(group_channel.get_channel_ids_count(), 1);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/jobs/error.rs
+++ b/sv2/channels-sv2/src/server/jobs/error.rs
@@ -29,4 +29,7 @@ pub enum JobFactoryError {
     CoinbaseOutputsSumOverflow,
     InvalidCoinbaseOutputsSum,
     ChainTipRequired,
+    /// The assembled coinbase `scriptSig` would exceed the size mandated by Bitcoin consensus
+    /// rules (see `MAX_SCRIPT_SIG_SIZE`).
+    ScriptSigSizeTooLarge,
 }

--- a/sv2/channels-sv2/src/server/jobs/factory.rs
+++ b/sv2/channels-sv2/src/server/jobs/factory.rs
@@ -13,6 +13,9 @@
 //!   messages, assembling all required coinbase transaction data and metadata.
 //! - **Coinbase Output Validation**: Verifies that coinbase outputs match SV2 template constraints
 //!   and protocol rules.
+//! - **`scriptSig` Budget Enforcement**: Verifies that the assembled coinbase `scriptSig` fits
+//!   within [`MAX_SCRIPT_SIG_SIZE`]. This is the authoritative check, since the template's
+//!   `coinbase_prefix` is only known at job creation time.
 //! - **Version Rolling**: Tracks version rolling allowance for created jobs.
 //!
 //! ## Usage
@@ -38,6 +41,17 @@ use bitcoin::{
 use mining_sv2::{NewExtendedMiningJobOwned, NewMiningJobOwned, SetCustomMiningJobOwned};
 use std::convert::TryInto;
 use template_distribution_sv2::NewTemplateOwned;
+
+/// Maximum size, in bytes, of a coinbase transaction `scriptSig`, as mandated by Bitcoin
+/// consensus rules.
+pub const MAX_SCRIPT_SIG_SIZE: usize = 100;
+
+/// Maximum number of bytes that [`NewTemplateOwned::coinbase_prefix`] is allowed to contribute to
+/// the coinbase `scriptSig`, as mandated by the Sv2 Template Distribution Protocol spec.
+///
+/// The spec phrase "up to 8 bytes (not including the length byte)" refers to the `B0255` wire
+/// length prefix. The BIP34 script push opcode is already part of these 8 bytes.
+pub const MAX_COINBASE_PREFIX_SIZE: usize = 8;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 struct JobIdFactory {
@@ -113,11 +127,9 @@ impl JobFactory {
 
         // Create the proper OP_PUSHBYTES opcode based on data length
         let op_pushbytes = match pool_miner_tag.len() {
-            // 100 bytes are available for scriptSig
-            // subtract 5 for BIP34
-            // subtract 1 for OP_PUSHBYTES before pool/miner tag
-            // subtract 1+32 for extranonce (OP_PUSHBYTES + 32 bytes max)
-            len @ 1..=61 => len as u8,
+            // OP_PUSHBYTES_N is a valid single-byte push opcode only for N in 1..=75.
+            // The scriptSig budget is enforced separately, see `MAX_SCRIPT_SIG_SIZE`.
+            len @ 1..=75 => len as u8,
             _ => return Err(JobFactoryError::CoinbaseTxPrefixError),
         };
 
@@ -126,6 +138,51 @@ impl JobFactory {
         op_pushbytes_pool_miner_tag.extend_from_slice(&pool_miner_tag);
 
         Ok(op_pushbytes_pool_miner_tag)
+    }
+
+    /// Returns the number of bytes that the `Sv2/<pool>/<miner>/` tag assembled by
+    /// [`JobFactory::op_pushbytes_pool_miner_tag`] contributes to the coinbase `scriptSig`,
+    /// including the `OP_PUSHBYTES` opcode.
+    pub fn pool_miner_tag_size(&self) -> usize {
+        1 // OP_PUSHBYTES opcode
+            + 3 // "Sv2"
+            + 3 // three `/` delimiters
+            + self.pool_tag_string.as_ref().map_or(0, |s| s.len())
+            + self.miner_tag_string.as_ref().map_or(0, |s| s.len())
+    }
+
+    /// Returns the number of bytes of the coinbase `scriptSig` assembled by this factory, for a
+    /// [`NewTemplateOwned::coinbase_prefix`] of `coinbase_prefix_size` bytes and a full extranonce
+    /// of `full_extranonce_size` bytes.
+    ///
+    /// The assembled layout is:
+    /// `coinbase_prefix || OP_PUSHBYTES_N || Sv2/pool_tag/miner_tag/ || OP_PUSHBYTES_M ||
+    /// extranonce`
+    ///
+    /// Callers that do not have a template at hand (such as channel constructors) should pass
+    /// [`MAX_COINBASE_PREFIX_SIZE`] to get the worst-case size allowed by the spec.
+    pub fn script_sig_size(
+        &self,
+        coinbase_prefix_size: usize,
+        full_extranonce_size: usize,
+    ) -> usize {
+        coinbase_prefix_size
+            + self.pool_miner_tag_size()
+            + 1 // OP_PUSHBYTES opcode for the extranonce
+            + full_extranonce_size
+    }
+
+    /// Returns whether the coinbase `scriptSig` assembled by this factory fits within
+    /// [`MAX_SCRIPT_SIG_SIZE`], for a full extranonce of `full_extranonce_size` bytes and the
+    /// worst-case [`NewTemplateOwned::coinbase_prefix`] allowed by the spec
+    /// ([`MAX_COINBASE_PREFIX_SIZE`]).
+    ///
+    /// Meant for callers that do not have a template at hand, such as channel constructors and
+    /// extranonce setters. Since it assumes the largest in-spec prefix, a `true` here guarantees
+    /// that no in-spec template can overflow the budget; the exact size is still re-checked
+    /// against each actual template in `JobFactory::coinbase`.
+    pub fn fits_script_sig_budget(&self, full_extranonce_size: usize) -> bool {
+        self.script_sig_size(MAX_COINBASE_PREFIX_SIZE, full_extranonce_size) <= MAX_SCRIPT_SIG_SIZE
     }
 
     /// Creates a new job from a template.
@@ -568,6 +625,15 @@ impl JobFactory {
         coinbase_reward_outputs: Vec<TxOut>,
         full_extranonce_size: usize,
     ) -> Result<Transaction, JobFactoryError> {
+        // the template's coinbase_prefix is only known here, so this is the authoritative
+        // scriptSig budget check; channel constructors can only check against the spec's
+        // worst-case MAX_COINBASE_PREFIX_SIZE
+        if self.script_sig_size(template.coinbase_prefix.len(), full_extranonce_size)
+            > MAX_SCRIPT_SIG_SIZE
+        {
+            return Err(JobFactoryError::ScriptSigSizeTooLarge);
+        }
+
         // check that the sum of the additional coinbase outputs is equal to the value remaining in
         // the active template
         let mut coinbase_reward_outputs_sum = Amount::from_sat(0);
@@ -633,12 +699,8 @@ impl JobFactory {
         )?;
         let serialized_coinbase = serialize(&coinbase);
 
-        // Calculate the full `Sv2/<pool>/<miner>/` tag length including OP_PUSHBYTES opcode.
-        let pool_miner_tag_len = 1 // OP_PUSHBYTES opcode
-            + 3 // "Sv2"
-            + 3 // three "/" delimiters
-            + self.pool_tag_string.as_ref().map_or(0, |s| s.len())
-            + self.miner_tag_string.as_ref().map_or(0, |s| s.len());
+        // the full pool/miner tag length, including delimiters and OP_PUSHBYTES opcode
+        let pool_miner_tag_len = self.pool_miner_tag_size();
 
         // the coinbase scriptSig is limited to 100 bytes by Bitcoin consensus rules, which is
         // always below the 253 byte threshold where CompactSize switches from a 1-byte to a
@@ -671,12 +733,8 @@ impl JobFactory {
         )?;
         let serialized_coinbase = serialize(&coinbase);
 
-        // Calculate the full `Sv2/<pool>/<miner>/` tag length including OP_PUSHBYTES opcode.
-        let pool_miner_tag_len = 1 // OP_PUSHBYTES opcode
-            + 3 // "Sv2"
-            + 3 // three "/" delimiters
-            + self.pool_tag_string.as_ref().map_or(0, |s| s.len())
-            + self.miner_tag_string.as_ref().map_or(0, |s| s.len());
+        // the full pool/miner tag length, including delimiters and OP_PUSHBYTES opcode
+        let pool_miner_tag_len = self.pool_miner_tag_size();
 
         // the coinbase scriptSig is limited to 100 bytes by Bitcoin consensus rules, which is
         // always below the 253 byte threshold where CompactSize switches from a 1-byte to a
@@ -794,6 +852,83 @@ mod tests {
         };
 
         assert_eq!(job.get_job_message(), &expected_job);
+    }
+
+    // builds a template with the provided `coinbase_prefix`, reusing the same vectors as
+    // `test_new_pool_job` for everything else
+    fn template_with_coinbase_prefix(coinbase_prefix: Vec<u8>) -> NewTemplate {
+        NewTemplate {
+            template_id: 1,
+            future_template: true,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: coinbase_prefix.try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967295,
+            coinbase_tx_value_remaining: 5000000000,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        }
+    }
+
+    fn coinbase_reward_outputs() -> Vec<TxOut> {
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        vec![TxOut {
+            value: Amount::from_sat(5000000000),
+            script_pubkey: ScriptBuf::from(script_bytes),
+        }]
+    }
+
+    #[test]
+    fn test_coinbase_rejects_oversized_script_sig() {
+        // a 52 char pool tag places the worst-case scriptSig exactly on the budget:
+        // 8 (MAX_COINBASE_PREFIX_SIZE) + 1 + 3 ("Sv2") + 3 + 52 (tag) + 1 + 32 (extranonce) = 100
+        let pool_tag_string = "x".repeat(52);
+        let mut job_factory = JobFactory::new(true, Some(pool_tag_string), None);
+
+        assert_eq!(
+            job_factory.script_sig_size(MAX_COINBASE_PREFIX_SIZE, 32),
+            MAX_SCRIPT_SIG_SIZE
+        );
+
+        // a spec-compliant 8 byte coinbase_prefix fits exactly
+        let job = job_factory.new_extended_job(
+            1,
+            None,
+            vec![0; 32],
+            template_with_coinbase_prefix(vec![0xab; MAX_COINBASE_PREFIX_SIZE]),
+            coinbase_reward_outputs(),
+            32,
+        );
+        assert!(job.is_ok());
+
+        // an out-of-spec Template Provider sending 9 bytes overflows the budget, and must be
+        // rejected instead of yielding a consensus-invalid coinbase
+        let job = job_factory.new_extended_job(
+            1,
+            None,
+            vec![0; 32],
+            template_with_coinbase_prefix(vec![0xab; MAX_COINBASE_PREFIX_SIZE + 1]),
+            coinbase_reward_outputs(),
+            32,
+        );
+        assert!(matches!(
+            job.unwrap_err(),
+            JobFactoryError::ScriptSigSizeTooLarge
+        ));
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/jobs/factory.rs
+++ b/sv2/channels-sv2/src/server/jobs/factory.rs
@@ -411,6 +411,9 @@ impl JobFactory {
     ///
     /// It's up to the caller to ensure that the sum of the additional coinbase outputs is equal to
     /// available template revenue.
+    ///
+    /// Returns [`JobFactoryError::ScriptSigSizeTooLarge`] if the template's `coinbase_prefix`, the
+    /// pool/miner tag and the full extranonce do not fit within [`MAX_SCRIPT_SIG_SIZE`].
     #[allow(clippy::too_many_arguments)]
     pub fn new_custom_job(
         &self,
@@ -422,6 +425,15 @@ impl JobFactory {
         additional_coinbase_outputs: Vec<TxOut>,
         full_extranonce_size: usize,
     ) -> Result<SetCustomMiningJobOwned, JobFactoryError> {
+        // the `coinbase_prefix` assembled below carries this factory's pool/miner tag, so the
+        // regular scriptSig layout applies. catching it here means the Job Declarator Client fails
+        // locally instead of having the pool reject the `SetCustomMiningJob` it just sent
+        if self.script_sig_size(template.coinbase_prefix.len(), full_extranonce_size)
+            > MAX_SCRIPT_SIG_SIZE
+        {
+            return Err(JobFactoryError::ScriptSigSizeTooLarge);
+        }
+
         let coinbase_outputs_sum = additional_coinbase_outputs
             .iter()
             .map(|o| o.value.to_sat())
@@ -472,7 +484,13 @@ impl JobFactory {
 
     /// Creates a new Extended Job from a SetCustomMiningJob message.
     ///
-    /// Assumes that the SetCustomMiningJob message has already been validated.
+    /// Assumes that the SetCustomMiningJob message has already been validated, with the exception
+    /// of its `coinbase_prefix` length: since that arrives from a downstream Job Declarator Client,
+    /// it is bounded here rather than delegated to the caller.
+    ///
+    /// Returns [`JobFactoryError::ScriptSigSizeTooLarge`] if the message's `coinbase_prefix` and
+    /// the full extranonce do not fit within [`MAX_SCRIPT_SIG_SIZE`]. Note that a custom job's
+    /// `coinbase_prefix` already embeds the pool/miner tag, so no tag is added on top of it.
     ///
     /// To be used by Extended Channels on a Sv2 Pool Server.
     pub fn new_extended_job_from_custom_job(
@@ -543,6 +561,19 @@ impl JobFactory {
         m: SetCustomMiningJobOwned,
         full_extranonce_size: usize,
     ) -> Result<Transaction, JobFactoryError> {
+        // a custom job arrives from a downstream Job Declarator Client with the pool/miner tag
+        // already embedded in `coinbase_prefix`, so the assembled scriptSig is just the prefix
+        // followed by the extranonce, with no tag of ours to account for.
+        //
+        // this is untrusted input off the wire and nothing upstream of here bounds it, so the
+        // check cannot be delegated to the caller the way it is for a locally built job. an
+        // oversized prefix would otherwise yield a consensus-invalid coinbase, and past 252 bytes
+        // it would also break the one-byte CompactSize assumption the prefix/suffix split indexes
+        // rely on, silently mis-slicing the coinbase.
+        if m.coinbase_prefix.len() + full_extranonce_size > MAX_SCRIPT_SIG_SIZE {
+            return Err(JobFactoryError::ScriptSigSizeTooLarge);
+        }
+
         let deserialized_outputs =
             Vec::<TxOut>::consensus_decode(&mut m.coinbase_tx_outputs.to_owned_bytes().as_slice())
                 .map_err(|_| JobFactoryError::DeserializeCoinbaseOutputsError)?;
@@ -1038,5 +1069,92 @@ mod tests {
         };
 
         assert_eq!(custom_job.get_job_message(), &expected_job);
+    }
+
+    // builds a `SetCustomMiningJob` with the given `coinbase_prefix`, bypassing `new_custom_job`
+    // so the receiving side can be exercised with prefixes a well-behaved JDC would never send
+    fn custom_job_with_coinbase_prefix(coinbase_prefix: Vec<u8>) -> SetCustomMiningJobOwned {
+        SetCustomMiningJobOwned {
+            channel_id: 1,
+            request_id: 1,
+            token: vec![0].try_into().unwrap(),
+            version: 536870912,
+            prev_hash: [0u8; 32].into(),
+            min_ntime: 1746839905,
+            nbits: 503543726,
+            coinbase_tx_version: 2,
+            coinbase_prefix: coinbase_prefix.try_into().unwrap(),
+            coinbase_tx_input_n_sequence: 4294967295,
+            coinbase_tx_outputs: serialize(&coinbase_reward_outputs()).try_into().unwrap(),
+            coinbase_tx_locktime: 0,
+            merkle_path: vec![].try_into().unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_new_custom_job_rejects_oversized_script_sig() {
+        // same boundary as `test_coinbase_rejects_oversized_script_sig`: a 52 char pool tag places
+        // the worst-case scriptSig exactly on the budget
+        let job_factory = JobFactory::new(true, Some("x".repeat(52)), None);
+        let chain_tip = ChainTip::new([0u8; 32].into(), 503543726, 1746839905);
+
+        let new_custom_job = |coinbase_prefix_len: usize| {
+            job_factory.new_custom_job(
+                1,
+                1,
+                vec![0].try_into().unwrap(),
+                chain_tip.clone(),
+                template_with_coinbase_prefix(vec![0xab; coinbase_prefix_len]),
+                coinbase_reward_outputs(),
+                32,
+            )
+        };
+
+        // a spec-compliant 8 byte coinbase_prefix fits exactly
+        assert!(new_custom_job(MAX_COINBASE_PREFIX_SIZE).is_ok());
+
+        // one byte over must be rejected here, so the Job Declarator Client fails locally rather
+        // than having the pool reject the `SetCustomMiningJob` it just sent
+        assert!(matches!(
+            new_custom_job(MAX_COINBASE_PREFIX_SIZE + 1).unwrap_err(),
+            JobFactoryError::ScriptSigSizeTooLarge
+        ));
+    }
+
+    #[test]
+    fn test_custom_job_rejects_oversized_script_sig() {
+        // a custom job's coinbase_prefix already embeds the pool/miner tag, so the assembled
+        // scriptSig is just the prefix plus the full extranonce: 68 + 32 = 100
+        let mut job_factory = JobFactory::new(true, None, None);
+
+        let job = job_factory.new_extended_job_from_custom_job(
+            custom_job_with_coinbase_prefix(vec![0xab; MAX_SCRIPT_SIG_SIZE - 32]),
+            vec![0; 32],
+            32,
+        );
+        assert!(job.is_ok());
+
+        // one byte over the budget yields a consensus-invalid coinbase
+        let job = job_factory.new_extended_job_from_custom_job(
+            custom_job_with_coinbase_prefix(vec![0xab; MAX_SCRIPT_SIG_SIZE - 32 + 1]),
+            vec![0; 32],
+            32,
+        );
+        assert!(matches!(
+            job.unwrap_err(),
+            JobFactoryError::ScriptSigSizeTooLarge
+        ));
+
+        // a hostile downstream can otherwise push the scriptSig past the 252 byte CompactSize
+        // threshold, which would also mis-slice the prefix/suffix split
+        let job = job_factory.new_extended_job_from_custom_job(
+            custom_job_with_coinbase_prefix(vec![0xab; 250]),
+            vec![0; 32],
+            32,
+        );
+        assert!(matches!(
+            job.unwrap_err(),
+            JobFactoryError::ScriptSigSizeTooLarge
+        ));
     }
 }

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -715,7 +715,10 @@ impl StandardChannel {
 
             let mut script_sig = job.get_template().coinbase_prefix.to_owned_bytes();
             script_sig.extend(op_pushbytes_pool_miner_tag);
-            script_sig.push(self.extranonce_prefix.len() as u8); // OP_PUSHBYTES_X (for the extranonce)
+            // the opcode must describe the job's extranonce prefix, not the channel's current one:
+            // `set_extranonce_prefix` may have rotated to a different length since this job was
+            // created, and the job's `merkle_root` is committed to the job's prefix
+            script_sig.push(job.get_extranonce_prefix().len() as u8); // OP_PUSHBYTES_X (for the extranonce)
             script_sig.extend(job.get_extranonce_prefix());
 
             let tx_in = TxIn {
@@ -791,7 +794,9 @@ mod tests {
         },
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
-    use bitcoin::{transaction::TxOut, Amount, ScriptBuf, Target};
+    use bitcoin::{
+        consensus::deserialize, transaction::TxOut, Amount, ScriptBuf, Target, Transaction,
+    };
     use mining_sv2::{
         NewMiningJobOwned as NewMiningJob, SubmitSharesStandardOwned,
         ERROR_CODE_SUBMIT_SHARES_DIFFICULTY_TOO_LOW,
@@ -1242,6 +1247,143 @@ mod tests {
             standard_channel.get_share_accounting().get_blocks_found(),
             0
         );
+    }
+
+    #[test]
+    fn test_share_validation_block_found_after_extranonce_prefix_rotation() {
+        // note:
+        // same test vectors as `test_share_validation_block_found`, plus an extranonce prefix
+        // rotation (to a prefix of a different length) in between job creation and share
+        // submission.
+        //
+        // the job (and therefore its merkle root, and therefore the winning nonce) is committed to
+        // the prefix that was current at `on_new_template` time, so the coinbase reconstructed on
+        // BlockFound must also be committed to that same prefix.
+
+        let standard_channel_id = 1;
+        let user_identity = "user_identity".to_string();
+
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let max_target = Target::from_le_bytes([0xff; 32]);
+        let nominal_hashrate = 1.0;
+        let share_batch_size = 100;
+        let expected_share_per_minute = 1.0;
+        let mut standard_channel = StandardChannel::new(
+            standard_channel_id,
+            user_identity,
+            ExtranoncePrefix::from_wire(extranonce_prefix.clone()).unwrap(),
+            max_target,
+            nominal_hashrate,
+            share_batch_size,
+            expected_share_per_minute,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // channel target: 04325c53ef368eb04325c53ef368eb04325c53ef368eb04325c53ef368eb0431
+        let template = NewTemplate {
+            template_id: 1,
+            future_template: false,
+            version: 536870912,
+            coinbase_tx_version: 2,
+            coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
+            coinbase_tx_input_sequence: 4294967294,
+            coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+            coinbase_tx_outputs_count: 1,
+            coinbase_tx_outputs: vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209,
+                222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180,
+                139, 235, 216, 54, 151, 78, 140, 249,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_locktime: 158,
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        // match the original script format used to generate the coinbase_reward_outputs for the
+        // expected job
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0]; // SegWit version 0
+        script_bytes.push(20); // Push 20 bytes (length of pubkey hash)
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let script = ScriptBuf::from(script_bytes);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: script,
+        }];
+
+        // network target: 7fffff0000000000000000000000000000000000000000000000000000000000
+        let ntime = 1745596910;
+        let prev_hash = [
+            251, 175, 106, 40, 35, 87, 122, 90, 58, 51, 78, 32, 202, 236, 228, 36, 154, 174, 206,
+            144, 147, 195, 21, 224, 195, 103, 214, 189, 51, 190, 24, 98,
+        ]
+        .into();
+        let n_bits = 545259519;
+        let chain_tip = ChainTip::new(prev_hash, n_bits, ntime);
+
+        // prepare standard channel with non-future job
+        standard_channel.set_chain_tip(chain_tip);
+        standard_channel
+            .on_new_template(template.clone(), coinbase_reward_outputs)
+            .unwrap();
+
+        // capture what the job is committed to, before rotating the channel's prefix
+        let active_standard_job = standard_channel.get_active_job().unwrap();
+        let job_id = active_standard_job.get_job_id();
+        let job_merkle_root = active_standard_job.get_merkle_root().to_array();
+        let job_extranonce_prefix = active_standard_job.get_extranonce_prefix().to_vec();
+        assert_eq!(job_extranonce_prefix, extranonce_prefix);
+
+        // rotate the channel to a prefix of a different length
+        let rotated_extranonce_prefix = vec![0xab; 16];
+        standard_channel
+            .set_extranonce_prefix(
+                AllocatedExtranoncePrefix::for_test(rotated_extranonce_prefix).unwrap(),
+            )
+            .unwrap();
+
+        // this share has hash 3c34f63de61283c907b68e3127146d7d11f1fb14e50020a8317a292d11e2dab6
+        // which satisfied the network target
+        // 7fffff0000000000000000000000000000000000000000000000000000000000
+        let share_valid_block = SubmitSharesStandardOwned {
+            channel_id: standard_channel_id,
+            sequence_number: 0,
+            job_id,
+            nonce: 0,
+            ntime: 1745596932,
+            version: 536870912,
+        };
+
+        let Ok(ShareValidationResult::BlockFound(_, _, serialized_coinbase)) =
+            standard_channel.validate_share(share_valid_block)
+        else {
+            panic!("expected BlockFound");
+        };
+
+        let coinbase: Transaction = deserialize(&serialized_coinbase).unwrap();
+
+        // merkle_path is empty in this template, so the merkle root IS the coinbase txid
+        let coinbase_txid: [u8; 32] = *coinbase.compute_txid().as_ref();
+        assert_eq!(coinbase_txid, job_merkle_root);
+
+        // the scriptSig must push the job's extranonce prefix, with a matching OP_PUSHBYTES opcode
+        let script_sig = coinbase.input[0].script_sig.as_bytes();
+        let extranonce_start = script_sig.len() - job_extranonce_prefix.len();
+        assert_eq!(
+            script_sig[extranonce_start - 1],
+            job_extranonce_prefix.len() as u8
+        );
+        assert_eq!(&script_sig[extranonce_start..], &job_extranonce_prefix[..]);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -113,6 +113,10 @@ impl StandardChannel {
     ///
     /// For non-JD jobs, `pool_tag_string` is added to the coinbase scriptSig as
     /// `Sv2/pool_tag_string//`.
+    ///
+    /// Returns [`StandardChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
+    /// extranonce prefix and a worst-case coinbase prefix do not fit within the coinbase
+    /// `scriptSig` budget, see [`JobFactory::fits_script_sig_budget`].
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_pool(
         channel_id: u32,
@@ -147,6 +151,10 @@ impl StandardChannel {
     ///
     /// The `pool_tag_string` and `miner_tag_string` are added to the coinbase scriptSig as
     /// `Sv2/pool_tag_string/miner_tag_string/`.
+    ///
+    /// Returns [`StandardChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
+    /// extranonce prefix and a worst-case coinbase prefix do not fit within the coinbase
+    /// `scriptSig` budget, see [`JobFactory::fits_script_sig_budget`].
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_job_declaration_client(
         channel_id: u32,
@@ -204,16 +212,12 @@ impl StandardChannel {
             return Err(StandardChannelError::ExtranoncePrefixTooLarge);
         }
 
-        let script_sig_size = 5 + // BIP34
-            1 + // OP_PUSHBYTES
-            3 + // "Sv2"
-            3 + // `/` delimiters
-            pool_tag_string.as_ref().map_or(0, |s| s.len()) +
-            miner_tag_string.as_ref().map_or(0, |s| s.len()) +
-            1 + // OP_PUSHBYTES
-            extranonce_prefix.len();
+        let job_factory = JobFactory::new(true, pool_tag_string, miner_tag_string);
 
-        if script_sig_size > 100 {
+        // conservative check against the spec's worst-case `NewTemplate::coinbase_prefix`.
+        // the exact size is re-checked against each actual template in `JobFactory::coinbase`.
+        // standard channels have no rollable extranonce, so the prefix is the full extranonce
+        if !job_factory.fits_script_sig_budget(extranonce_prefix.len()) {
             return Err(StandardChannelError::ScriptSigSizeTooLarge);
         }
 
@@ -229,7 +233,7 @@ impl StandardChannel {
             share_accounting: ShareAccounting::new(share_batch_size),
             expected_share_per_minute,
             job_store: JobStore::new(),
-            job_factory: JobFactory::new(true, pool_tag_string, miner_tag_string),
+            job_factory,
             chain_tip: None,
         })
     }
@@ -441,6 +445,13 @@ impl StandardChannel {
     /// Only meant to be used in case we want to broadcast standard jobs.
     /// In case we want to broadcast extended jobs via group channel, use `on_group_channel_job`
     /// instead.
+    ///
+    /// Returns [`StandardChannelError::JobFactoryError`] wrapping
+    /// [`JobFactoryError::ScriptSigSizeTooLarge`](crate::server::jobs::error::JobFactoryError::ScriptSigSizeTooLarge)
+    /// if the template's `coinbase_prefix` pushes the assembled coinbase `scriptSig` past
+    /// its budget. The constructor can only check against the spec's worst-case prefix (see
+    /// [`JobFactory::fits_script_sig_budget`]), so this is where an out-of-spec Template Provider
+    /// is caught.
     pub fn on_new_template(
         &mut self,
         template: NewTemplateOwned,
@@ -789,6 +800,7 @@ mod tests {
         },
         server::{
             error::StandardChannelError,
+            jobs::factory::{MAX_COINBASE_PREFIX_SIZE, MAX_SCRIPT_SIG_SIZE},
             share_accounting::{ShareValidationError, ShareValidationResult},
             standard::StandardChannel,
         },
@@ -1842,6 +1854,57 @@ mod tests {
             &not_so_permissive_max_target
         );
         assert_eq!(channel.get_target(), &not_so_permissive_max_target);
+    }
+
+    // standard channels have no rollable extranonce, so a 52 char pool tag places the worst-case
+    // scriptSig exactly on the budget:
+    // 8 (MAX_COINBASE_PREFIX_SIZE) + 1 + 3 ("Sv2") + 3 + 52 (tag) + 1 + 32 (extranonce prefix)
+    // = 100
+    const POOL_TAG_AT_SCRIPT_SIG_BUDGET: usize = 52;
+    const EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET: usize = 32;
+
+    fn new_standard_channel_with_pool_tag(
+        pool_tag_len: usize,
+        extranonce_prefix_len: usize,
+    ) -> Result<StandardChannel, StandardChannelError> {
+        StandardChannel::new(
+            1,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(vec![0xab; extranonce_prefix_len]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            100,
+            1.0,
+            Some("x".repeat(pool_tag_len)),
+            None,
+        )
+    }
+
+    #[test]
+    fn test_new_rejects_oversized_script_sig() {
+        // exactly on the budget
+        let channel = new_standard_channel_with_pool_tag(
+            POOL_TAG_AT_SCRIPT_SIG_BUDGET,
+            EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET,
+        )
+        .unwrap();
+        assert_eq!(
+            channel.job_factory.script_sig_size(
+                MAX_COINBASE_PREFIX_SIZE,
+                channel.get_extranonce_prefix().len()
+            ),
+            MAX_SCRIPT_SIG_SIZE
+        );
+
+        // one byte over the budget, via a longer tag
+        let channel = new_standard_channel_with_pool_tag(
+            POOL_TAG_AT_SCRIPT_SIG_BUDGET + 1,
+            EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET,
+        );
+        assert!(matches!(
+            channel.unwrap_err(),
+            StandardChannelError::ScriptSigSizeTooLarge
+        ));
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -264,13 +264,24 @@ impl StandardChannel {
     /// every job created under it has become stale. This prevents the allocator from handing the
     /// same extranonce space to another live channel while those jobs still validate shares.
     ///
-    /// Returns an error if the new prefix is too large.
+    /// Returns an error if the new prefix is too large, or if it would push the assembled coinbase
+    /// `scriptSig` past its budget (see [`JobFactory::fits_script_sig_budget`]). The channel is
+    /// left unchanged in both error cases.
     pub fn set_extranonce_prefix(
         &mut self,
         extranonce_prefix: AllocatedExtranoncePrefix,
     ) -> Result<(), StandardChannelError> {
         if extranonce_prefix.len() > MAX_EXTRANONCE_LEN as usize {
             return Err(StandardChannelError::ExtranoncePrefixTooLarge);
+        }
+
+        // re-run the constructor's invariant: a prefix that is individually valid can still push
+        // the assembled scriptSig past the consensus cap
+        if !self
+            .job_factory
+            .fits_script_sig_budget(extranonce_prefix.len())
+        {
+            return Err(StandardChannelError::ScriptSigSizeTooLarge);
         }
 
         let retired_extranonce_prefix =
@@ -804,6 +815,7 @@ mod tests {
             share_accounting::{ShareValidationError, ShareValidationResult},
             standard::StandardChannel,
         },
+        MAX_EXTRANONCE_LEN,
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
     use bitcoin::{
@@ -1905,6 +1917,59 @@ mod tests {
             channel.unwrap_err(),
             StandardChannelError::ScriptSigSizeTooLarge
         ));
+    }
+
+    // a 60 char pool tag makes the budget bind below MAX_EXTRANONCE_LEN, so the setter's scriptSig
+    // check is exercised on a prefix that is still individually valid:
+    // 8 (MAX_COINBASE_PREFIX_SIZE) + 1 + 3 ("Sv2") + 3 + 60 (tag) + 1 + 24 (extranonce prefix)
+    // = 100
+    const POOL_TAG_BINDING_BELOW_MAX_EXTRANONCE_LEN: usize = 60;
+    const EXTRANONCE_PREFIX_LEN_AT_BINDING_BUDGET: usize = 24;
+
+    #[test]
+    fn test_set_extranonce_prefix_rejects_oversized_script_sig() {
+        // start well within the budget
+        let original_prefix_len = 4;
+        let mut channel = new_standard_channel_with_pool_tag(
+            POOL_TAG_BINDING_BELOW_MAX_EXTRANONCE_LEN,
+            original_prefix_len,
+        )
+        .unwrap();
+        let original_prefix = channel.get_extranonce_prefix().to_vec();
+
+        // growing up to the budget is allowed
+        channel
+            .set_extranonce_prefix(
+                AllocatedExtranoncePrefix::for_test(vec![
+                    0xcd;
+                    EXTRANONCE_PREFIX_LEN_AT_BINDING_BUDGET
+                ])
+                .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            channel.get_extranonce_prefix().len(),
+            EXTRANONCE_PREFIX_LEN_AT_BINDING_BUDGET
+        );
+
+        // go back to the original prefix, so we can assert the channel is untouched on error
+        channel
+            .set_extranonce_prefix(
+                AllocatedExtranoncePrefix::for_test(original_prefix.clone()).unwrap(),
+            )
+            .unwrap();
+
+        // a prefix that is individually valid (<= MAX_EXTRANONCE_LEN) but pushes the assembled
+        // scriptSig one byte past the budget must be rejected
+        let oversized_prefix = vec![0xcd; EXTRANONCE_PREFIX_LEN_AT_BINDING_BUDGET + 1];
+        assert!(oversized_prefix.len() <= MAX_EXTRANONCE_LEN as usize);
+        let res = channel
+            .set_extranonce_prefix(AllocatedExtranoncePrefix::for_test(oversized_prefix).unwrap());
+        assert!(matches!(
+            res.unwrap_err(),
+            StandardChannelError::ScriptSigSizeTooLarge
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &original_prefix[..]);
     }
 
     #[test]


### PR DESCRIPTION
close #2242
close https://github.com/project-loupe/audit-stratum/issues/20
close https://github.com/project-loupe/audit-stratum/issues/30
close https://github.com/project-loupe/audit-stratum/issues/79
close https://github.com/project-loupe/audit-stratum/issues/88

companion https://github.com/stratum-mining/sv2-apps/pull/658