### PR TITLE
binary-sv2: bound and redact the ValueExceedsMaxSize sample

### DIFF
--- a/sv1/src/utils.rs
+++ b/sv1/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::error::{self, Error};
-use binary_sv2::{B032Owned, U256Owned, B032};
+use binary_sv2::{B032Owned, U256Owned, B032, ERROR_SAMPLE_LEN};
 use bitcoin::hashes::hex::{DisplayHex, FromHex};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
 use serde_json::Value;
@@ -216,7 +216,7 @@ impl TryFrom<&str> for PrevHash {
                         32,
                         0,
                         0,
-                        prev_hash_stratum_order,
+                        prev_hash_stratum_order[..len.min(ERROR_SAMPLE_LEN)].to_vec(),
                         len,
                     ),
                 ))

--- a/sv2/binary-sv2/src/datatypes/mod.rs
+++ b/sv2/binary-sv2/src/datatypes/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use non_copy_data_types::Inner;
 pub use non_copy_data_types::{
     B016MOwned, B0255Owned, B032Owned, B064KOwned, Mac, MacOwned, PubKey, PubKeyOwned, Seq0255,
     Seq0255Owned, Seq064K, Seq064KOwned, Signature, SignatureOwned, Str0255, Str0255Owned,
-    Sv2Option, Sv2OptionOwned, U256Owned, B016M, B0255, B032, B064K, U256,
+    Sv2Option, Sv2OptionOwned, U256Owned, B016M, B0255, B032, B064K, ERROR_SAMPLE_LEN, U256,
 };
 
 use alloc::vec::Vec;

--- a/sv2/binary-sv2/src/datatypes/non_copy_data_types/inner.rs
+++ b/sv2/binary-sv2/src/datatypes/non_copy_data_types/inner.rs
@@ -257,6 +257,11 @@ fn expected_length_variable<
     }
 }
 
+/// Upper bound on the offending bytes retained in `Error::ValueExceedsMaxSize`.
+///
+/// Retain one hash-sized prefix for diagnostics while keeping error allocations bounded.
+pub const ERROR_SAMPLE_LEN: usize = 32;
+
 fn validate_payload<
     const ISFIXED: bool,
     const SIZE: usize,
@@ -276,7 +281,7 @@ fn validate_payload<
                 SIZE,
                 HEADERSIZE,
                 MAXSIZE,
-                value.to_vec(),
+                value[..value.len().min(ERROR_SAMPLE_LEN)].to_vec(),
                 value.len(),
             ))
         };
@@ -288,7 +293,7 @@ fn validate_payload<
             SIZE,
             HEADERSIZE,
             MAXSIZE,
-            value.to_vec(),
+            value[..value.len().min(ERROR_SAMPLE_LEN)].to_vec(),
             value.len(),
         ))
     } else {
@@ -488,7 +493,11 @@ impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXS
     type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Self::new(value.to_vec())
+        validate_payload::<ISFIXED, SIZE, HEADERSIZE, MAXSIZE>(value)?;
+
+        Ok(Self {
+            data: value.to_vec(),
+        })
     }
 }
 
@@ -520,7 +529,7 @@ impl<const N: usize, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: 
     type Error = Error;
 
     fn try_from(value: [u8; N]) -> Result<Self, Self::Error> {
-        Self::new(value.to_vec())
+        Self::try_from(&value[..])
     }
 }
 
@@ -530,7 +539,7 @@ impl<const N: usize, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: 
     type Error = Error;
 
     fn try_from(value: &[u8; N]) -> Result<Self, Self::Error> {
-        Self::new(value.to_vec())
+        Self::try_from(&value[..])
     }
 }
 
@@ -540,7 +549,7 @@ impl<const N: usize, const SIZE: usize, const HEADERSIZE: usize, const MAXSIZE: 
     type Error = Error;
 
     fn try_from(value: &mut [u8; N]) -> Result<Self, Self::Error> {
-        Self::new(value.to_vec())
+        Self::try_from(&value[..])
     }
 }
 
