### PR TITLE
`channels_sv2`: make the past-jobs cap configurable w/ a 'good' default value

### DIFF
--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -4,7 +4,7 @@
 //! **Extended Channel** within a mining client.
 
 extern crate alloc;
-use super::{resolve_max_past_jobs, HashMap, MAX_FUTURE_JOBS};
+use super::{HashMap, MAX_FUTURE_JOBS, MAX_PAST_JOBS};
 use crate::{
     bip141::try_strip_bip141,
     chain_tip::ChainTip,
@@ -27,7 +27,6 @@ use bitcoin::{
     transaction::Version,
     CompactTarget, OutPoint, Sequence, Target, Transaction, TxIn, TxOut, Witness,
 };
-use core::num::NonZeroUsize;
 use mining_sv2::{
     NewExtendedMiningJobOwned, SetCustomMiningJobOwned, SetCustomMiningJobSuccess,
     SetNewPrevHashOwned as SetNewPrevHashMp, SubmitSharesExtendedOwned,
@@ -62,7 +61,7 @@ pub type ExtendedJob = (NewExtendedMiningJobOwned, Vec<u8>, Target);
 ///   [`SetNewPrevHash`](SetNewPrevHashMp) message.
 /// - The currently active job.
 /// - Past jobs (previously active under the current chain tip, indexed by `job_id`, capped at
-///   [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS)).
+///   [`MAX_PAST_JOBS`]).
 /// - Stale jobs (previously active and past jobs under the previous chain tip, indexed by
 ///   `job_id`).
 /// - Share accounting for the channel (as tracked by the client).
@@ -90,7 +89,7 @@ pub struct ExtendedChannel {
     // stale jobs are indexed with job_id (u32)
     stale_jobs: HashMap<u32, ExtendedJob>,
     // Cap on `past_jobs` under the current chain tip, resolved from the constructor's
-    // `Option<NonZeroUsize>` against `MAX_PAST_JOBS`.
+    // `Option<usize>`; `None` and `Some(0)` both resolve to `MAX_PAST_JOBS`.
     max_past_jobs: usize,
     share_accounting: ShareAccounting,
     chain_tip: Option<ChainTip>,
@@ -99,8 +98,8 @@ pub struct ExtendedChannel {
 impl ExtendedChannel {
     /// Constructs a new [`ExtendedChannel`].
     ///
-    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS).
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip. `None` and
+    /// `Some(0)` both select [`MAX_PAST_JOBS`].
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         channel_id: u32,
@@ -110,8 +109,15 @@ impl ExtendedChannel {
         nominal_hashrate: f32,
         version_rolling: bool,
         rollable_extranonce_size: u16,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Self {
+        // fall back to the default when the caller has no opinion: `None`, or `Some(0)`, which
+        // would otherwise evict the just-retired job and reject the most common late share
+        let max_past_jobs = match max_past_jobs {
+            Some(cap) if cap > 0 => cap,
+            _ => MAX_PAST_JOBS,
+        };
+
         Self {
             channel_id,
             user_identity,
@@ -126,7 +132,7 @@ impl ExtendedChannel {
             past_jobs: HashMap::new(),
             past_job_order: VecDeque::new(),
             stale_jobs: HashMap::new(),
-            max_past_jobs: resolve_max_past_jobs(max_past_jobs),
+            max_past_jobs,
             share_accounting: ShareAccounting::new(),
             chain_tip: None,
         }
@@ -258,7 +264,7 @@ impl ExtendedChannel {
 
     /// Returns an iterator over all past jobs for this channel.
     ///
-    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
     pub fn get_past_jobs(&self) -> impl Iterator<Item = (&u32, &ExtendedJob)> + '_ {
         self.past_jobs.iter()
     }
@@ -270,7 +276,7 @@ impl ExtendedChannel {
 
     /// Returns the number of past jobs tracked by this channel.
     ///
-    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
     pub fn get_past_jobs_count(&self) -> usize {
         self.past_jobs.len()
     }
@@ -321,7 +327,7 @@ impl ExtendedChannel {
     ///   At most [`MAX_FUTURE_JOBS`] future jobs are kept: storing a new one beyond that limit
     ///   evicts the oldest.
     /// - Otherwise, the job is activated and previous active job moves to the past jobs list.
-    ///   At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) past jobs are kept: retiring one beyond that limit evicts the
+    ///   At most [`MAX_PAST_JOBS`] past jobs are kept: retiring one beyond that limit evicts the
     ///   oldest.
     pub fn on_new_extended_mining_job(
         &mut self,
@@ -388,7 +394,7 @@ impl ExtendedChannel {
     /// Handles a `SetCustomMiningJobSuccess` message from upstream.
     /// Requires the corresponding `SetCustomMiningJob`.
     ///
-    /// The previous active job (if any) moves to the past jobs list. At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS)
+    /// The previous active job (if any) moves to the past jobs list. At most [`MAX_PAST_JOBS`]
     /// past jobs are kept: retiring one beyond that limit evicts the oldest.
     ///
     /// To be used by a Sv2 Job Declarator Client
@@ -835,7 +841,6 @@ mod tests {
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
     use bitcoin::Target;
-    use core::num::NonZeroUsize;
     use mining_sv2::{
         NewExtendedMiningJobOwned as NewExtendedMiningJob, SetNewPrevHashOwned as SetNewPrevHashMp,
         SubmitSharesExtendedOwned as SubmitSharesExtended,
@@ -1136,8 +1141,8 @@ mod tests {
     #[test]
     fn test_past_jobs_respect_constructor_override() {
         // Some(cap) must override MAX_PAST_JOBS all the way through to the eviction path.
-        let custom_cap = NonZeroUsize::new(3).unwrap();
-        assert!(custom_cap.get() < MAX_PAST_JOBS);
+        let custom_cap = 3usize;
+        assert!(custom_cap < MAX_PAST_JOBS);
 
         let channel_id = 1;
         let extranonce_prefix = [
@@ -1189,15 +1194,33 @@ mod tests {
         }
 
         // bounded by the override, not by MAX_PAST_JOBS
-        assert_eq!(channel.get_past_jobs_count(), custom_cap.get());
+        assert_eq!(channel.get_past_jobs_count(), custom_cap);
 
         // the last job is active; only the newest `custom_cap` retired jobs survive
-        for job_id in 0..job_count - 1 - custom_cap.get() as u32 {
+        for job_id in 0..job_count - 1 - custom_cap as u32 {
             assert!(channel.get_past_job(job_id).is_none());
         }
-        for job_id in job_count - 1 - custom_cap.get() as u32..job_count - 1 {
+        for job_id in job_count - 1 - custom_cap as u32..job_count - 1 {
             assert!(channel.get_past_job(job_id).is_some());
         }
+
+        // `Some(0)` is not a zero cap: it means "no opinion" and selects the default
+        let mut zero_cap_channel = ExtendedChannel::new(
+            channel_id,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(vec![0; 27]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            4u16,
+            Some(0),
+        );
+        for job_id in 0..MAX_PAST_JOBS as u32 + 2 {
+            let mut job = active_job.clone();
+            job.job_id = job_id;
+            zero_cap_channel.on_new_extended_mining_job(job).unwrap();
+        }
+        assert_eq!(zero_cap_channel.get_past_jobs_count(), MAX_PAST_JOBS);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -4,7 +4,7 @@
 //! **Extended Channel** within a mining client.
 
 extern crate alloc;
-use super::{HashMap, MAX_FUTURE_JOBS, MAX_PAST_JOBS};
+use super::{resolve_max_past_jobs, HashMap, MAX_FUTURE_JOBS};
 use crate::{
     bip141::try_strip_bip141,
     chain_tip::ChainTip,
@@ -62,7 +62,7 @@ pub type ExtendedJob = (NewExtendedMiningJobOwned, Vec<u8>, Target);
 ///   [`SetNewPrevHash`](SetNewPrevHashMp) message.
 /// - The currently active job.
 /// - Past jobs (previously active under the current chain tip, indexed by `job_id`, capped at
-///   [`MAX_PAST_JOBS`]).
+///   [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS)).
 /// - Stale jobs (previously active and past jobs under the previous chain tip, indexed by
 ///   `job_id`).
 /// - Share accounting for the channel (as tracked by the client).
@@ -100,7 +100,7 @@ impl ExtendedChannel {
     /// Constructs a new [`ExtendedChannel`].
     ///
     /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// [`MAX_PAST_JOBS`].
+    /// [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS).
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         channel_id: u32,
@@ -126,9 +126,7 @@ impl ExtendedChannel {
             past_jobs: HashMap::new(),
             past_job_order: VecDeque::new(),
             stale_jobs: HashMap::new(),
-            max_past_jobs: max_past_jobs
-                .map(NonZeroUsize::get)
-                .unwrap_or(MAX_PAST_JOBS),
+            max_past_jobs: resolve_max_past_jobs(max_past_jobs),
             share_accounting: ShareAccounting::new(),
             chain_tip: None,
         }
@@ -260,7 +258,7 @@ impl ExtendedChannel {
 
     /// Returns an iterator over all past jobs for this channel.
     ///
-    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
     pub fn get_past_jobs(&self) -> impl Iterator<Item = (&u32, &ExtendedJob)> + '_ {
         self.past_jobs.iter()
     }
@@ -272,7 +270,7 @@ impl ExtendedChannel {
 
     /// Returns the number of past jobs tracked by this channel.
     ///
-    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
     pub fn get_past_jobs_count(&self) -> usize {
         self.past_jobs.len()
     }
@@ -323,7 +321,7 @@ impl ExtendedChannel {
     ///   At most [`MAX_FUTURE_JOBS`] future jobs are kept: storing a new one beyond that limit
     ///   evicts the oldest.
     /// - Otherwise, the job is activated and previous active job moves to the past jobs list.
-    ///   At most [`MAX_PAST_JOBS`] past jobs are kept: retiring one beyond that limit evicts the
+    ///   At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) past jobs are kept: retiring one beyond that limit evicts the
     ///   oldest.
     pub fn on_new_extended_mining_job(
         &mut self,
@@ -390,7 +388,7 @@ impl ExtendedChannel {
     /// Handles a `SetCustomMiningJobSuccess` message from upstream.
     /// Requires the corresponding `SetCustomMiningJob`.
     ///
-    /// The previous active job (if any) moves to the past jobs list. At most [`MAX_PAST_JOBS`]
+    /// The previous active job (if any) moves to the past jobs list. At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS)
     /// past jobs are kept: retiring one beyond that limit evicts the oldest.
     ///
     /// To be used by a Sv2 Job Declarator Client
@@ -1136,7 +1134,7 @@ mod tests {
     }
 
     #[test]
-    fn test_past_jobs_honour_constructor_override() {
+    fn test_past_jobs_respect_constructor_override() {
         // Some(cap) must override MAX_PAST_JOBS all the way through to the eviction path.
         let custom_cap = NonZeroUsize::new(3).unwrap();
         assert!(custom_cap.get() < MAX_PAST_JOBS);

--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -27,6 +27,7 @@ use bitcoin::{
     transaction::Version,
     CompactTarget, OutPoint, Sequence, Target, Transaction, TxIn, TxOut, Witness,
 };
+use core::num::NonZeroUsize;
 use mining_sv2::{
     NewExtendedMiningJobOwned, SetCustomMiningJobOwned, SetCustomMiningJobSuccess,
     SetNewPrevHashOwned as SetNewPrevHashMp, SubmitSharesExtendedOwned,
@@ -88,12 +89,19 @@ pub struct ExtendedChannel {
     past_job_order: VecDeque<u32>,
     // stale jobs are indexed with job_id (u32)
     stale_jobs: HashMap<u32, ExtendedJob>,
+    // Cap on `past_jobs` under the current chain tip, resolved from the constructor's
+    // `Option<NonZeroUsize>` against `MAX_PAST_JOBS`.
+    max_past_jobs: usize,
     share_accounting: ShareAccounting,
     chain_tip: Option<ChainTip>,
 }
 
 impl ExtendedChannel {
     /// Constructs a new [`ExtendedChannel`].
+    ///
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
+    /// [`MAX_PAST_JOBS`].
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         channel_id: u32,
         user_identity: String,
@@ -102,6 +110,7 @@ impl ExtendedChannel {
         nominal_hashrate: f32,
         version_rolling: bool,
         rollable_extranonce_size: u16,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Self {
         Self {
             channel_id,
@@ -117,6 +126,9 @@ impl ExtendedChannel {
             past_jobs: HashMap::new(),
             past_job_order: VecDeque::new(),
             stale_jobs: HashMap::new(),
+            max_past_jobs: max_past_jobs
+                .map(NonZeroUsize::get)
+                .unwrap_or(MAX_PAST_JOBS),
             share_accounting: ShareAccounting::new(),
             chain_tip: None,
         }
@@ -499,7 +511,7 @@ impl ExtendedChannel {
         self.past_job_order.retain(|id| *id != job_id);
         self.past_job_order.push_back(job_id);
 
-        if self.past_jobs.len() > MAX_PAST_JOBS {
+        if self.past_jobs.len() > self.max_past_jobs {
             if let Some(evicted_job_id) = self.past_job_order.pop_front() {
                 self.past_jobs.remove(&evicted_job_id);
             }
@@ -825,6 +837,7 @@ mod tests {
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
     use bitcoin::Target;
+    use core::num::NonZeroUsize;
     use mining_sv2::{
         NewExtendedMiningJobOwned as NewExtendedMiningJob, SetNewPrevHashOwned as SetNewPrevHashMp,
         SubmitSharesExtendedOwned as SubmitSharesExtended,
@@ -854,6 +867,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -935,6 +949,7 @@ mod tests {
             1.0,
             true,
             4u16,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -995,6 +1010,7 @@ mod tests {
             1.0,
             true,
             4u16,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1074,6 +1090,7 @@ mod tests {
             1.0,
             true,
             4u16,
+            None,
         );
 
         let active_job = NewExtendedMiningJob {
@@ -1119,6 +1136,73 @@ mod tests {
     }
 
     #[test]
+    fn test_past_jobs_honour_constructor_override() {
+        // Some(cap) must override MAX_PAST_JOBS all the way through to the eviction path.
+        let custom_cap = NonZeroUsize::new(3).unwrap();
+        assert!(custom_cap.get() < MAX_PAST_JOBS);
+
+        let channel_id = 1;
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            4u16,
+            Some(custom_cap),
+        );
+
+        let active_job = NewExtendedMiningJob {
+            channel_id,
+            job_id: 0,
+            min_ntime: Sv2Option::new(Some(1746839905)),
+            version: 536870912,
+            version_rolling_allowed: true,
+            coinbase_tx_prefix: vec![
+                2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 34, 82, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            coinbase_tx_suffix: vec![
+                255, 255, 255, 255, 2, 0, 242, 5, 42, 1, 0, 0, 0, 22, 0, 20, 235, 225, 183, 220,
+                194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194, 8, 252, 0, 0, 0,
+                0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113, 209, 222,
+                253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153, 98, 180, 139,
+                235, 216, 54, 151, 78, 140, 249, 0, 0, 0, 0,
+            ]
+            .try_into()
+            .unwrap(),
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        let job_count = 20u32;
+        for job_id in 0..job_count {
+            let mut job = active_job.clone();
+            job.job_id = job_id;
+            channel.on_new_extended_mining_job(job).unwrap();
+        }
+
+        // bounded by the override, not by MAX_PAST_JOBS
+        assert_eq!(channel.get_past_jobs_count(), custom_cap.get());
+
+        // the last job is active; only the newest `custom_cap` retired jobs survive
+        for job_id in 0..job_count - 1 - custom_cap.get() as u32 {
+            assert!(channel.get_past_job(job_id).is_none());
+        }
+        for job_id in job_count - 1 - custom_cap.get() as u32..job_count - 1 {
+            assert!(channel.get_past_job(job_id).is_some());
+        }
+    }
+
+    #[test]
     fn test_past_jobs_flow() {
         let channel_id = 1;
         let user_identity = "user_identity".to_string();
@@ -1140,6 +1224,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let ntime: u32 = 1746839905;
@@ -1221,6 +1306,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1320,6 +1406,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1409,6 +1496,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1504,6 +1592,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1612,6 +1701,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1708,6 +1798,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1818,6 +1909,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -1908,6 +2000,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -2007,6 +2100,7 @@ mod tests {
             nominal_hashrate,
             version_rolling,
             rollable_extranonce_size,
+            None,
         );
 
         let future_job = NewExtendedMiningJob {
@@ -2103,6 +2197,7 @@ mod tests {
             1.0,
             true,
             8u16,
+            None,
         );
 
         // a non-future job is activated immediately
@@ -2168,6 +2263,7 @@ mod tests {
             1.0,
             true,
             8u16,
+            None,
         );
 
         let job_template = NewExtendedMiningJob {
@@ -2259,6 +2355,7 @@ mod tests {
             1.0,
             true,
             8u16,
+            None,
         );
 
         let job_template = NewExtendedMiningJob {
@@ -2380,6 +2477,7 @@ mod tests {
             1.0,
             true,
             8u16,
+            None,
         );
 
         let job = |job_id: u32, min_ntime: Option<u32>| NewExtendedMiningJob {
@@ -2472,6 +2570,7 @@ mod tests {
             1.0,
             true,
             8u16,
+            None,
         );
 
         channel

--- a/sv2/channels-sv2/src/client/mod.rs
+++ b/sv2/channels-sv2/src/client/mod.rs
@@ -33,6 +33,10 @@ pub const MAX_FUTURE_JOBS: usize = 16;
 /// 50 matches the server-side cap, so a proxy's client channel never evicts a job its upstream
 /// still accepts, and buys ample headroom over the reachable submit depth of ~1-2 past jobs at a
 /// small measured memory cost — see the load-test data in PR #2290.
+///
+/// This is only the default. The cap is really a retention window — `cap / job rate` — and the
+/// job rate belongs to the deployment, so channel constructors take a
+/// `max_past_jobs: Option<NonZeroUsize>` and fall back to this value when passed `None`.
 pub const MAX_PAST_JOBS: usize = 50;
 
 /// Maximum number of accepted-share hashes a client channel retains for duplicate detection.

--- a/sv2/channels-sv2/src/client/mod.rs
+++ b/sv2/channels-sv2/src/client/mod.rs
@@ -22,22 +22,25 @@ pub const MAX_FUTURE_JOBS: usize = 16;
 
 /// Maximum number of past jobs a client channel retains under the current chain tip.
 ///
-/// Upstream servers control the job stream, so a malicious or buggy server can force one retained
-/// past job per immediately-active job message. Bounding this map prevents unbounded memory
-/// growth. Past jobs exist for late-share validation, so the cap must stay nonzero. On overflow,
-/// the oldest past job is evicted: a share against it is rejected as
-/// [`InvalidJobId`](crate::client::share_accounting::ShareValidationError::InvalidJobId) even
-/// though it would otherwise have been accepted and propagated — a bounded loss of creditable
-/// work, the price of bounding memory under a hostile upstream.
+/// Past jobs serve late-share validation, so the cap must stay nonzero. On overflow the oldest is
+/// evicted and a share against it is rejected as
+/// [`InvalidJobId`](crate::client::share_accounting::ShareValidationError::InvalidJobId) — a
+/// bounded loss of creditable work, the price of bounding memory under a hostile upstream, which
+/// controls the job stream and can otherwise force one retained past job per active-job message.
 ///
-/// 50 matches the server-side cap, so a proxy's client channel never evicts a job its upstream
-/// still accepts, and buys ample headroom over the reachable submit depth of ~1-2 past jobs at a
-/// small measured memory cost — see the load-test data in PR #2290.
+/// Matches the server-side default, so a proxy never evicts a job its upstream still accepts.
+/// Retaining more than the upstream gains nothing: the proxy credits the share locally and the
+/// upstream rejects it anyway.
 ///
-/// This is only the default. The cap is really a retention window — `cap / job rate` — and the
-/// job rate belongs to the deployment, so channel constructors take a
-/// `max_past_jobs: Option<usize>` and fall back to this value when passed `None` or `Some(0)`.
-pub const MAX_PAST_JOBS: usize = 50;
+/// The cap is a retention *window* — `cap / job rate` — and here the upstream sets the rate.
+/// Measurement bounded the requirement at ~16 s (PR #2307), so 16 covers the fastest configurable
+/// rate of one job per second. Operators who know their upstream's interval `T` should set
+/// `ceil(16 s / T)`: 3 at a typical 6 s interval, 13.5 kB per channel against 72 kB (PR #2290).
+/// That matters most on a translator, where every downstream miner holds its own client channel;
+/// on a job-declaration client the interval is its own `SetCustomMiningJob` rate.
+///
+/// Constructors take a `max_past_jobs` override, falling back here on `None`/`Some(0)`.
+pub const MAX_PAST_JOBS: usize = 16;
 
 /// Maximum number of accepted-share hashes a client channel retains for duplicate detection.
 ///

--- a/sv2/channels-sv2/src/client/mod.rs
+++ b/sv2/channels-sv2/src/client/mod.rs
@@ -36,7 +36,7 @@ pub const MAX_FUTURE_JOBS: usize = 16;
 ///
 /// This is only the default. The cap is really a retention window — `cap / job rate` — and the
 /// job rate belongs to the deployment, so channel constructors take a
-/// `max_past_jobs: Option<NonZeroUsize>` and fall back to this value when passed `None`.
+/// `max_past_jobs: Option<usize>` and fall back to this value when passed `None` or `Some(0)`.
 pub const MAX_PAST_JOBS: usize = 50;
 
 /// Maximum number of accepted-share hashes a client channel retains for duplicate detection.
@@ -52,16 +52,6 @@ pub const MAX_PAST_JOBS: usize = 50;
 /// far beyond any realistic duplicate window in both cases. Overflow evicts oldest-first, and
 /// an evicted-then-replayed hash costs one double-counted local statistic.
 pub const MAX_SEEN_SHARES: usize = 4_096;
-
-/// Resolves a caller-supplied past-jobs cap against [`MAX_PAST_JOBS`].
-///
-/// Keeps the default referenced in one place, so changing it does not mean touching every
-/// channel constructor.
-pub(crate) fn resolve_max_past_jobs(max_past_jobs: Option<core::num::NonZeroUsize>) -> usize {
-    max_past_jobs
-        .map(core::num::NonZeroUsize::get)
-        .unwrap_or(MAX_PAST_JOBS)
-}
 
 // Type aliases that switch between `std::collections` and `hashbrown`
 // depending on whether the `no_std` feature is enabled.

--- a/sv2/channels-sv2/src/client/mod.rs
+++ b/sv2/channels-sv2/src/client/mod.rs
@@ -53,6 +53,16 @@ pub const MAX_PAST_JOBS: usize = 50;
 /// an evicted-then-replayed hash costs one double-counted local statistic.
 pub const MAX_SEEN_SHARES: usize = 4_096;
 
+/// Resolves a caller-supplied past-jobs cap against [`MAX_PAST_JOBS`].
+///
+/// Keeps the default referenced in one place, so changing it does not mean touching every
+/// channel constructor.
+pub(crate) fn resolve_max_past_jobs(max_past_jobs: Option<core::num::NonZeroUsize>) -> usize {
+    max_past_jobs
+        .map(core::num::NonZeroUsize::get)
+        .unwrap_or(MAX_PAST_JOBS)
+}
+
 // Type aliases that switch between `std::collections` and `hashbrown`
 // depending on whether the `no_std` feature is enabled.
 #[cfg(not(feature = "no_std"))]

--- a/sv2/channels-sv2/src/client/standard.rs
+++ b/sv2/channels-sv2/src/client/standard.rs
@@ -5,7 +5,7 @@
 //! and chain tip state, enabling share validation and mining job lifecycle management.
 
 extern crate alloc;
-use super::{resolve_max_past_jobs, HashMap, MAX_FUTURE_JOBS};
+use super::{HashMap, MAX_FUTURE_JOBS, MAX_PAST_JOBS};
 use crate::{
     chain_tip::ChainTip,
     client::{
@@ -24,7 +24,6 @@ use bitcoin::{
     hashes::sha256d::Hash,
     CompactTarget, Target,
 };
-use core::num::NonZeroUsize;
 use mining_sv2::{
     NewExtendedMiningJobOwned, NewMiningJobOwned, SetNewPrevHashOwned as SetNewPrevHashMp,
     SubmitSharesStandardOwned, ERROR_CODE_SUBMIT_SHARES_DIFFICULTY_TOO_LOW,
@@ -48,7 +47,7 @@ pub type StandardJob = (NewMiningJobOwned, Target);
 /// - future mining jobs (indexed by job_id, activated upon [`NewMiningJob`](mining_sv2::NewMiningJob) receipt, capped at [`MAX_FUTURE_JOBS`])
 /// - active mining job
 /// - past jobs (active jobs under current chain tip, indexed by job_id, capped at
-///   [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS))
+///   [`MAX_PAST_JOBS`])
 /// - stale jobs (jobs from previous chain tip, indexed by job_id)
 /// - share accounting state
 /// - chain tip state
@@ -70,7 +69,7 @@ pub struct StandardChannel {
     past_job_order: VecDeque<u32>,
     stale_jobs: HashMap<u32, StandardJob>,
     // Cap on `past_jobs` under the current chain tip, resolved from the constructor's
-    // `Option<NonZeroUsize>` against `MAX_PAST_JOBS`.
+    // `Option<usize>`; `None` and `Some(0)` both resolve to `MAX_PAST_JOBS`.
     max_past_jobs: usize,
     share_accounting: ShareAccounting,
     chain_tip: Option<ChainTip>,
@@ -79,16 +78,23 @@ pub struct StandardChannel {
 impl StandardChannel {
     /// Creates a new [`StandardChannel`] instance with provided channel parameters.
     ///
-    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS).
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip. `None` and
+    /// `Some(0)` both select [`MAX_PAST_JOBS`].
     pub fn new(
         channel_id: u32,
         user_identity: String,
         extranonce_prefix: ExtranoncePrefix,
         target: Target,
         nominal_hashrate: f32,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Self {
+        // fall back to the default when the caller has no opinion: `None`, or `Some(0)`, which
+        // would otherwise evict the just-retired job and reject the most common late share
+        let max_past_jobs = match max_past_jobs {
+            Some(cap) if cap > 0 => cap,
+            _ => MAX_PAST_JOBS,
+        };
+
         Self {
             channel_id,
             user_identity,
@@ -101,7 +107,7 @@ impl StandardChannel {
             past_jobs: HashMap::new(),
             past_job_order: VecDeque::new(),
             stale_jobs: HashMap::new(),
-            max_past_jobs: resolve_max_past_jobs(max_past_jobs),
+            max_past_jobs,
             share_accounting: ShareAccounting::new(),
             chain_tip: None,
         }
@@ -211,7 +217,7 @@ impl StandardChannel {
 
     /// Returns an iterator over all past jobs for the channel (active jobs under current chain tip).
     ///
-    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
     pub fn get_past_jobs(&self) -> impl Iterator<Item = (&u32, &StandardJob)> + '_ {
         self.past_jobs.iter()
     }
@@ -223,7 +229,7 @@ impl StandardChannel {
 
     /// Returns the number of past jobs tracked by this channel.
     ///
-    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
     pub fn get_past_jobs_count(&self) -> usize {
         self.past_jobs.len()
     }
@@ -305,7 +311,7 @@ impl StandardChannel {
     /// - If `min_ntime` is empty, the job is added to future jobs. At most [`MAX_FUTURE_JOBS`]
     ///   future jobs are kept: storing a new one beyond that limit evicts the oldest.
     /// - If an active job exists, it is moved to past jobs on activation. At most
-    ///   [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) past jobs are kept: retiring one beyond that limit evicts the oldest.
+    ///   [`MAX_PAST_JOBS`] past jobs are kept: retiring one beyond that limit evicts the oldest.
     pub fn on_new_mining_job(&mut self, new_mining_job: NewMiningJobOwned) {
         self.store_new_mining_job(new_mining_job);
     }
@@ -589,7 +595,6 @@ mod tests {
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
     use bitcoin::Target;
-    use core::num::NonZeroUsize;
     use mining_sv2::{
         NewExtendedMiningJobOwned as NewExtendedMiningJob, NewMiningJobOwned as NewMiningJob,
         SetNewPrevHashOwned as SetNewPrevHashMp, SubmitSharesStandardOwned,
@@ -775,8 +780,8 @@ mod tests {
     fn test_past_jobs_respect_constructor_override() {
         // Some(cap) must override MAX_PAST_JOBS on the client standard channel's own eviction
         // path, which keeps its past jobs directly rather than delegating to a JobStore.
-        let custom_cap = NonZeroUsize::new(3).unwrap();
-        assert!(custom_cap.get() < MAX_PAST_JOBS);
+        let custom_cap = 3usize;
+        assert!(custom_cap < MAX_PAST_JOBS);
 
         let channel_id = 1;
         let extranonce_prefix = [
@@ -814,15 +819,31 @@ mod tests {
         }
 
         // bounded by the override, not by MAX_PAST_JOBS
-        assert_eq!(channel.get_past_jobs_count(), custom_cap.get());
+        assert_eq!(channel.get_past_jobs_count(), custom_cap);
 
         // the last job is active; only the newest `custom_cap` retired jobs survive
-        for job_id in 0..job_count - 1 - custom_cap.get() as u32 {
+        for job_id in 0..job_count - 1 - custom_cap as u32 {
             assert!(channel.get_past_job(job_id).is_none());
         }
-        for job_id in job_count - 1 - custom_cap.get() as u32..job_count - 1 {
+        for job_id in job_count - 1 - custom_cap as u32..job_count - 1 {
             assert!(channel.get_past_job(job_id).is_some());
         }
+
+        // `Some(0)` is not a zero cap: it means "no opinion" and selects the default
+        let mut zero_cap_channel = StandardChannel::new(
+            channel_id,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(vec![0; 27]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            Some(0),
+        );
+        for job_id in 0..MAX_PAST_JOBS as u32 + 2 {
+            let mut job = active_job.clone();
+            job.job_id = job_id;
+            zero_cap_channel.on_new_mining_job(job);
+        }
+        assert_eq!(zero_cap_channel.get_past_jobs_count(), MAX_PAST_JOBS);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/client/standard.rs
+++ b/sv2/channels-sv2/src/client/standard.rs
@@ -24,6 +24,7 @@ use bitcoin::{
     hashes::sha256d::Hash,
     CompactTarget, Target,
 };
+use core::num::NonZeroUsize;
 use mining_sv2::{
     NewExtendedMiningJobOwned, NewMiningJobOwned, SetNewPrevHashOwned as SetNewPrevHashMp,
     SubmitSharesStandardOwned, ERROR_CODE_SUBMIT_SHARES_DIFFICULTY_TOO_LOW,
@@ -68,18 +69,25 @@ pub struct StandardChannel {
     // Replaced IDs move to the back; overflow evicts from the front.
     past_job_order: VecDeque<u32>,
     stale_jobs: HashMap<u32, StandardJob>,
+    // Cap on `past_jobs` under the current chain tip, resolved from the constructor's
+    // `Option<NonZeroUsize>` against `MAX_PAST_JOBS`.
+    max_past_jobs: usize,
     share_accounting: ShareAccounting,
     chain_tip: Option<ChainTip>,
 }
 
 impl StandardChannel {
     /// Creates a new [`StandardChannel`] instance with provided channel parameters.
+    ///
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
+    /// [`MAX_PAST_JOBS`].
     pub fn new(
         channel_id: u32,
         user_identity: String,
         extranonce_prefix: ExtranoncePrefix,
         target: Target,
         nominal_hashrate: f32,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Self {
         Self {
             channel_id,
@@ -93,6 +101,9 @@ impl StandardChannel {
             past_jobs: HashMap::new(),
             past_job_order: VecDeque::new(),
             stale_jobs: HashMap::new(),
+            max_past_jobs: max_past_jobs
+                .map(NonZeroUsize::get)
+                .unwrap_or(MAX_PAST_JOBS),
             share_accounting: ShareAccounting::new(),
             chain_tip: None,
         }
@@ -313,7 +324,7 @@ impl StandardChannel {
         self.past_job_order.retain(|id| *id != job_id);
         self.past_job_order.push_back(job_id);
 
-        if self.past_jobs.len() > MAX_PAST_JOBS {
+        if self.past_jobs.len() > self.max_past_jobs {
             if let Some(evicted_job_id) = self.past_job_order.pop_front() {
                 self.past_jobs.remove(&evicted_job_id);
             }
@@ -604,6 +615,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -664,6 +676,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             Target::from_le_bytes([0xff; 32]),
             1.0,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -710,6 +723,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             Target::from_le_bytes([0xff; 32]),
             1.0,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -773,6 +787,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             Target::from_le_bytes([0xff; 32]),
             1.0,
+            None,
         );
 
         let active_job = NewMiningJob {
@@ -823,6 +838,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let ntime: u32 = 1746839905;
@@ -877,6 +893,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -957,6 +974,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -1027,6 +1045,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -1103,6 +1122,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -1174,6 +1194,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -1255,6 +1276,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -1335,6 +1357,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let future_job = NewMiningJob {
@@ -1414,6 +1437,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             Target::from_le_bytes([0xff; 32]),
             1.0,
+            None,
         );
 
         let merkle_root = [
@@ -1495,6 +1519,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             Target::from_le_bytes([0xff; 32]),
             1.0,
+            None,
         );
 
         let merkle_root = [
@@ -1565,6 +1590,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             Target::from_le_bytes([0xff; 32]),
             1.0,
+            None,
         );
 
         let merkle_root = [
@@ -1650,6 +1676,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             target,
             nominal_hashrate,
+            None,
         );
 
         let malformed_job = NewExtendedMiningJob {
@@ -1692,6 +1719,7 @@ mod tests {
             ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
             Target::from_le_bytes([0xff; 32]),
             1.0,
+            None,
         );
 
         channel.on_new_mining_job(NewMiningJob {

--- a/sv2/channels-sv2/src/client/standard.rs
+++ b/sv2/channels-sv2/src/client/standard.rs
@@ -5,7 +5,7 @@
 //! and chain tip state, enabling share validation and mining job lifecycle management.
 
 extern crate alloc;
-use super::{HashMap, MAX_FUTURE_JOBS, MAX_PAST_JOBS};
+use super::{resolve_max_past_jobs, HashMap, MAX_FUTURE_JOBS};
 use crate::{
     chain_tip::ChainTip,
     client::{
@@ -48,7 +48,7 @@ pub type StandardJob = (NewMiningJobOwned, Target);
 /// - future mining jobs (indexed by job_id, activated upon [`NewMiningJob`](mining_sv2::NewMiningJob) receipt, capped at [`MAX_FUTURE_JOBS`])
 /// - active mining job
 /// - past jobs (active jobs under current chain tip, indexed by job_id, capped at
-///   [`MAX_PAST_JOBS`])
+///   [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS))
 /// - stale jobs (jobs from previous chain tip, indexed by job_id)
 /// - share accounting state
 /// - chain tip state
@@ -80,7 +80,7 @@ impl StandardChannel {
     /// Creates a new [`StandardChannel`] instance with provided channel parameters.
     ///
     /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// [`MAX_PAST_JOBS`].
+    /// [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS).
     pub fn new(
         channel_id: u32,
         user_identity: String,
@@ -101,9 +101,7 @@ impl StandardChannel {
             past_jobs: HashMap::new(),
             past_job_order: VecDeque::new(),
             stale_jobs: HashMap::new(),
-            max_past_jobs: max_past_jobs
-                .map(NonZeroUsize::get)
-                .unwrap_or(MAX_PAST_JOBS),
+            max_past_jobs: resolve_max_past_jobs(max_past_jobs),
             share_accounting: ShareAccounting::new(),
             chain_tip: None,
         }
@@ -213,7 +211,7 @@ impl StandardChannel {
 
     /// Returns an iterator over all past jobs for the channel (active jobs under current chain tip).
     ///
-    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
     pub fn get_past_jobs(&self) -> impl Iterator<Item = (&u32, &StandardJob)> + '_ {
         self.past_jobs.iter()
     }
@@ -225,7 +223,7 @@ impl StandardChannel {
 
     /// Returns the number of past jobs tracked by this channel.
     ///
-    /// At most [`MAX_PAST_JOBS`] jobs are kept (oldest evicted first).
+    /// At most [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) jobs are kept (oldest evicted first).
     pub fn get_past_jobs_count(&self) -> usize {
         self.past_jobs.len()
     }
@@ -307,7 +305,7 @@ impl StandardChannel {
     /// - If `min_ntime` is empty, the job is added to future jobs. At most [`MAX_FUTURE_JOBS`]
     ///   future jobs are kept: storing a new one beyond that limit evicts the oldest.
     /// - If an active job exists, it is moved to past jobs on activation. At most
-    ///   [`MAX_PAST_JOBS`] past jobs are kept: retiring one beyond that limit evicts the oldest.
+    ///   [`MAX_PAST_JOBS`](super::MAX_PAST_JOBS) past jobs are kept: retiring one beyond that limit evicts the oldest.
     pub fn on_new_mining_job(&mut self, new_mining_job: NewMiningJobOwned) {
         self.store_new_mining_job(new_mining_job);
     }
@@ -591,6 +589,7 @@ mod tests {
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
     use bitcoin::Target;
+    use core::num::NonZeroUsize;
     use mining_sv2::{
         NewExtendedMiningJobOwned as NewExtendedMiningJob, NewMiningJobOwned as NewMiningJob,
         SetNewPrevHashOwned as SetNewPrevHashMp, SubmitSharesStandardOwned,
@@ -770,6 +769,60 @@ mod tests {
             min_ntime: 1746839905,
         };
         channel.on_set_new_prev_hash(set_new_prev_hash).unwrap();
+    }
+
+    #[test]
+    fn test_past_jobs_respect_constructor_override() {
+        // Some(cap) must override MAX_PAST_JOBS on the client standard channel's own eviction
+        // path, which keeps its past jobs directly rather than delegating to a JobStore.
+        let custom_cap = NonZeroUsize::new(3).unwrap();
+        assert!(custom_cap.get() < MAX_PAST_JOBS);
+
+        let channel_id = 1;
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+
+        let mut channel = StandardChannel::new(
+            channel_id,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            Some(custom_cap),
+        );
+
+        let active_job = NewMiningJob {
+            channel_id,
+            job_id: 0,
+            merkle_root: [
+                189, 200, 25, 246, 119, 73, 34, 42, 209, 112, 237, 50, 169, 71, 163, 192, 24, 84,
+                56, 86, 147, 71, 243, 44, 18, 107, 167, 169, 169, 66, 186, 98,
+            ]
+            .into(),
+            version: 536870912,
+            min_ntime: Sv2Option::new(Some(1746839905)),
+        };
+
+        let job_count = 20u32;
+        for job_id in 0..job_count {
+            let mut job = active_job.clone();
+            job.job_id = job_id;
+            channel.on_new_mining_job(job);
+        }
+
+        // bounded by the override, not by MAX_PAST_JOBS
+        assert_eq!(channel.get_past_jobs_count(), custom_cap.get());
+
+        // the last job is active; only the newest `custom_cap` retired jobs survive
+        for job_id in 0..job_count - 1 - custom_cap.get() as u32 {
+            assert!(channel.get_past_job(job_id).is_none());
+        }
+        for job_id in job_count - 1 - custom_cap.get() as u32..job_count - 1 {
+            assert!(channel.get_past_job(job_id).is_some());
+        }
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -46,7 +46,12 @@ use crate::{
     merkle_root::merkle_root_from_path,
     server::{
         error::ExtendedChannelError,
-        jobs::{extended::ExtendedJob, factory::JobFactory, job_store::JobStore, JobOrigin},
+        jobs::{
+            extended::ExtendedJob,
+            factory::JobFactory,
+            job_store::{JobStore, MAX_PAST_JOBS},
+            JobOrigin,
+        },
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
     },
     target::{bytes_to_hex, hash_rate_to_target, u256_to_block_hash},
@@ -67,7 +72,7 @@ use mining_sv2::{
     ERROR_CODE_SUBMIT_SHARES_INVALID_SHARE, ERROR_CODE_SUBMIT_SHARES_STALE_SHARE,
     ERROR_CODE_UPDATE_CHANNEL_INVALID_NOMINAL_HASHRATE, ERROR_CODE_VERSION_ROLLING_NOT_ALLOWED,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroUsize};
 use template_distribution_sv2::{NewTemplateOwned, SetNewPrevHashOwned as SetNewPrevHashTdp};
 use tracing::debug;
 
@@ -122,6 +127,9 @@ impl ExtendedChannel {
     /// Returns [`ExtendedChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
     /// full extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
     /// budget, see [`JobFactory::fits_script_sig_budget`].
+    ///
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
+    /// the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_pool(
         channel_id: u32,
@@ -134,6 +142,7 @@ impl ExtendedChannel {
         share_batch_size: usize,
         expected_share_per_minute: f32,
         pool_tag_string: String,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Result<Self, ExtendedChannelError> {
         Self::new(
             channel_id,
@@ -147,6 +156,7 @@ impl ExtendedChannel {
             expected_share_per_minute,
             Some(pool_tag_string),
             None,
+            max_past_jobs,
         )
     }
 
@@ -164,6 +174,9 @@ impl ExtendedChannel {
     /// Returns [`ExtendedChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
     /// full extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
     /// budget, see [`JobFactory::fits_script_sig_budget`].
+    ///
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
+    /// the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_job_declaration_client(
         channel_id: u32,
@@ -177,6 +190,7 @@ impl ExtendedChannel {
         expected_share_per_minute: f32,
         pool_tag_string: Option<String>,
         miner_tag_string: String,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Result<Self, ExtendedChannelError> {
         Self::new(
             channel_id,
@@ -190,6 +204,7 @@ impl ExtendedChannel {
             expected_share_per_minute,
             pool_tag_string,
             Some(miner_tag_string),
+            max_past_jobs,
         )
     }
 
@@ -207,6 +222,7 @@ impl ExtendedChannel {
         expected_share_per_minute: f32,
         pool_tag: Option<String>,
         miner_tag: Option<String>,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Result<Self, ExtendedChannelError> {
         let target =
             match hash_rate_to_target(nominal_hashrate.into(), expected_share_per_minute.into()) {
@@ -247,7 +263,11 @@ impl ExtendedChannel {
             job_id_to_target: HashMap::new(),
             nominal_hashrate,
             stable_hashrate: false,
-            job_store: JobStore::new(),
+            job_store: JobStore::new(
+                max_past_jobs
+                    .map(NonZeroUsize::get)
+                    .unwrap_or(MAX_PAST_JOBS),
+            ),
             job_factory,
             share_accounting: ShareAccounting::new(
                 share_batch_size,
@@ -1045,6 +1065,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1190,6 +1211,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1309,6 +1331,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1383,6 +1406,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -1502,6 +1526,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1599,6 +1624,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -1715,6 +1741,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -1841,6 +1868,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1873,6 +1901,7 @@ mod tests {
             100,
             1.0,
             Some("x".repeat(pool_tag_len)),
+            None,
             None,
         )
     }
@@ -1988,6 +2017,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2071,6 +2101,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2135,6 +2166,7 @@ mod tests {
             100,
             1.0,
             String::new(),
+            None,
         )
         .unwrap();
 
@@ -2333,6 +2365,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2437,6 +2470,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2538,6 +2572,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2614,6 +2649,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -2725,6 +2761,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2795,6 +2832,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2834,6 +2872,7 @@ mod tests {
             8u16,
             100,
             1.0,
+            None,
             None,
             None,
         )
@@ -2909,6 +2948,7 @@ mod tests {
             100,
             1.0,
             String::new(),
+            None,
         )
         .unwrap();
 
@@ -3021,6 +3061,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -3143,6 +3184,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -3247,6 +3289,7 @@ mod tests {
             rollable_extranonce_size,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -3373,6 +3416,7 @@ mod tests {
             1.0,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -3447,6 +3491,7 @@ mod tests {
             4u16,
             100,
             1.0,
+            None,
             None,
             None,
         )
@@ -3535,6 +3580,7 @@ mod tests {
             8u16,
             100,
             1.0,
+            None,
             None,
             None,
         )

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -49,7 +49,7 @@ use crate::{
         jobs::{
             extended::ExtendedJob,
             factory::JobFactory,
-            job_store::{JobStore, MAX_PAST_JOBS},
+            job_store::{resolve_max_past_jobs, JobStore},
             JobOrigin,
         },
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
@@ -263,11 +263,7 @@ impl ExtendedChannel {
             job_id_to_target: HashMap::new(),
             nominal_hashrate,
             stable_hashrate: false,
-            job_store: JobStore::new(
-                max_past_jobs
-                    .map(NonZeroUsize::get)
-                    .unwrap_or(MAX_PAST_JOBS),
-            ),
+            job_store: JobStore::new(resolve_max_past_jobs(max_past_jobs)),
             job_factory,
             share_accounting: ShareAccounting::new(
                 share_batch_size,

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -49,7 +49,7 @@ use crate::{
         jobs::{
             extended::ExtendedJob,
             factory::JobFactory,
-            job_store::{resolve_max_past_jobs, JobStore},
+            job_store::{JobStore, MAX_PAST_JOBS},
             JobOrigin,
         },
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
@@ -72,7 +72,7 @@ use mining_sv2::{
     ERROR_CODE_SUBMIT_SHARES_INVALID_SHARE, ERROR_CODE_SUBMIT_SHARES_STALE_SHARE,
     ERROR_CODE_UPDATE_CHANNEL_INVALID_NOMINAL_HASHRATE, ERROR_CODE_VERSION_ROLLING_NOT_ALLOWED,
 };
-use std::{collections::HashMap, num::NonZeroUsize};
+use std::collections::HashMap;
 use template_distribution_sv2::{NewTemplateOwned, SetNewPrevHashOwned as SetNewPrevHashTdp};
 use tracing::debug;
 
@@ -128,8 +128,8 @@ impl ExtendedChannel {
     /// full extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
     /// budget, see [`JobFactory::fits_script_sig_budget`].
     ///
-    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// the crate default.
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip. `None` and
+    /// `Some(0)` both select the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_pool(
         channel_id: u32,
@@ -142,7 +142,7 @@ impl ExtendedChannel {
         share_batch_size: usize,
         expected_share_per_minute: f32,
         pool_tag_string: String,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Result<Self, ExtendedChannelError> {
         Self::new(
             channel_id,
@@ -175,8 +175,8 @@ impl ExtendedChannel {
     /// full extranonce and a worst-case coinbase prefix do not fit within the coinbase `scriptSig`
     /// budget, see [`JobFactory::fits_script_sig_budget`].
     ///
-    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// the crate default.
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip. `None` and
+    /// `Some(0)` both select the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_job_declaration_client(
         channel_id: u32,
@@ -190,7 +190,7 @@ impl ExtendedChannel {
         expected_share_per_minute: f32,
         pool_tag_string: Option<String>,
         miner_tag_string: String,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Result<Self, ExtendedChannelError> {
         Self::new(
             channel_id,
@@ -222,7 +222,7 @@ impl ExtendedChannel {
         expected_share_per_minute: f32,
         pool_tag: Option<String>,
         miner_tag: Option<String>,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Result<Self, ExtendedChannelError> {
         let target =
             match hash_rate_to_target(nominal_hashrate.into(), expected_share_per_minute.into()) {
@@ -253,6 +253,13 @@ impl ExtendedChannel {
             return Err(ExtendedChannelError::ScriptSigSizeTooLarge);
         }
 
+        // fall back to the default when the caller has no opinion: `None`, or `Some(0)`, which
+        // would otherwise evict the just-retired job and reject the most common late share
+        let max_past_jobs = match max_past_jobs {
+            Some(cap) if cap > 0 => cap,
+            _ => MAX_PAST_JOBS,
+        };
+
         Ok(Self {
             channel_id,
             user_identity,
@@ -263,7 +270,7 @@ impl ExtendedChannel {
             job_id_to_target: HashMap::new(),
             nominal_hashrate,
             stable_hashrate: false,
-            job_store: JobStore::new(resolve_max_past_jobs(max_past_jobs)),
+            job_store: JobStore::new(max_past_jobs),
             job_factory,
             share_accounting: ShareAccounting::new(
                 share_batch_size,
@@ -3467,6 +3474,93 @@ mod tests {
                 .get_future_job_id_from_template_id(template_id)
                 .is_some());
         }
+    }
+
+    // Builds an extended channel with the given past-jobs cap, feeds it `templates`
+    // non-future templates (each retiring the previous active job), and returns how many past
+    // jobs survived.
+    fn retained_past_jobs(max_past_jobs: Option<usize>, templates: u64) -> usize {
+        let channel_id = 1;
+        let extranonce_prefix = [
+            83, 116, 114, 97, 116, 117, 109, 32, 86, 50, 32, 83, 82, 73, 32, 80, 111, 111, 108, 0,
+            0, 0, 0, 0, 0, 0, 1,
+        ]
+        .to_vec();
+        let mut channel = ExtendedChannel::new(
+            channel_id,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(extranonce_prefix).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            4u16,
+            100,
+            1.0,
+            None,
+            None,
+            max_past_jobs,
+        )
+        .unwrap();
+
+        let prev_hash = [
+            200, 53, 253, 129, 214, 31, 43, 84, 179, 58, 58, 76, 128, 213, 24, 53, 38, 144, 205,
+            88, 172, 20, 251, 22, 217, 141, 21, 221, 21, 0, 0, 0,
+        ]
+        .into();
+        channel.set_chain_tip(ChainTip::new(prev_hash, 503543726, 1747092633));
+
+        let pubkey_hash = [
+            235, 225, 183, 220, 194, 147, 204, 170, 14, 231, 67, 168, 111, 137, 223, 130, 88, 194,
+            8, 252,
+        ];
+        let mut script_bytes = vec![0];
+        script_bytes.push(20);
+        script_bytes.extend_from_slice(&pubkey_hash);
+        let coinbase_reward_outputs = vec![TxOut {
+            value: Amount::from_sat(SATS_AVAILABLE_IN_TEMPLATE),
+            script_pubkey: ScriptBuf::from(script_bytes),
+        }];
+
+        for template_id in 0..templates {
+            let template = NewTemplate {
+                template_id,
+                future_template: false,
+                version: 536870912,
+                coinbase_tx_version: 2,
+                coinbase_prefix: vec![82, 0].try_into().unwrap(),
+                coinbase_tx_input_sequence: 4294967295,
+                coinbase_tx_value_remaining: SATS_AVAILABLE_IN_TEMPLATE,
+                coinbase_tx_outputs_count: 1,
+                coinbase_tx_outputs: vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 226, 246, 28, 63, 113,
+                    209, 222, 253, 63, 169, 153, 223, 163, 105, 83, 117, 92, 105, 6, 137, 121, 153,
+                    98, 180, 139, 235, 216, 54, 151, 78, 140, 249,
+                ]
+                .try_into()
+                .unwrap(),
+                coinbase_tx_locktime: 0,
+                merkle_path: vec![].try_into().unwrap(),
+            };
+            channel
+                .on_new_template(template, coinbase_reward_outputs.clone())
+                .unwrap();
+        }
+
+        (0..=templates as u32)
+            .filter(|job_id| channel.get_past_job(*job_id).is_some())
+            .count()
+    }
+
+    #[test]
+    fn test_max_past_jobs_override_and_zero_fallback() {
+        let templates = MAX_PAST_JOBS as u64 + 2;
+
+        // `None` and `Some(0)` both mean "no opinion" and select the default
+        assert_eq!(retained_past_jobs(None, templates), MAX_PAST_JOBS);
+        assert_eq!(retained_past_jobs(Some(0), templates), MAX_PAST_JOBS);
+
+        // a real override bounds below the default
+        assert_eq!(retained_past_jobs(Some(2), templates), 2);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/group.rs
+++ b/sv2/channels-sv2/src/server/group.rs
@@ -34,7 +34,11 @@ use crate::{
     chain_tip::ChainTip,
     server::{
         error::GroupChannelError,
-        jobs::{extended::ExtendedJob, factory::JobFactory, job_store::JobStore},
+        jobs::{
+            extended::ExtendedJob,
+            factory::JobFactory,
+            job_store::{JobStore, MAX_PAST_JOBS},
+        },
     },
 };
 use bitcoin::transaction::TxOut;
@@ -143,7 +147,10 @@ impl GroupChannel {
             group_channel_id,
             channel_ids: HashSet::new(),
             job_factory,
-            job_store: JobStore::new(),
+            // group channels never validate shares, so they replace the active job rather than
+            // retiring it into past jobs (see `JobStore::replace_active_job`). The cap is
+            // therefore inert here and needs no constructor parameter.
+            job_store: JobStore::new(MAX_PAST_JOBS),
             chain_tip: None,
             full_extranonce_size,
         })

--- a/sv2/channels-sv2/src/server/jobs/job_store.rs
+++ b/sv2/channels-sv2/src/server/jobs/job_store.rs
@@ -35,6 +35,10 @@ pub(crate) const MAX_FUTURE_JOBS: usize = 16;
 /// 50 buys ample headroom over the reachable submit depth (a miner abandons a job once the next
 /// one arrives, so late shares realistically target the last 1-2 jobs) at a small measured
 /// memory cost — see the load-test data in PR #2290.
+///
+/// This is only the default. The cap is really a retention window — `cap / job rate` — and the
+/// job rate belongs to the deployment, so channel constructors accept a `max_past_jobs`
+/// override and fall back to this value when none is given.
 pub(crate) const MAX_PAST_JOBS: usize = 50;
 
 /// Internal implementation for tracking mining job states in SV2 server channels.
@@ -61,11 +65,15 @@ pub(crate) struct JobStore<T: Job> {
     // that can accept shares. Holding the object here keeps its allocator slot reserved; dropping
     // it releases the slot.
     retired_extranonce_prefixes: Vec<ExtranoncePrefix>,
+    // Cap on `past_jobs` under the current chain tip. Nonzero by construction: the caller
+    // resolves an `Option<NonZeroUsize>` against `MAX_PAST_JOBS` before reaching here.
+    max_past_jobs: usize,
 }
 
 impl<T: Job> JobStore<T> {
-    /// Creates a new empty job store.
-    pub fn new() -> Self {
+    /// Creates a new empty job store retaining at most `max_past_jobs` past jobs under the
+    /// current chain tip.
+    pub fn new(max_past_jobs: usize) -> Self {
         Self {
             future_template_to_job_id: HashMap::new(),
             future_template_order: VecDeque::new(),
@@ -75,13 +83,14 @@ impl<T: Job> JobStore<T> {
             past_job_order: VecDeque::new(),
             stale_jobs: HashMap::new(),
             retired_extranonce_prefixes: Vec::new(),
+            max_past_jobs,
         }
     }
 }
 
 impl<T: Job> Default for JobStore<T> {
     fn default() -> Self {
-        Self::new()
+        Self::new(MAX_PAST_JOBS)
     }
 }
 
@@ -133,10 +142,10 @@ impl<T: Job> JobStore<T> {
         new_job_id
     }
 
-    /// Moves the active job (if any) into past jobs, evicting the oldest past job beyond
-    /// `MAX_PAST_JOBS`. A share against an evicted job is rejected as `InvalidJobId` even though
-    /// it would otherwise have been accepted and credited: a bounded loss of creditable work,
-    /// the price of bounding memory under a hostile upstream.
+    /// Moves the active job (if any) into past jobs, evicting the oldest past job beyond this
+    /// store's `max_past_jobs`. A share against an evicted job is rejected as `InvalidJobId` even
+    /// though it would otherwise have been accepted and credited: a bounded loss of creditable
+    /// work, the price of bounding memory under a hostile upstream.
     ///
     /// Returns the evicted job's ID, if any, so callers can drop metadata they key by job ID.
     fn retire_active_to_past(&mut self) -> Option<u32> {
@@ -148,7 +157,7 @@ impl<T: Job> JobStore<T> {
         // ID can never already be in the eviction order
         self.past_job_order.push_back(job_id);
 
-        if self.past_jobs.len() > MAX_PAST_JOBS {
+        if self.past_jobs.len() > self.max_past_jobs {
             if let Some(evicted_job_id) = self.past_job_order.pop_front() {
                 self.past_jobs.remove(&evicted_job_id);
                 // the evicted job may have been the last one holding a retired extranonce
@@ -161,11 +170,11 @@ impl<T: Job> JobStore<T> {
         None
     }
 
-    /// Moves the active job (if any) into past jobs without the `MAX_PAST_JOBS` cap and without
+    /// Moves the active job (if any) into past jobs without the `max_past_jobs` cap and without
     /// pruning retired extranonce prefixes.
     ///
     /// Only for tip transitions, where past jobs immediately drain into stale jobs: `stale_jobs`
-    /// stays bounded at `MAX_PAST_JOBS + 1`, no job is dropped from the stale set (which would
+    /// stays bounded at `max_past_jobs + 1`, no job is dropped from the stale set (which would
     /// misclassify its late shares as `InvalidJobId` instead of `Stale`), and no prune runs
     /// while an in-flight future job is outside every collection (which would release its
     /// retired extranonce prefix while the job goes on to accept shares under it).
@@ -182,7 +191,7 @@ impl<T: Job> JobStore<T> {
 
     /// Adds an active job, moving the previous active job (if any) to past jobs.
     ///
-    /// At most `MAX_PAST_JOBS` past jobs are kept: retiring one beyond that limit evicts the
+    /// At most `max_past_jobs` past jobs are kept: retiring one beyond that limit evicts the
     /// oldest (giving up shares that would still have been creditable), and its ID is returned
     /// so callers can drop metadata they key by job ID (e.g. the per-job target mapping of
     /// standard and extended channels).
@@ -258,7 +267,7 @@ impl<T: Job> JobStore<T> {
         true
     }
 
-    /// Moves the active job (if any) into past jobs, without the `MAX_PAST_JOBS` cap.
+    /// Moves the active job (if any) into past jobs, without the `max_past_jobs` cap.
     ///
     /// Only for tip transitions, right before [`Self::mark_past_jobs_as_stale`] drains past
     /// jobs into stale jobs: the displaced job must go stale with the rest, not push another
@@ -383,7 +392,7 @@ mod tests {
 
     #[test]
     fn future_jobs_are_bounded() {
-        let mut store = JobStore::new();
+        let mut store = JobStore::new(MAX_PAST_JOBS);
 
         let flood_size = 10_000u64;
         for template_id in 0..flood_size {
@@ -411,8 +420,40 @@ mod tests {
     }
 
     #[test]
+    fn past_jobs_honour_a_custom_cap() {
+        // a store built with a cap below the default must evict against that cap, not the default
+        let custom_cap = 2;
+        assert!(custom_cap < MAX_PAST_JOBS);
+        let mut store = JobStore::new(custom_cap);
+
+        for job_id in 0..10u32 {
+            let evicted_job_id = store.add_active_job(DummyJob { job_id });
+            if job_id as usize > custom_cap {
+                assert_eq!(evicted_job_id, Some(job_id - custom_cap as u32 - 1));
+            } else {
+                assert_eq!(evicted_job_id, None);
+            }
+        }
+
+        assert_eq!(store.past_jobs.len(), custom_cap);
+        assert_eq!(store.past_job_order.len(), custom_cap);
+        // job 9 is active; only the two most recently retired survive
+        assert!(store.get_past_job(8).is_some());
+        assert!(store.get_past_job(7).is_some());
+        for job_id in 0..7u32 {
+            assert!(store.get_past_job(job_id).is_none());
+        }
+    }
+
+    #[test]
+    fn default_job_store_uses_the_default_cap() {
+        let store: JobStore<DummyJob> = JobStore::default();
+        assert_eq!(store.max_past_jobs, MAX_PAST_JOBS);
+    }
+
+    #[test]
     fn past_jobs_are_bounded() {
-        let mut store = JobStore::new();
+        let mut store = JobStore::new(MAX_PAST_JOBS);
 
         let flood_size = 10_000u32;
         for job_id in 0..flood_size {
@@ -458,7 +499,7 @@ mod tests {
 
     #[test]
     fn tip_transition_moves_displaced_and_all_past_jobs_to_stale() {
-        let mut store = JobStore::new();
+        let mut store = JobStore::new(MAX_PAST_JOBS);
 
         // fill past jobs to the cap, plus an active job
         for job_id in 0..=MAX_PAST_JOBS as u32 {
@@ -489,7 +530,7 @@ mod tests {
 
     #[test]
     fn activation_keeps_retired_prefix_of_activated_job() {
-        let mut store = JobStore::new();
+        let mut store = JobStore::new(MAX_PAST_JOBS);
         let old_prefix = vec![1u8];
 
         // a future job created under the old prefix, which is then rotated out
@@ -521,7 +562,7 @@ mod tests {
 
     #[test]
     fn dropped_jobs_release_retired_extranonce_prefixes() {
-        let mut store = JobStore::new();
+        let mut store = JobStore::new(MAX_PAST_JOBS);
         let old_prefix = vec![1u8];
 
         // a future job created under the old prefix keeps the retired prefix alive
@@ -550,7 +591,7 @@ mod tests {
 
     #[test]
     fn reused_template_id_evicts_superseded_future_job() {
-        let mut store = JobStore::new();
+        let mut store = JobStore::new(MAX_PAST_JOBS);
 
         let old_job_id = store.add_future_job(1, DummyJob { job_id: 10 });
         let new_job_id = store.add_future_job(1, DummyJob { job_id: 11 });

--- a/sv2/channels-sv2/src/server/jobs/job_store.rs
+++ b/sv2/channels-sv2/src/server/jobs/job_store.rs
@@ -26,20 +26,20 @@ pub(crate) const MAX_FUTURE_JOBS: usize = 16;
 
 /// Maximum number of past jobs a server channel retains under the current chain tip.
 ///
-/// Past jobs exist for late-share validation, so the cap must stay nonzero. A share against an
-/// evicted job is rejected as `InvalidJobId` even though it would otherwise have been accepted
-/// and credited — a bounded loss of creditable work, the price of bounding memory against a
-/// malicious template-distribution peer streaming non-future templates while withholding
-/// `SetNewPrevHash`.
+/// Past jobs serve late-share validation, so the cap must stay nonzero. On overflow the oldest is
+/// evicted and a share against it is rejected as `InvalidJobId` — a bounded loss of creditable
+/// work, the price of bounding memory against a hostile peer.
 ///
-/// 50 buys ample headroom over the reachable submit depth (a miner abandons a job once the next
-/// one arrives, so late shares realistically target the last 1-2 jobs) at a small measured
-/// memory cost — see the load-test data in PR #2290.
+/// The cap is a retention *window* — `cap / job rate` — and the rate belongs to the deployment.
+/// Measurement bounded the requirement at ~16 s (PR #2307), so 16 covers the fastest configurable
+/// rate of one job per second. Operators who know their own interval `T` should set
+/// `ceil(16 s / T)`: 3 at a typical 6 s interval, 13.5 kB per channel against 72 kB (PR #2290).
 ///
-/// This is only the default. The cap is really a retention window — `cap / job rate` — and the
-/// job rate belongs to the deployment, so channel constructors accept a `max_past_jobs`
-/// override and fall back to this value when given `None` or `Some(0)`.
-pub(crate) const MAX_PAST_JOBS: usize = 50;
+/// Channels accepting `SetCustomMiningJob` are the exception — each accepted job retires the
+/// active one, so the rate is the client's. Size against the rate the pool permits, or keep 16.
+///
+/// Constructors take a `max_past_jobs` override, falling back here on `None`/`Some(0)`.
+pub(crate) const MAX_PAST_JOBS: usize = 16;
 
 /// Internal implementation for tracking mining job states in SV2 server channels.
 ///

--- a/sv2/channels-sv2/src/server/jobs/job_store.rs
+++ b/sv2/channels-sv2/src/server/jobs/job_store.rs
@@ -10,7 +10,10 @@
 //! - **Retired Extranonce Prefixes**: Holds on to extranonce prefixes that were rotated out of the
 //!   channel while jobs created under them can still accept shares, so that their allocator slots
 //!   are not handed to another channel too early.
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    num::NonZeroUsize,
+};
 
 use super::Job;
 use crate::extranonce_manager::ExtranoncePrefix;
@@ -40,6 +43,16 @@ pub(crate) const MAX_FUTURE_JOBS: usize = 16;
 /// job rate belongs to the deployment, so channel constructors accept a `max_past_jobs`
 /// override and fall back to this value when none is given.
 pub(crate) const MAX_PAST_JOBS: usize = 50;
+
+/// Resolves a caller-supplied past-jobs cap against `MAX_PAST_JOBS`.
+///
+/// Keeps the default referenced in one place, so changing it does not mean touching every
+/// channel constructor.
+pub(crate) fn resolve_max_past_jobs(max_past_jobs: Option<NonZeroUsize>) -> usize {
+    max_past_jobs
+        .map(NonZeroUsize::get)
+        .unwrap_or(MAX_PAST_JOBS)
+}
 
 /// Internal implementation for tracking mining job states in SV2 server channels.
 ///
@@ -74,6 +87,10 @@ impl<T: Job> JobStore<T> {
     /// Creates a new empty job store retaining at most `max_past_jobs` past jobs under the
     /// current chain tip.
     pub fn new(max_past_jobs: usize) -> Self {
+        // callers resolve an `Option<NonZeroUsize>` via `resolve_max_past_jobs`, so a zero cap
+        // cannot arrive here; a zero cap would evict the just-retired job immediately and reject
+        // the most common late share as `InvalidJobId`
+        debug_assert!(max_past_jobs > 0, "max_past_jobs must be nonzero");
         Self {
             future_template_to_job_id: HashMap::new(),
             future_template_order: VecDeque::new(),
@@ -420,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    fn past_jobs_honour_a_custom_cap() {
+    fn past_jobs_respect_a_custom_cap() {
         // a store built with a cap below the default must evict against that cap, not the default
         let custom_cap = 2;
         assert!(custom_cap < MAX_PAST_JOBS);

--- a/sv2/channels-sv2/src/server/jobs/job_store.rs
+++ b/sv2/channels-sv2/src/server/jobs/job_store.rs
@@ -10,10 +10,7 @@
 //! - **Retired Extranonce Prefixes**: Holds on to extranonce prefixes that were rotated out of the
 //!   channel while jobs created under them can still accept shares, so that their allocator slots
 //!   are not handed to another channel too early.
-use std::{
-    collections::{HashMap, VecDeque},
-    num::NonZeroUsize,
-};
+use std::collections::{HashMap, VecDeque};
 
 use super::Job;
 use crate::extranonce_manager::ExtranoncePrefix;
@@ -41,18 +38,8 @@ pub(crate) const MAX_FUTURE_JOBS: usize = 16;
 ///
 /// This is only the default. The cap is really a retention window — `cap / job rate` — and the
 /// job rate belongs to the deployment, so channel constructors accept a `max_past_jobs`
-/// override and fall back to this value when none is given.
+/// override and fall back to this value when given `None` or `Some(0)`.
 pub(crate) const MAX_PAST_JOBS: usize = 50;
-
-/// Resolves a caller-supplied past-jobs cap against `MAX_PAST_JOBS`.
-///
-/// Keeps the default referenced in one place, so changing it does not mean touching every
-/// channel constructor.
-pub(crate) fn resolve_max_past_jobs(max_past_jobs: Option<NonZeroUsize>) -> usize {
-    max_past_jobs
-        .map(NonZeroUsize::get)
-        .unwrap_or(MAX_PAST_JOBS)
-}
 
 /// Internal implementation for tracking mining job states in SV2 server channels.
 ///
@@ -78,8 +65,8 @@ pub(crate) struct JobStore<T: Job> {
     // that can accept shares. Holding the object here keeps its allocator slot reserved; dropping
     // it releases the slot.
     retired_extranonce_prefixes: Vec<ExtranoncePrefix>,
-    // Cap on `past_jobs` under the current chain tip. Nonzero by construction: the caller
-    // resolves an `Option<NonZeroUsize>` against `MAX_PAST_JOBS` before reaching here.
+    // Cap on `past_jobs` under the current chain tip. Nonzero by construction: channel
+    // constructors resolve `None`/`Some(0)` to `MAX_PAST_JOBS` before reaching here.
     max_past_jobs: usize,
 }
 
@@ -87,9 +74,9 @@ impl<T: Job> JobStore<T> {
     /// Creates a new empty job store retaining at most `max_past_jobs` past jobs under the
     /// current chain tip.
     pub fn new(max_past_jobs: usize) -> Self {
-        // callers resolve an `Option<NonZeroUsize>` via `resolve_max_past_jobs`, so a zero cap
-        // cannot arrive here; a zero cap would evict the just-retired job immediately and reject
-        // the most common late share as `InvalidJobId`
+        // channel constructors resolve `None`/`Some(0)` to `MAX_PAST_JOBS`, so a zero cap cannot
+        // arrive here; it would evict the just-retired job immediately and reject the most common
+        // late share as `InvalidJobId`
         debug_assert!(max_past_jobs > 0, "max_past_jobs must be nonzero");
         Self {
             future_template_to_job_id: HashMap::new(),

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -41,7 +41,7 @@ use crate::{
         jobs::{
             extended::ExtendedJob,
             factory::JobFactory,
-            job_store::{JobStore, MAX_PAST_JOBS},
+            job_store::{resolve_max_past_jobs, JobStore},
             standard::StandardJob,
         },
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
@@ -249,11 +249,7 @@ impl StandardChannel {
                 crate::seen_shares_budget(expected_share_per_minute as f64),
             ),
             expected_share_per_minute,
-            job_store: JobStore::new(
-                max_past_jobs
-                    .map(NonZeroUsize::get)
-                    .unwrap_or(MAX_PAST_JOBS),
-            ),
+            job_store: JobStore::new(resolve_max_past_jobs(max_past_jobs)),
             job_factory,
             chain_tip: None,
         })

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -41,7 +41,7 @@ use crate::{
         jobs::{
             extended::ExtendedJob,
             factory::JobFactory,
-            job_store::{resolve_max_past_jobs, JobStore},
+            job_store::{JobStore, MAX_PAST_JOBS},
             standard::StandardJob,
         },
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
@@ -68,7 +68,7 @@ use mining_sv2::{
     ERROR_CODE_SUBMIT_SHARES_INVALID_SHARE, ERROR_CODE_SUBMIT_SHARES_STALE_SHARE,
     ERROR_CODE_UPDATE_CHANNEL_INVALID_NOMINAL_HASHRATE,
 };
-use std::{collections::HashMap, num::NonZeroUsize};
+use std::collections::HashMap;
 use template_distribution_sv2::{NewTemplateOwned, SetNewPrevHashOwned as SetNewPrevHash};
 use tracing::{debug, warn};
 
@@ -121,8 +121,8 @@ impl StandardChannel {
     /// extranonce prefix and a worst-case coinbase prefix do not fit within the coinbase
     /// `scriptSig` budget, see [`JobFactory::fits_script_sig_budget`].
     ///
-    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// the crate default.
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip. `None` and
+    /// `Some(0)` both select the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_pool(
         channel_id: u32,
@@ -133,7 +133,7 @@ impl StandardChannel {
         share_batch_size: usize,
         expected_share_per_minute: f32,
         pool_tag_string: String,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Result<Self, StandardChannelError> {
         Self::new(
             channel_id,
@@ -164,8 +164,8 @@ impl StandardChannel {
     /// extranonce prefix and a worst-case coinbase prefix do not fit within the coinbase
     /// `scriptSig` budget, see [`JobFactory::fits_script_sig_budget`].
     ///
-    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
-    /// the crate default.
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip. `None` and
+    /// `Some(0)` both select the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_job_declaration_client(
         channel_id: u32,
@@ -177,7 +177,7 @@ impl StandardChannel {
         expected_share_per_minute: f32,
         pool_tag_string: Option<String>,
         miner_tag_string: String,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Result<Self, StandardChannelError> {
         Self::new(
             channel_id,
@@ -205,7 +205,7 @@ impl StandardChannel {
         expected_share_per_minute: f32,
         pool_tag_string: Option<String>,
         miner_tag_string: Option<String>,
-        max_past_jobs: Option<NonZeroUsize>,
+        max_past_jobs: Option<usize>,
     ) -> Result<Self, StandardChannelError> {
         let calculated_target =
             match hash_rate_to_target(nominal_hashrate.into(), expected_share_per_minute.into()) {
@@ -235,6 +235,13 @@ impl StandardChannel {
             return Err(StandardChannelError::ScriptSigSizeTooLarge);
         }
 
+        // fall back to the default when the caller has no opinion: `None`, or `Some(0)`, which
+        // would otherwise evict the just-retired job and reject the most common late share
+        let max_past_jobs = match max_past_jobs {
+            Some(cap) if cap > 0 => cap,
+            _ => MAX_PAST_JOBS,
+        };
+
         Ok(Self {
             channel_id,
             user_identity,
@@ -249,7 +256,7 @@ impl StandardChannel {
                 crate::seen_shares_budget(expected_share_per_minute as f64),
             ),
             expected_share_per_minute,
-            job_store: JobStore::new(resolve_max_past_jobs(max_past_jobs)),
+            job_store: JobStore::new(max_past_jobs),
             job_factory,
             chain_tip: None,
         })

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -39,7 +39,10 @@ use crate::{
     server::{
         error::StandardChannelError,
         jobs::{
-            extended::ExtendedJob, factory::JobFactory, job_store::JobStore, standard::StandardJob,
+            extended::ExtendedJob,
+            factory::JobFactory,
+            job_store::{JobStore, MAX_PAST_JOBS},
+            standard::StandardJob,
         },
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
     },
@@ -65,7 +68,7 @@ use mining_sv2::{
     ERROR_CODE_SUBMIT_SHARES_INVALID_SHARE, ERROR_CODE_SUBMIT_SHARES_STALE_SHARE,
     ERROR_CODE_UPDATE_CHANNEL_INVALID_NOMINAL_HASHRATE,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroUsize};
 use template_distribution_sv2::{NewTemplateOwned, SetNewPrevHashOwned as SetNewPrevHash};
 use tracing::{debug, warn};
 
@@ -117,6 +120,9 @@ impl StandardChannel {
     /// Returns [`StandardChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
     /// extranonce prefix and a worst-case coinbase prefix do not fit within the coinbase
     /// `scriptSig` budget, see [`JobFactory::fits_script_sig_budget`].
+    ///
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
+    /// the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_pool(
         channel_id: u32,
@@ -127,6 +133,7 @@ impl StandardChannel {
         share_batch_size: usize,
         expected_share_per_minute: f32,
         pool_tag_string: String,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Result<Self, StandardChannelError> {
         Self::new(
             channel_id,
@@ -138,6 +145,7 @@ impl StandardChannel {
             expected_share_per_minute,
             Some(pool_tag_string),
             None,
+            max_past_jobs,
         )
     }
 
@@ -155,6 +163,9 @@ impl StandardChannel {
     /// Returns [`StandardChannelError::ScriptSigSizeTooLarge`] if the tags, the delimiters, the
     /// extranonce prefix and a worst-case coinbase prefix do not fit within the coinbase
     /// `scriptSig` budget, see [`JobFactory::fits_script_sig_budget`].
+    ///
+    /// `max_past_jobs` caps the past jobs retained under the current chain tip; `None` uses
+    /// the crate default.
     #[allow(clippy::too_many_arguments)]
     pub fn new_for_job_declaration_client(
         channel_id: u32,
@@ -166,6 +177,7 @@ impl StandardChannel {
         expected_share_per_minute: f32,
         pool_tag_string: Option<String>,
         miner_tag_string: String,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Result<Self, StandardChannelError> {
         Self::new(
             channel_id,
@@ -177,6 +189,7 @@ impl StandardChannel {
             expected_share_per_minute,
             pool_tag_string,
             Some(miner_tag_string),
+            max_past_jobs,
         )
     }
 
@@ -192,6 +205,7 @@ impl StandardChannel {
         expected_share_per_minute: f32,
         pool_tag_string: Option<String>,
         miner_tag_string: Option<String>,
+        max_past_jobs: Option<NonZeroUsize>,
     ) -> Result<Self, StandardChannelError> {
         let calculated_target =
             match hash_rate_to_target(nominal_hashrate.into(), expected_share_per_minute.into()) {
@@ -235,7 +249,11 @@ impl StandardChannel {
                 crate::seen_shares_budget(expected_share_per_minute as f64),
             ),
             expected_share_per_minute,
-            job_store: JobStore::new(),
+            job_store: JobStore::new(
+                max_past_jobs
+                    .map(NonZeroUsize::get)
+                    .unwrap_or(MAX_PAST_JOBS),
+            ),
             job_factory,
             chain_tip: None,
         })
@@ -923,6 +941,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1046,6 +1065,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1144,6 +1164,7 @@ mod tests {
             nominal_hashrate,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -1265,6 +1286,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1366,6 +1388,7 @@ mod tests {
             nominal_hashrate,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -1500,6 +1523,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1611,6 +1635,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1715,6 +1740,7 @@ mod tests {
             nominal_hashrate,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -1829,6 +1855,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1932,6 +1959,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1962,6 +1990,7 @@ mod tests {
             100,
             1.0,
             Some("x".repeat(pool_tag_len)),
+            None,
             None,
         )
     }
@@ -2071,6 +2100,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2153,6 +2183,7 @@ mod tests {
             expected_share_per_minute,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2211,6 +2242,7 @@ mod tests {
             nominal_hashrate,
             share_batch_size,
             expected_share_per_minute,
+            None,
             None,
             None,
         )
@@ -2347,6 +2379,7 @@ mod tests {
             100,
             1.0,
             String::new(),
+            None,
         )
         .unwrap();
 
@@ -2433,6 +2466,7 @@ mod tests {
             1.0,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2506,6 +2540,7 @@ mod tests {
             10.0,
             100,
             1.0,
+            None,
             None,
             None,
         )
@@ -2593,6 +2628,7 @@ mod tests {
             1_000.0,
             100,
             1.0,
+            None,
             None,
             None,
         )
@@ -2689,6 +2725,7 @@ mod tests {
             1_000.0,
             100,
             expected_share_per_minute,
+            None,
             None,
             None,
         )


### PR DESCRIPTION
`MAX_PAST_JOBS` is really a retention window — `cap ÷ template rate` — and the template rate is a deployment property the library can't see. The same constant buys 50s of late-share tolerance at a 1s template cadence and over 16 minutes at 20s, so I don't think one number can be right for everyone.

Adds `max_past_jobs: Option<usize>` to the server and client `ExtendedChannel`/`StandardChannel` constructors. `None` and `Some(0)` both select `MAX_PAST_JOBS`, so nothing changes for existing callers.

Treating `Some(0)` as "no opinion" rather than as a literal zero keeps a zero cap unreachable: it would evict the job that just retired, so the most common late share would come back `InvalidJobId` with no startup error to warn you.

Group channels take no parameter — client `GroupChannel` has no `past_jobs`, and server group channels use `replace_active_job`.

A second commit will set the default once we've measured it; the analysis is coming in a comment.

Follow-up to #2290.

companion https://github.com/stratum-mining/sv2-apps/pull/735