### PR TITLE
`channels_sv2`: document why coinbase `scriptSig` length prefix is always 1 byte

### DIFF
--- a/sv2/channels-sv2/src/server/jobs/factory.rs
+++ b/sv2/channels-sv2/src/server/jobs/factory.rs
@@ -521,6 +521,9 @@ impl JobFactory {
         let coinbase = self.custom_coinbase(m.clone(), full_extranonce_size)?;
         let serialized_coinbase = serialize(&coinbase);
 
+        // the coinbase scriptSig is limited to 100 bytes by Bitcoin consensus rules, which is
+        // always below the 253 byte threshold where CompactSize switches from a 1-byte to a
+        // 3-byte encoding, so the script length prefix is unconditionally 1 byte
         let index = 4 // tx version
             + 2 // segwit
             + 1 // number of inputs
@@ -542,6 +545,9 @@ impl JobFactory {
         let coinbase = self.custom_coinbase(m.clone(), full_extranonce_size)?;
         let serialized_coinbase = serialize(&coinbase);
 
+        // the coinbase scriptSig is limited to 100 bytes by Bitcoin consensus rules, which is
+        // always below the 253 byte threshold where CompactSize switches from a 1-byte to a
+        // 3-byte encoding, so the script length prefix is unconditionally 1 byte
         let index = 4 // tx version
             + 2 // segwit
             + 1 // number of inputs
@@ -635,6 +641,9 @@ impl JobFactory {
             + self.pool_tag_string.as_ref().map_or(0, |s| s.len())
             + self.miner_tag_string.as_ref().map_or(0, |s| s.len());
 
+        // the coinbase scriptSig is limited to 100 bytes by Bitcoin consensus rules, which is
+        // always below the 253 byte threshold where CompactSize switches from a 1-byte to a
+        // 3-byte encoding, so the script length prefix is unconditionally 1 byte
         let index = 4 // tx version
             + 2 // segwit bytes
             + 1 // number of inputs
@@ -670,6 +679,9 @@ impl JobFactory {
             + self.pool_tag_string.as_ref().map_or(0, |s| s.len())
             + self.miner_tag_string.as_ref().map_or(0, |s| s.len());
 
+        // the coinbase scriptSig is limited to 100 bytes by Bitcoin consensus rules, which is
+        // always below the 253 byte threshold where CompactSize switches from a 1-byte to a
+        // 3-byte encoding, so the script length prefix is unconditionally 1 byte
         let coinbase_tx_suffix = serialized_coinbase[4 // tx version
             + 2 // segwit bytes
             + 1 // number of inputs


### PR DESCRIPTION
The prefix/suffix split indexes in `JobFactory` hardcode a `1 // bytes in script` term for the `scriptSig` `CompactSize` length prefix.

`CompactSize` switches to a 3-byte encoding at 253 bytes, so the hardcoded 1 looks like an off-by-2 hazard on inspection.

It is not: Bitcoin consensus limits the coinbase tx `scriptSig` to 100 bytes, unconditionally below the 253-byte threshold.

Any input that would push the scriptSig past 252 bytes is already consensus-invalid for reasons that have nothing to do with the split.

This PR adds a comment stating that rationale at each of the four sites so the assumption doesn't have to be re-derived.

close https://github.com/project-loupe/audit-stratum/issues/19