@@ -632,7 +641,7 @@ impl<const ISFIXED: bool, const SIZE: usize, const HEADERSIZE: usize, const MAXS
 
 #[cfg(test)]
 mod test {
-    use super::{Inner, InnerOwned};
+    use super::{Inner, InnerOwned, ERROR_SAMPLE_LEN};
     use crate::{B032Owned, Error, GetSize, SignatureOwned, SizeHint, U256Owned, B032, U256};
     extern crate std;
     use self::std::panic::catch_unwind;
@@ -799,6 +808,40 @@ mod test {
         match <B032<'_> as SizeHint>::size_hint(&frame, 0).unwrap_err() {
             Error::ValueExceedsMaxSize(false, 1, 1, 32, retained, 33) => {
                 assert_eq!(retained.len(), 1);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // Both construction paths cap their sample; only the length field grows with the input.
+    #[test]
+    fn oversized_value_error_retains_only_a_capped_sample() {
+        let oversized = std::vec![0_u8; 1024 * 1024];
+
+        match B032Owned::new(oversized.clone()).unwrap_err() {
+            Error::ValueExceedsMaxSize(false, 1, 1, 32, retained, 1_048_576) => {
+                assert_eq!(retained.len(), ERROR_SAMPLE_LEN);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        match B032Owned::try_from(oversized.as_slice()).unwrap_err() {
+            Error::ValueExceedsMaxSize(false, 1, 1, 32, retained, 1_048_576) => {
+                assert_eq!(retained.len(), ERROR_SAMPLE_LEN);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        match B032::new(&oversized).unwrap_err() {
+            Error::ValueExceedsMaxSize(false, 1, 1, 32, retained, 1_048_576) => {
+                assert_eq!(retained.len(), ERROR_SAMPLE_LEN);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        match U256Owned::new(oversized).unwrap_err() {
+            Error::ValueExceedsMaxSize(true, 32, 0, 0, retained, 1_048_576) => {
+                assert_eq!(retained.len(), ERROR_SAMPLE_LEN);
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/sv2/binary-sv2/src/datatypes/non_copy_data_types/inner.rs
+++ b/sv2/binary-sv2/src/datatypes/non_copy_data_types/inner.rs
@@ -251,7 +251,7 @@ fn expected_length_variable<
             SIZE,
             HEADERSIZE,
             MAXSIZE,
-            data.to_vec(),
+            data[..HEADERSIZE].to_vec(),
             payload_len,
         ))
     }
@@ -788,5 +788,19 @@ mod test {
         type FixedZero<'a> = Inner<'a, true, 0, 0, 0>;
 
         assert_eq!(<FixedZero<'_> as SizeHint>::size_hint(&[], 0).unwrap(), 0);
+    }
+
+    // An over-limit length prefix must not copy the rest of the frame into the error.
+    #[test]
+    fn oversized_length_error_retains_only_the_header() {
+        let mut frame = std::vec![0_u8; 1024 * 1024];
+        frame[0] = 33;
+
+        match <B032<'_> as SizeHint>::size_hint(&frame, 0).unwrap_err() {
+            Error::ValueExceedsMaxSize(false, 1, 1, 32, retained, 33) => {
+                assert_eq!(retained.len(), 1);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/sv2/binary-sv2/src/datatypes/non_copy_data_types/mod.rs
+++ b/sv2/binary-sv2/src/datatypes/non_copy_data_types/mod.rs
@@ -28,6 +28,7 @@ use core::fmt::Write as _;
 pub(crate) mod inner;
 mod seq_inner;
 
+pub use inner::ERROR_SAMPLE_LEN;
 pub(crate) use inner::{Inner, InnerOwned};
 pub use seq_inner::{Seq0255, Seq0255Owned, Seq064K, Seq064KOwned, Sv2Option, Sv2OptionOwned};
 

--- a/sv2/binary-sv2/src/lib.rs
+++ b/sv2/binary-sv2/src/lib.rs
@@ -68,7 +68,8 @@ mod datatypes;
 pub use datatypes::{
     B016MOwned, B0255Owned, B032Owned, B064KOwned, Mac, MacOwned, PubKey, PubKeyOwned, Seq0255,
     Seq0255Owned, Seq064K, Seq064KOwned, Signature, SignatureOwned, Str0255, Str0255Owned,
-    Sv2DataType, Sv2Option, Sv2OptionOwned, U256Owned, B016M, B0255, B032, B064K, U24, U256,
+    Sv2DataType, Sv2Option, Sv2OptionOwned, U256Owned, B016M, B0255, B032, B064K, ERROR_SAMPLE_LEN,
+    U24, U256,
 };
 
 pub use crate::codec::{
@@ -216,9 +217,9 @@ pub enum Error {
     /// Signifies a value overflow based on protocol restrictions, containing details about
     /// fixed/variable size, maximum size allowed, and the offending length.
     ///
-    /// The `Vec<u8>` is a bounded diagnostic sample; when the overflow is detected from a declared
-    /// encoded length it holds only that length prefix. The final field reports the complete
-    /// offending length.
+    /// The `Vec<u8>` is a bounded diagnostic sample holding at most the first [`ERROR_SAMPLE_LEN`]
+    /// bytes of the offending value, or only the length prefix when the overflow is detected from
+    /// a declared encoded length. The final field reports the complete offending length.
     ValueExceedsMaxSize(bool, usize, usize, usize, Vec<u8>, usize),
 
     /// Triggered when a sequence type (`Seq0255`, `Seq064K`) exceeds its maximum allowable size.

--- a/sv2/binary-sv2/src/lib.rs
+++ b/sv2/binary-sv2/src/lib.rs
@@ -214,7 +214,11 @@ pub enum Error {
     VoidFieldMarker,
 
     /// Signifies a value overflow based on protocol restrictions, containing details about
-    /// fixed/variable size, maximum size allowed, and the offending value details.
+    /// fixed/variable size, maximum size allowed, and the offending length.
+    ///
+    /// The `Vec<u8>` is a bounded diagnostic sample; when the overflow is detected from a declared
+    /// encoded length it holds only that length prefix. The final field reports the complete
+    /// offending length.
     ValueExceedsMaxSize(bool, usize, usize, usize, Vec<u8>, usize),
 
     /// Triggered when a sequence type (`Seq0255`, `Seq064K`) exceeds its maximum allowable size.

--- a/sv2/binary-sv2/src/lib.rs
+++ b/sv2/binary-sv2/src/lib.rs
@@ -235,3 +235,47 @@ pub enum Error {
     /// elements.
     Sv2OptionHaveMoreThenOneElement(u8),
 }
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            // Keep the diagnostic sample out of formatted output; the scalar fields already
+            // describe the violation.
+            Error::ValueExceedsMaxSize(is_fixed, size, header_size, max_size, _, actual_size) => {
+                write!(
+                    f,
+                    "ValueExceedsMaxSize({is_fixed}, {size}, {header_size}, {max_size}, [redacted], {actual_size})"
+                )
+            }
+            other => write!(f, "{other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use alloc::{string::ToString, vec};
+
+    // The variant is public, so a downstream crate can construct it with a payload larger than
+    // the in-crate cap. Display must not write that payload out regardless.
+    #[test]
+    fn binary_error_display_does_not_dump_embedded_payload() {
+        let sample = vec![0xAB_u8; 64 * 1024];
+        let err = Error::ValueExceedsMaxSize(false, 1, 1, 32, sample, 64 * 1024);
+
+        let rendered = err.to_string();
+
+        assert!(
+            !rendered.contains("171"),
+            "Display leaked sample bytes: {rendered}"
+        );
+        assert!(
+            rendered.len() < 128,
+            "Display grew with the sample: {} bytes",
+            rendered.len()
+        );
+        assert!(rendered.contains("[redacted]"));
+        assert!(rendered.contains("65536"));
+    }
+}

--- a/sv2/codec-sv2/src/error.rs
+++ b/sv2/codec-sv2/src/error.rs
@@ -68,9 +68,9 @@ impl fmt::Display for Error {
         match self {
             #[cfg(feature = "noise_sv2")]
             AeadError(e) => write!(f, "Aead Error: `{e:?}`"),
-            BinarySv2Error(e) => write!(f, "Binary Sv2 Error: `{e:?}`"),
-            FramingError(e) => write!(f, "Framing error in codec: `{e:?}`"),
-            FramingSv2Error(e) => write!(f, "Framing Sv2 Error: `{e:?}`"),
+            BinarySv2Error(e) => write!(f, "Binary Sv2 Error: `{e}`"),
+            FramingError(e) => write!(f, "Framing error in codec: `{e}`"),
+            FramingSv2Error(e) => write!(f, "Framing Sv2 Error: `{e}`"),
             #[cfg(feature = "noise_sv2")]
             InvalidStepForInitiator => write!(
                 f,
@@ -132,5 +132,38 @@ impl From<framing_sv2::Error> for Error {
 impl From<NoiseError> for Error {
     fn from(e: NoiseError) -> Self {
         Error::NoiseSv2Error(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use alloc::{string::ToString, vec};
+
+    // `ValueExceedsMaxSize` carries a peer-derived sample and this error is logged, so no
+    // formatting path may write that sample out.
+    #[test]
+    fn binary_error_display_does_not_dump_embedded_payload() {
+        let sample = vec![0xAB_u8; 64 * 1024];
+        let err = Error::BinarySv2Error(binary_sv2::Error::ValueExceedsMaxSize(
+            false,
+            1,
+            1,
+            32,
+            sample,
+            64 * 1024,
+        ));
+
+        let rendered = err.to_string();
+
+        assert!(
+            !rendered.contains("171"),
+            "Display leaked sample bytes: {rendered}"
+        );
+        assert!(
+            rendered.len() < 128,
+            "Display grew with the sample: {} bytes",
+            rendered.len()
+        );
     }
 }

--- a/sv2/framing-sv2/src/error.rs
+++ b/sv2/framing-sv2/src/error.rs
@@ -21,7 +21,7 @@ impl fmt::Display for Error {
         use Error::*;
         match self {
             BinarySv2Error(ref e) => {
-                write!(f, "BinarySv2Error: `{e:?}`")
+                write!(f, "BinarySv2Error: `{e}`")
             }
             ExpectedHandshakeFrame => {
                 write!(f, "Expected `HandshakeFrame`, received `Sv2Frame`")
@@ -48,5 +48,38 @@ impl fmt::Display for Error {
 impl From<binary_sv2::Error> for Error {
     fn from(e: binary_sv2::Error) -> Self {
         Error::BinarySv2Error(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use alloc::{string::ToString, vec};
+
+    // `ValueExceedsMaxSize` carries a peer-derived sample and this error is logged, so no
+    // formatting path may write that sample out.
+    #[test]
+    fn binary_error_display_does_not_dump_embedded_payload() {
+        let sample = vec![0xAB_u8; 64 * 1024];
+        let err = Error::BinarySv2Error(binary_sv2::Error::ValueExceedsMaxSize(
+            false,
+            1,
+            1,
+            32,
+            sample,
+            64 * 1024,
+        ));
+
+        let rendered = err.to_string();
+
+        assert!(
+            !rendered.contains("171"),
+            "Display leaked sample bytes: {rendered}"
+        );
+        assert!(
+            rendered.len() < 128,
+            "Display grew with the sample: {} bytes",
+            rendered.len()
+        );
     }
 }

--- a/sv2/parsers-sv2/src/error.rs
+++ b/sv2/parsers-sv2/src/error.rs
@@ -34,7 +34,7 @@ impl core::fmt::Display for ParserError {
             }
             ParserError::BadPayloadSize => write!(f, "Bad payload size"),
             ParserError::UnexpectedPoolMessage => write!(f, "Unexpected pool message"),
-            ParserError::BinaryError(e) => write!(f, "Binary error: {e:?}"),
+            ParserError::BinaryError(e) => write!(f, "Binary error: {e}"),
             ParserError::TlvError(e) => write!(f, "TLV error: {e}"),
             ParserError::ExtensionError(e) => write!(f, "Extension error: {e}"),
         }


### PR DESCRIPTION
closes: #2315 
closes: https://github.com/project-loupe/audit-stratum/issues/108
closes: https://github.com/project-loupe/audit-stratum/issues/181
closes: https://github.com/project-loupe/audit-stratum/issues/177
closes: https://github.com/project-loupe/audit-stratum/issues/167