### PR TITLE
Make merkle root from path return [u8; 32]

### DIFF
--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -585,9 +585,7 @@ impl ExtendedChannel {
         )
         .ok_or(ShareValidationError::Invalid(
             ERROR_CODE_SUBMIT_SHARES_INVALID_SHARE,
-        ))?
-        .try_into()
-        .expect("merkle root must be 32 bytes");
+        ))?;
 
         let chain_tip = self
             .chain_tip

--- a/sv2/channels-sv2/src/client/standard.rs
+++ b/sv2/channels-sv2/src/client/standard.rs
@@ -254,8 +254,7 @@ impl StandardChannel {
             new_extended_mining_job.merkle_path.as_slice(),
         )
         .expect("merkle root must be valid")
-        .try_into()
-        .expect("merkle root must be 32 bytes");
+        .into();
 
         let new_mining_job = NewMiningJobOwned {
             channel_id: self.channel_id,

--- a/sv2/channels-sv2/src/merkle_root.rs
+++ b/sv2/channels-sv2/src/merkle_root.rs
@@ -26,7 +26,7 @@ pub fn merkle_root_from_path<T: AsRef<[u8]>>(
     coinbase_tx_suffix: &[u8],
     extranonce: &[u8],
     path: &[T],
-) -> Option<Vec<u8>> {
+) -> Option<[u8; 32]> {
     let mut coinbase =
         Vec::with_capacity(coinbase_tx_prefix.len() + coinbase_tx_suffix.len() + extranonce.len());
     coinbase.extend_from_slice(coinbase_tx_prefix);
@@ -42,7 +42,7 @@ pub fn merkle_root_from_path<T: AsRef<[u8]>>(
 
     let coinbase_id: [u8; 32] = *coinbase.compute_txid().as_ref();
 
-    Some(merkle_root_from_path_(coinbase_id, path).to_vec())
+    Some(merkle_root_from_path_(coinbase_id, path))
 }
 
 /// Computes the Merkle root from a validated coinbase transaction and a path of transaction

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -744,9 +744,7 @@ impl ExtendedChannel {
         )
         .ok_or(ShareValidationError::Invalid(
             ERROR_CODE_SUBMIT_SHARES_INVALID_SHARE,
-        ))?
-        .try_into()
-        .expect("merkle root must be 32 bytes");
+        ))?;
 
         let chain_tip = self
             .chain_tip

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -67,7 +67,7 @@ use mining_sv2::{
     ERROR_CODE_SUBMIT_SHARES_INVALID_SHARE, ERROR_CODE_SUBMIT_SHARES_STALE_SHARE,
     ERROR_CODE_UPDATE_CHANNEL_INVALID_NOMINAL_HASHRATE, ERROR_CODE_VERSION_ROLLING_NOT_ALLOWED,
 };
-use std::{collections::HashMap, convert::TryInto};
+use std::collections::HashMap;
 use template_distribution_sv2::{NewTemplateOwned, SetNewPrevHashOwned as SetNewPrevHashTdp};
 use tracing::debug;
 

--- a/sv2/channels-sv2/src/server/jobs/extended.rs
+++ b/sv2/channels-sv2/src/server/jobs/extended.rs
@@ -120,8 +120,7 @@ impl ExtendedJob {
             self.get_merkle_path().as_slice(),
         )
         .ok_or(ExtendedJobError::FailedToCalculateMerkleRoot)?
-        .try_into()
-        .map_err(|_| ExtendedJobError::FailedToCalculateMerkleRoot)?;
+        .into();
 
         let standard_job_message = NewMiningJobOwned {
             channel_id,

--- a/sv2/channels-sv2/src/server/jobs/extended.rs
+++ b/sv2/channels-sv2/src/server/jobs/extended.rs
@@ -7,7 +7,6 @@ use crate::{
 use binary_sv2::{Seq0255Owned, Sv2OptionOwned, U256Owned};
 use bitcoin::transaction::TxOut;
 use mining_sv2::{NewExtendedMiningJobOwned, NewMiningJobOwned, SetCustomMiningJobOwned};
-use std::convert::TryInto;
 use template_distribution_sv2::NewTemplateOwned;
 
 /// Abstraction of an extended mining job with:

--- a/sv2/channels-sv2/src/server/jobs/factory.rs
+++ b/sv2/channels-sv2/src/server/jobs/factory.rs
@@ -180,8 +180,7 @@ impl JobFactory {
             merkle_path.as_slice(),
         )
         .expect("merkle root must be valid")
-        .try_into()
-        .expect("merkle root must be 32 bytes");
+        .into();
 
         let job_message = match template.future_template {
             true => NewMiningJobOwned {


### PR DESCRIPTION
We were initially converting the merkle root to vec and then again explicitly converting it back to [u8; 32]. This PR removes the intermediary Vec conversion itself.