### PR TITLE
feat(channels_sv2, sv1_api): support prefix updates and typed submit errors

### DIFF
--- a/sv1/examples/client_and_server.rs
+++ b/sv1/examples/client_and_server.rs
@@ -241,7 +241,7 @@ impl IsServer for Server {
     }
 
     /// Indicates to the server that the client supports the mining.set_extranonce method.
-    fn handle_extranonce_subscribe(&self) -> Result<(), Error> {
+    fn handle_extranonce_subscribe(&mut self, _client_id: Option<usize>) -> Result<(), Error> {
         Ok(())
     }
 

--- a/sv1/examples/client_and_server.rs
+++ b/sv1/examples/client_and_server.rs
@@ -236,8 +236,8 @@ impl IsServer for Server {
         &self,
         _client_id: Option<usize>,
         _request: &client_to_server::Submit,
-    ) -> Result<bool, Error> {
-        Ok(true)
+    ) -> Result<client_to_server::SubmitOutcome, Error> {
+        Ok(client_to_server::SubmitOutcome::Accepted)
     }
 
     /// Indicates to the server that the client supports the mining.set_extranonce method.

--- a/sv1/src/error.rs
+++ b/sv1/src/error.rs
@@ -19,8 +19,6 @@ pub enum Error {
     /// client to the server, NOT from the server to the client.
     #[allow(clippy::upper_case_acronyms)]
     InvalidReceiver(Box<Method>),
-    /// Errors if server receives and invalid `mining.submit` from the client.
-    InvalidSubmission,
     /// Errors encountered during conversion between valid `json_rpc` messages and SV1 messages.
     Method(Box<MethodError>),
     /// Errors if action is attempted that requires the client to be authorized, but it is
@@ -54,9 +52,6 @@ impl std::fmt::Display for Error {
                 "Client received an invalid message that was intended to be sent from the
             client to the server, NOT from the server to the client. Invalid message: `{e:?}`"
             ),
-            Error::InvalidSubmission => {
-                write!(f, "Server received an invalid `mining.submit` message.")
-            }
             Error::Method(ref e) => {
                 write!(
                     f,

--- a/sv1/src/json_rpc.rs
+++ b/sv1/src/json_rpc.rs
@@ -2,13 +2,34 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, fmt::Display};
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 #[serde(untagged)]
 pub enum Message {
     StandardRequest(StandardRequest),
     Notification(Notification),
     OkResponse(Response),
     ErrorResponse(Response),
+}
+
+impl<'de> Deserialize<'de> for Message {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum MessageWire {
+            StandardRequest(StandardRequest),
+            Notification(Notification),
+            Response(Response),
+        }
+
+        Ok(match MessageWire::deserialize(deserializer)? {
+            MessageWire::StandardRequest(request) => Self::StandardRequest(request),
+            MessageWire::Notification(notification) => Self::Notification(notification),
+            MessageWire::Response(response) => response.into(),
+        })
+    }
 }
 
 impl Message {
@@ -92,6 +113,14 @@ impl fmt::Display for Response {
     }
 }
 
+/// An SV1 response error, serialized as `[code, message, data]`.
+///
+/// The three-element format is used by the [original Stratum implementation][a] and the
+/// [NiceHash extranonce extension][b]. Deserialization additionally accepts `[code, message]`
+/// with absent data, and object-form errors, for compatibility.
+///
+/// [a]: https://github.com/slush0/stratum/blob/master/stratum/protocol.py
+/// [b]: https://github.com/nicehash/Specifications/blob/master/NiceHash_extranonce_subscribe_extension.txt
 #[derive(Clone, Debug, PartialEq)]
 pub struct JsonRpcError {
     pub code: i32, // json do not specify precision which one should be used?
@@ -117,6 +146,7 @@ impl<'de> Deserialize<'de> for JsonRpcError {
         #[serde(untagged)]
         enum JsonRpcErrorWire {
             Legacy((i32, String, Option<serde_json::Value>)),
+            LegacyWithoutData((i32, String)),
             Object {
                 code: i32,
                 message: String,
@@ -124,18 +154,20 @@ impl<'de> Deserialize<'de> for JsonRpcError {
             },
         }
 
-        match JsonRpcErrorWire::deserialize(deserializer)? {
+        let (code, message, data) = match JsonRpcErrorWire::deserialize(deserializer)? {
             JsonRpcErrorWire::Legacy((code, message, data))
             | JsonRpcErrorWire::Object {
                 code,
                 message,
                 data,
-            } => Ok(Self {
-                code,
-                message,
-                data,
-            }),
-        }
+            } => (code, message, data),
+            JsonRpcErrorWire::LegacyWithoutData((code, message)) => (code, message, None),
+        };
+        Ok(Self {
+            code,
+            message,
+            data,
+        })
     }
 }
 
@@ -185,6 +217,72 @@ mod tests {
     }
 
     #[test]
+    fn deserializes_two_element_errors_and_serializes_three_elements() {
+        for code in 20..=25 {
+            let message: Message = serde_json::from_value(serde_json::json!({
+                "id": 42,
+                "result": null,
+                "error": [code, "Rejected"],
+            }))
+            .unwrap();
+
+            let Message::ErrorResponse(response) = &message else {
+                panic!("a two-element error must remain an error response");
+            };
+            assert_eq!(
+                response.error,
+                Some(JsonRpcError {
+                    code,
+                    message: "Rejected".to_string(),
+                    data: None,
+                })
+            );
+            assert_eq!(
+                serde_json::to_value(&message).unwrap(),
+                serde_json::json!({
+                    "id": 42,
+                    "result": null,
+                    "error": [code, "Rejected", null],
+                })
+            );
+            assert!(matches!(
+                crate::methods::Method::try_from(message),
+                Ok(crate::methods::Method::ErrorMessage(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn legacy_error_round_trip_preserves_additional_data() {
+        let wire = serde_json::json!([20, "Rejected", {"detail": "invalid share"}]);
+        let error: JsonRpcError = serde_json::from_value(wire.clone()).unwrap();
+        assert_eq!(
+            error.data,
+            Some(serde_json::json!({"detail": "invalid share"}))
+        );
+        assert_eq!(serde_json::to_value(error).unwrap(), wire);
+    }
+
+    #[test]
+    fn rejects_legacy_errors_with_invalid_types_or_arity() {
+        for wire in [
+            serde_json::json!([]),
+            serde_json::json!([20]),
+            serde_json::json!([20, "Rejected", null, null]),
+            serde_json::json!(["20", "Rejected"]),
+            serde_json::json!(["20", "Rejected", null]),
+            serde_json::json!([20.5, "Rejected"]),
+            serde_json::json!([20, 42]),
+            serde_json::json!([20, 42, null]),
+        ] {
+            assert!(
+                serde_json::from_value::<JsonRpcError>(wire.clone()).is_err(),
+                "invalid error unexpectedly accepted: {wire}"
+            );
+        }
+    }
+
+    #[test]
     fn deserializes_json_rpc_error_object_for_compatibility() {
         let response: Response = serde_json::from_value(serde_json::json!({
             "id": 42,
@@ -205,5 +303,28 @@ mod tests {
                 data: None,
             })
         );
+    }
+
+    #[test]
+    fn message_classifies_response_from_error_field() {
+        let error: Message = serde_json::from_value(serde_json::json!({
+            "id": 42,
+            "result": null,
+            "error": [22, "Duplicate share", null],
+        }))
+        .unwrap();
+        assert!(matches!(&error, Message::ErrorResponse(_)));
+        assert!(matches!(
+            crate::methods::Method::try_from(error),
+            Ok(crate::methods::Method::ErrorMessage(_))
+        ));
+
+        let success: Message = serde_json::from_value(serde_json::json!({
+            "id": 43,
+            "result": true,
+            "error": null,
+        }))
+        .unwrap();
+        assert!(matches!(success, Message::OkResponse(_)));
     }
 }

--- a/sv1/src/json_rpc.rs
+++ b/sv1/src/json_rpc.rs
@@ -1,5 +1,5 @@
 //! https://www.jsonrpc.org/specification#response_object
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, fmt::Display};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -92,11 +92,51 @@ impl fmt::Display for Response {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct JsonRpcError {
     pub code: i32, // json do not specify precision which one should be used?
     pub message: String,
     pub data: Option<serde_json::Value>,
+}
+
+impl Serialize for JsonRpcError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        (&self.code, &self.message, &self.data).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonRpcError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum JsonRpcErrorWire {
+            Legacy((i32, String, Option<serde_json::Value>)),
+            Object {
+                code: i32,
+                message: String,
+                data: Option<serde_json::Value>,
+            },
+        }
+
+        match JsonRpcErrorWire::deserialize(deserializer)? {
+            JsonRpcErrorWire::Legacy((code, message, data))
+            | JsonRpcErrorWire::Object {
+                code,
+                message,
+                data,
+            } => Ok(Self {
+                code,
+                message,
+                data,
+            }),
+        }
+    }
 }
 
 impl From<Response> for Message {
@@ -118,5 +158,52 @@ impl From<StandardRequest> for Message {
 impl From<Notification> for Message {
     fn from(n: Notification) -> Self {
         Message::Notification(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_legacy_sv1_error_array() {
+        let response: Response = serde_json::from_value(serde_json::json!({
+            "id": 42,
+            "result": null,
+            "error": [22, "Duplicate share", null],
+        }))
+        .unwrap();
+
+        assert_eq!(
+            response.error,
+            Some(JsonRpcError {
+                code: 22,
+                message: "Duplicate share".to_string(),
+                data: None,
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_json_rpc_error_object_for_compatibility() {
+        let response: Response = serde_json::from_value(serde_json::json!({
+            "id": 42,
+            "result": null,
+            "error": {
+                "code": 22,
+                "message": "Duplicate share",
+                "data": null,
+            },
+        }))
+        .unwrap();
+
+        assert_eq!(
+            response.error,
+            Some(JsonRpcError {
+                code: 22,
+                message: "Duplicate share".to_string(),
+                data: None,
+            })
+        );
     }
 }

--- a/sv1/src/lib.rs
+++ b/sv1/src/lib.rs
@@ -28,7 +28,9 @@
 //! Every response contains the following parts
 //! * message ID: same ID as in request, for pairing request-response together
 //! * result: any json-encoded result object (number, string, list, array, …)
-//! * error: null or list (error code, error message)
+//! * error: null or a three-element list (error code, error message, additional data). The third
+//!   element is null when no additional data is provided. For compatibility, deserialization also
+//!   accepts two-element lists with absent data and object-form errors.
 //!
 //! References:
 //! [https://docs.google.com/document/d/17zHy1SUlhgtCMbypO8cHgpWH73V5iUQKk_0rWvMqSNs/edit?hl=en_US#]
@@ -140,7 +142,7 @@ pub trait IsServer {
             }
             methods::Client2Server::ExtranonceSubscribe(subscribe) => {
                 self.handle_extranonce_subscribe(client_id)?;
-                Ok(Some(subscribe.respond(true)))
+                Ok(Some(subscribe.respond()))
             }
             methods::Client2Server::Submit(submit) => {
                 let has_valid_version_bits = match &submit.version_bits {
@@ -155,7 +157,11 @@ pub trait IsServer {
                 };
 
                 if !self.is_authorized(client_id, &submit.user_name)? {
-                    return Err(Error::InvalidSubmission.into());
+                    return Ok(Some(submit.respond(
+                        client_to_server::SubmitOutcome::Rejected(
+                            client_to_server::SubmitError::UnauthorizedWorker,
+                        ),
+                    )));
                 }
 
                 let outcome = if self.extranonce2_size(client_id)? != submit.extra_nonce2.len()
@@ -224,8 +230,17 @@ pub trait IsServer {
         request: &client_to_server::Authorize,
     ) -> Result<bool, Self::Error>;
 
-    /// When miner find the job which meets requested difficulty, it can submit share to the server.
-    /// Only [Submit](client_to_server::Submit) requests for authorized user names can be submitted.
+    /// Validates a share after the default request handler has checked its SV1 session fields.
+    ///
+    /// [`Self::handle_parsed_request`] calls this only when the worker is authorized, extranonce2
+    /// has the size returned by [`Self::extranonce2_size`], and the version bits match the negotiated
+    /// version-rolling mask (including whether version bits must be present).
+    ///
+    /// Unauthorized workers receive [`client_to_server::SubmitError::UnauthorizedWorker`] (24).
+    /// Invalid extranonce2 sizes or version bits receive [`client_to_server::SubmitError::Other`]
+    /// (20). These rejections bypass this method and return `Ok(Some(response))`, not a Rust error;
+    /// applications that log or count them should inspect the returned response's `error` field.
+    /// Errors returned by the session-state accessors are still propagated to the caller.
     fn handle_submit(
         &self,
         client_id: Option<usize>,
@@ -977,6 +992,32 @@ mod tests {
             .error
             .expect("invalid submit must include an error");
         assert_eq!(error.code, 20);
+    }
+
+    #[test]
+    fn unauthorized_submit_returns_code_24() {
+        let extranonce1 = Extranonce::try_from(hex_decode("08000002").unwrap()).unwrap();
+        let mut server = TestServer::new(extranonce1, 4);
+        let request = client_to_server::Submit {
+            user_name: "worker".to_string(),
+            job_id: "job".to_string(),
+            extra_nonce2: vec![0; 4].try_into().unwrap(),
+            time: HexU32Be(0),
+            nonce: HexU32Be(0),
+            version_bits: None,
+            id: 42,
+        };
+
+        let response = server
+            .handle_message(None, request.into())
+            .unwrap()
+            .expect("unauthorized mining.submit must receive a response");
+
+        assert_eq!(response.result, serde_json::Value::Null);
+        let error = response
+            .error
+            .expect("unauthorized mining.submit must include an error");
+        assert_eq!(error.code, 24);
     }
 
     #[test]

--- a/sv1/src/lib.rs
+++ b/sv1/src/lib.rs
@@ -138,16 +138,19 @@ pub trait IsServer {
                     None => self.version_rolling_mask(client_id)?.is_none(),
                 };
 
-                let is_valid_submission = self.is_authorized(client_id, &submit.user_name)?
-                    && self.extranonce2_size(client_id)? == submit.extra_nonce2.len()
-                    && has_valid_version_bits;
-
-                if is_valid_submission {
-                    let accepted = self.handle_submit(client_id, &submit)?;
-                    Ok(Some(submit.respond(accepted)))
-                } else {
-                    Err(Error::InvalidSubmission.into())
+                if !self.is_authorized(client_id, &submit.user_name)? {
+                    return Err(Error::InvalidSubmission.into());
                 }
+
+                let outcome = if self.extranonce2_size(client_id)? != submit.extra_nonce2.len()
+                    || !has_valid_version_bits
+                {
+                    client_to_server::SubmitOutcome::Rejected(client_to_server::SubmitError::Other)
+                } else {
+                    self.handle_submit(client_id, &submit)?
+                };
+
+                Ok(Some(submit.respond(outcome)))
             }
             methods::Client2Server::Subscribe(subscribe) => {
                 let subscriptions = self.handle_subscribe(client_id, &subscribe)?;
@@ -211,7 +214,7 @@ pub trait IsServer {
         &self,
         client_id: Option<usize>,
         request: &client_to_server::Submit,
-    ) -> Result<bool, Self::Error>;
+    ) -> Result<client_to_server::SubmitOutcome, Self::Error>;
 
     /// Records that the identified client supports the `mining.set_extranonce`
     /// notification.
@@ -758,8 +761,8 @@ mod tests {
             &self,
             _client_id: Option<usize>,
             _request: &client_to_server::Submit,
-        ) -> Result<bool, Error> {
-            Ok(true)
+        ) -> Result<client_to_server::SubmitOutcome, Error> {
+            Ok(client_to_server::SubmitOutcome::Accepted)
         }
 
         fn handle_extranonce_subscribe(&mut self, client_id: Option<usize>) -> Result<(), Error> {
@@ -901,6 +904,33 @@ mod tests {
             assert!(response.error.is_none());
             assert_eq!(server.extranonce_subscriptions, HashSet::from([Some(7)]));
         }
+    }
+
+    #[test]
+    fn invalid_submit_fields_return_code_20() {
+        let extranonce1 = Extranonce::try_from(hex_decode("08000002").unwrap()).unwrap();
+        let mut server = TestServer::new(extranonce1, 4);
+        server.authorized_users.insert("worker".to_string());
+        let request = client_to_server::Submit {
+            user_name: "worker".to_string(),
+            job_id: "job".to_string(),
+            extra_nonce2: vec![0; 3].try_into().unwrap(),
+            time: HexU32Be(0),
+            nonce: HexU32Be(0),
+            version_bits: None,
+            id: 42,
+        };
+
+        let response = server
+            .handle_message(None, request.into())
+            .unwrap()
+            .expect("mining.submit must receive a response");
+
+        assert_eq!(response.result, serde_json::Value::Null);
+        let error = response
+            .error
+            .expect("invalid submit must include an error");
+        assert_eq!(error.code, 20);
     }
 
     #[test]

--- a/sv1/src/lib.rs
+++ b/sv1/src/lib.rs
@@ -122,9 +122,9 @@ pub trait IsServer {
                 let (version_rolling, min_diff) = self.handle_configure(client_id, &configure)?;
                 Ok(Some(configure.respond(version_rolling, min_diff)))
             }
-            methods::Client2Server::ExtranonceSubscribe(_) => {
-                self.handle_extranonce_subscribe()?;
-                Ok(None)
+            methods::Client2Server::ExtranonceSubscribe(subscribe) => {
+                self.handle_extranonce_subscribe(client_id)?;
+                Ok(Some(subscribe.respond(true)))
             }
             methods::Client2Server::Submit(submit) => {
                 let has_valid_version_bits = match &submit.version_bits {
@@ -213,8 +213,12 @@ pub trait IsServer {
         request: &client_to_server::Submit,
     ) -> Result<bool, Self::Error>;
 
-    /// Indicates to the server that the client supports the mining.set_extranonce method.
-    fn handle_extranonce_subscribe(&self) -> Result<(), Self::Error>;
+    /// Records that the identified client supports the `mining.set_extranonce`
+    /// notification.
+    ///
+    /// The mutable receiver allows an implementation to retain this capability
+    /// for the lifetime of the client session.
+    fn handle_extranonce_subscribe(&mut self, client_id: Option<usize>) -> Result<(), Self::Error>;
 
     fn is_authorized(&self, client_id: Option<usize>, name: &str) -> Result<bool, Self::Error>;
 
@@ -285,6 +289,26 @@ pub trait IsServer {
     }
 }
 
+fn route_general_response(
+    general: server_to_client::GeneralResponse,
+    authorize_user_name: Option<String>,
+    is_submit: bool,
+    is_extranonce_subscribe: bool,
+) -> Result<methods::Server2ClientResponse, Error> {
+    match (authorize_user_name, is_submit, is_extranonce_subscribe) {
+        (Some(previous_name), false, false) => Ok(methods::Server2ClientResponse::Authorize(
+            general.into_authorize(previous_name),
+        )),
+        (None, false, true) => Ok(methods::Server2ClientResponse::ExtranonceSubscribe(
+            general.into_extranonce_subscribe(),
+        )),
+        (None, false, false) => Ok(methods::Server2ClientResponse::Submit(
+            general.into_submit(),
+        )),
+        _ => Err(Error::UnknownID(general.id)),
+    }
+}
+
 pub trait IsClient {
     /// Error returned by the client implementation.
     ///
@@ -327,22 +351,16 @@ pub trait IsClient {
         server_id: Option<usize>,
         response: methods::Server2ClientResponse,
     ) -> Result<methods::Server2ClientResponse, Self::Error> {
-        match &response {
+        match response {
             methods::Server2ClientResponse::GeneralResponse(general) => {
                 let is_authorize = self.id_is_authorize(server_id, &general.id)?;
                 let is_submit = self.id_is_submit(server_id, &general.id)?;
-                match (is_authorize, is_submit) {
-                    (Some(prev_name), false) => {
-                        let authorize = general.clone().into_authorize(prev_name);
-                        Ok(methods::Server2ClientResponse::Authorize(authorize))
-                    }
-                    (None, false) => Ok(methods::Server2ClientResponse::Submit(
-                        general.clone().into_submit(),
-                    )),
-                    _ => Err(Error::UnknownID(general.id).into()),
-                }
+                let is_extranonce_subscribe =
+                    self.id_is_extranonce_subscribe(server_id, &general.id)?;
+                route_general_response(general, is_authorize, is_submit, is_extranonce_subscribe)
+                    .map_err(Self::Error::from)
             }
-            _ => Ok(response),
+            response => Ok(response),
         }
     }
 
@@ -417,6 +435,7 @@ pub trait IsClient {
                 };
                 Ok(None)
             }
+            methods::Server2ClientResponse::ExtranonceSubscribe(_) => Ok(None),
             methods::Server2ClientResponse::Submit(_) => Ok(None),
             // impossible state
             methods::Server2ClientResponse::GeneralResponse(_) => panic!(),
@@ -440,6 +459,17 @@ pub trait IsClient {
 
     /// Check if the client sent a Submit request with the given id
     fn id_is_submit(&mut self, server_id: Option<usize>, id: &u64) -> Result<bool, Self::Error>;
+
+    /// Returns whether `id` belongs to a `mining.extranonce.subscribe` request.
+    ///
+    /// Clients that do not send this extension can use the default implementation.
+    fn id_is_extranonce_subscribe(
+        &mut self,
+        _server_id: Option<usize>,
+        _id: &u64,
+    ) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
 
     fn handle_notify(
         &mut self,
@@ -644,9 +674,30 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
+    #[test]
+    fn extranonce_subscribe_acknowledgement_has_distinct_response_route() {
+        let response = route_general_response(
+            server_to_client::GeneralResponse {
+                id: 42,
+                result: true,
+            },
+            None,
+            false,
+            true,
+        )
+        .unwrap();
+
+        let methods::Server2ClientResponse::ExtranonceSubscribe(response) = response else {
+            panic!("extranonce subscription acknowledgement was routed as another response");
+        };
+        assert_eq!(response.id, 42);
+        assert!(response.is_ok());
+    }
+
     // A minimal implementation of IsServer trait for testing
     struct TestServer {
         authorized_users: HashSet<String>,
+        extranonce_subscriptions: HashSet<Option<usize>>,
         extranonce1: Extranonce,
         extranonce2_size: usize,
         version_rolling_mask: Option<HexU32Be>,
@@ -657,6 +708,7 @@ mod tests {
         fn new(extranonce1: Extranonce, extranonce2_size: usize) -> Self {
             Self {
                 authorized_users: HashSet::new(),
+                extranonce_subscriptions: HashSet::new(),
                 extranonce1,
                 extranonce2_size,
                 version_rolling_mask: None,
@@ -710,7 +762,8 @@ mod tests {
             Ok(true)
         }
 
-        fn handle_extranonce_subscribe(&self) -> Result<(), Error> {
+        fn handle_extranonce_subscribe(&mut self, client_id: Option<usize>) -> Result<(), Error> {
+            self.extranonce_subscriptions.insert(client_id);
             Ok(())
         }
 
@@ -800,6 +853,53 @@ mod tests {
                 other => panic!("Expected MethodNotFound error, got {:?}", other),
             },
             other => panic!("Expected Error::Method, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn extranonce_subscribe_passes_client_id_to_server() {
+        let extranonce1 = Extranonce::try_from(hex_decode("08000002").unwrap()).unwrap();
+        let mut server = TestServer::new(extranonce1, 4);
+        let request = json_rpc::Message::StandardRequest(json_rpc::StandardRequest {
+            id: 42,
+            method: "mining.extranonce.subscribe".to_string(),
+            params: serde_json::json!([]),
+        });
+
+        let response = server.handle_message(Some(7), request).unwrap();
+
+        let response = response.expect("extranonce subscribe should be acknowledged");
+        assert_eq!(response.id, 42);
+        assert_eq!(response.result, serde_json::json!(true));
+        assert!(response.error.is_none());
+        assert_eq!(server.extranonce_subscriptions, HashSet::from([Some(7)]));
+    }
+
+    #[test]
+    fn extranonce_subscribe_ignores_params_and_acknowledges_request_id() {
+        for params in [
+            serde_json::Value::Null,
+            serde_json::json!(["ignored"]),
+            serde_json::json!({"ignored": true}),
+        ] {
+            let extranonce1 = vec![0; 4].try_into().unwrap();
+            let mut server = TestServer::new(extranonce1, 4);
+            let request = serde_json::from_value(serde_json::json!({
+                "id": 42,
+                "method": "mining.extranonce.subscribe",
+                "params": params,
+            }))
+            .unwrap();
+
+            let response = server
+                .handle_message(Some(7), request)
+                .unwrap()
+                .expect("extranonce subscribe should be acknowledged");
+
+            assert_eq!(response.id, 42);
+            assert_eq!(response.result, serde_json::json!(true));
+            assert!(response.error.is_none());
+            assert_eq!(server.extranonce_subscriptions, HashSet::from([Some(7)]));
         }
     }
 

--- a/sv1/src/lib.rs
+++ b/sv1/src/lib.rs
@@ -102,6 +102,22 @@ pub trait IsServer {
     {
         let request = msg.try_into().map_err(Error::from)?;
 
+        self.handle_parsed_request(client_id, request)
+    }
+
+    /// Handles a request already decoded by [`methods::Client2Server::try_from`].
+    ///
+    /// Servers may use the typed request to check session ordering before allocating resources,
+    /// then dispatch it here without parsing it again. This is the same dispatch path used by
+    /// [`Self::handle_message`]; decoding alone does not execute handlers or authorize a client.
+    fn handle_parsed_request(
+        &mut self,
+        client_id: Option<usize>,
+        request: methods::Client2Server,
+    ) -> Result<Option<json_rpc::Response>, Self::Error>
+    where
+        Self: std::marker::Sized,
+    {
         match request {
             // TODO: Handle suggested difficulty
             methods::Client2Server::SuggestDifficulty() => Ok(None),
@@ -903,6 +919,36 @@ mod tests {
             assert_eq!(response.result, serde_json::json!(true));
             assert!(response.error.is_none());
             assert_eq!(server.extranonce_subscriptions, HashSet::from([Some(7)]));
+        }
+    }
+
+    #[test]
+    fn parsed_requests_use_the_same_dispatch_as_wire_messages() {
+        let prefix: Extranonce = vec![1, 2, 3, 4].try_into().unwrap();
+        let mut wire_server = TestServer::new(prefix.clone(), 4);
+        let mut typed_server = TestServer::new(prefix, 4);
+        for wire in [
+            r#"{"id":1,"method":"mining.configure","params":[[],{}]}"#,
+            r#"{"id":2,"method":"mining.subscribe","params":[]}"#,
+            r#"{"id":3,"method":"mining.authorize","params":["worker",""]}"#,
+            r#"{"id":4,"method":"mining.extranonce.subscribe","params":[]}"#,
+            r#"{"id":5,"method":"mining.submit","params":["worker","1","00000000","00000001","00000000"]}"#,
+        ] {
+            let message: Message = serde_json::from_str(wire).unwrap();
+            let request = methods::Client2Server::try_from(message.clone()).unwrap();
+            let wire_response = wire_server.handle_message(Some(7), message).unwrap();
+            let typed_response = typed_server
+                .handle_parsed_request(Some(7), request)
+                .unwrap();
+            assert_eq!(
+                serde_json::to_value(wire_response).unwrap(),
+                serde_json::to_value(typed_response).unwrap()
+            );
+            assert_eq!(wire_server.authorized_users, typed_server.authorized_users);
+            assert_eq!(
+                wire_server.extranonce_subscriptions,
+                typed_server.extranonce_subscriptions
+            );
         }
     }
 

--- a/sv1/src/methods/client_to_server.rs
+++ b/sv1/src/methods/client_to_server.rs
@@ -9,7 +9,7 @@ use std::fmt;
 
 use crate::{
     error::Error,
-    json_rpc::{Message, Response, StandardRequest},
+    json_rpc::{JsonRpcError, Message, Response, StandardRequest},
     methods::ParsingMethodError,
     utils::{Extranonce, HexU32Be, VERSION_ROLLING_MASK},
 };
@@ -171,6 +171,45 @@ pub struct Submit {
     pub version_bits: Option<HexU32Be>,
     pub id: u64,
 }
+
+/// Result of validating a `mining.submit` request at the SV1 server boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitOutcome {
+    Accepted,
+    Rejected(SubmitError),
+}
+
+/// Standard Stratum V1 share-submission errors.
+///
+/// These codes originate from the original Stratum mining protocol and remain the format used by
+/// production SV1 servers such as CKPool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitError {
+    Other,
+    JobNotFound,
+    DuplicateShare,
+    LowDifficultyShare,
+}
+
+impl SubmitError {
+    pub const fn code(self) -> i32 {
+        match self {
+            Self::Other => 20,
+            Self::JobNotFound => 21,
+            Self::DuplicateShare => 22,
+            Self::LowDifficultyShare => 23,
+        }
+    }
+
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::Other => "Other/Unknown",
+            Self::JobNotFound => "Job not found",
+            Self::DuplicateShare => "Duplicate share",
+            Self::LowDifficultyShare => "Low difficulty share",
+        }
+    }
+}
 //"{"params": ["spotbtc1.m30s40x16", "2", "147a3f0000000000", "6436eddf", "41d5deb0", "00000000"],
 //"{"params": "id": 2196, "method": "mining.submit"}"
 
@@ -191,13 +230,22 @@ impl fmt::Display for Submit {
 }
 
 impl Submit {
-    pub fn respond(self, is_ok: bool) -> Response {
-        // infallibel
-        let result = serde_json::to_value(is_ok).unwrap();
-        Response {
-            id: self.id,
-            result,
-            error: None,
+    pub fn respond(self, outcome: SubmitOutcome) -> Response {
+        match outcome {
+            SubmitOutcome::Accepted => Response {
+                id: self.id,
+                result: Value::Bool(true),
+                error: None,
+            },
+            SubmitOutcome::Rejected(error) => Response {
+                id: self.id,
+                result: Value::Null,
+                error: Some(JsonRpcError {
+                    code: error.code(),
+                    message: error.message().to_string(),
+                    data: None,
+                }),
+            },
         }
     }
 }
@@ -326,6 +374,38 @@ fn submit_from_to_json_rpc(submit: Submit) -> bool {
     };
     println!("\nREQUEST: {request:?}\n");
     submit == TryInto::<Submit>::try_into(request).unwrap()
+}
+
+#[test]
+fn rejected_submit_uses_legacy_sv1_error_array() {
+    let submit = Submit {
+        user_name: "worker".to_string(),
+        job_id: "job".to_string(),
+        extra_nonce2: vec![0; 4].try_into().unwrap(),
+        time: HexU32Be(0),
+        nonce: HexU32Be(0),
+        version_bits: None,
+        id: 42,
+    };
+
+    let response = submit.respond(SubmitOutcome::Rejected(SubmitError::DuplicateShare));
+
+    assert_eq!(
+        serde_json::to_value(response).unwrap(),
+        serde_json::json!({
+            "id": 42,
+            "result": null,
+            "error": [22, "Duplicate share", null],
+        })
+    );
+}
+
+#[test]
+fn submit_errors_use_standard_sv1_codes() {
+    assert_eq!(SubmitError::Other.code(), 20);
+    assert_eq!(SubmitError::JobNotFound.code(), 21);
+    assert_eq!(SubmitError::DuplicateShare.code(), 22);
+    assert_eq!(SubmitError::LowDifficultyShare.code(), 23);
 }
 
 /// _mining.subscribe("user agent/version", "extranonce1")_

--- a/sv1/src/methods/client_to_server.rs
+++ b/sv1/src/methods/client_to_server.rs
@@ -106,10 +106,45 @@ fn from_to_json_rpc(auth: Authorize) -> bool {
 // mining.capabilities (DRAFT) (incompatible with mining.configure)
 
 /// _mining.extranonce.subscribe()_
-/// Indicates to the server that the client supports the mining.set_extranonce method.
-/// https://en.bitcoin.it/wiki/BIP_0310
-#[derive(Debug, Clone, Copy)]
-pub struct ExtranonceSubscribe();
+///
+/// Indicates to the server that the client supports the `mining.set_extranonce` method, as
+/// defined by the [NiceHash extranonce subscribe extension][a].
+///
+/// Parameters are ignored for compatibility with existing clients; only the request ID is kept.
+///
+/// [a]: https://github.com/nicehash/Specifications/blob/master/NiceHash_extranonce_subscribe_extension.txt
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtranonceSubscribe {
+    pub id: u64,
+}
+
+impl ExtranonceSubscribe {
+    pub fn respond(self, is_ok: bool) -> Response {
+        Response {
+            id: self.id,
+            result: serde_json::to_value(is_ok).expect("a boolean is always valid JSON"),
+            error: None,
+        }
+    }
+}
+
+impl From<ExtranonceSubscribe> for Message {
+    fn from(subscribe: ExtranonceSubscribe) -> Self {
+        Message::StandardRequest(StandardRequest {
+            id: subscribe.id,
+            method: "mining.extranonce.subscribe".into(),
+            params: Value::Array(Vec::new()),
+        })
+    }
+}
+
+impl TryFrom<StandardRequest> for ExtranonceSubscribe {
+    type Error = ParsingMethodError;
+
+    fn try_from(msg: StandardRequest) -> Result<Self, Self::Error> {
+        Ok(Self { id: msg.id })
+    }
+}
 
 // mining.get_transactions
 

--- a/sv1/src/methods/client_to_server.rs
+++ b/sv1/src/methods/client_to_server.rs
@@ -119,10 +119,10 @@ pub struct ExtranonceSubscribe {
 }
 
 impl ExtranonceSubscribe {
-    pub fn respond(self, is_ok: bool) -> Response {
+    pub fn respond(self) -> Response {
         Response {
             id: self.id,
-            result: serde_json::to_value(is_ok).expect("a boolean is always valid JSON"),
+            result: Value::Bool(true),
             error: None,
         }
     }
@@ -189,6 +189,8 @@ pub enum SubmitError {
     JobNotFound,
     DuplicateShare,
     LowDifficultyShare,
+    UnauthorizedWorker,
+    NotSubscribed,
 }
 
 impl SubmitError {
@@ -198,6 +200,8 @@ impl SubmitError {
             Self::JobNotFound => 21,
             Self::DuplicateShare => 22,
             Self::LowDifficultyShare => 23,
+            Self::UnauthorizedWorker => 24,
+            Self::NotSubscribed => 25,
         }
     }
 
@@ -207,6 +211,8 @@ impl SubmitError {
             Self::JobNotFound => "Job not found",
             Self::DuplicateShare => "Duplicate share",
             Self::LowDifficultyShare => "Low difficulty share",
+            Self::UnauthorizedWorker => "Unauthorized worker",
+            Self::NotSubscribed => "Not subscribed",
         }
     }
 }
@@ -406,6 +412,8 @@ fn submit_errors_use_standard_sv1_codes() {
     assert_eq!(SubmitError::JobNotFound.code(), 21);
     assert_eq!(SubmitError::DuplicateShare.code(), 22);
     assert_eq!(SubmitError::LowDifficultyShare.code(), 23);
+    assert_eq!(SubmitError::UnauthorizedWorker.code(), 24);
+    assert_eq!(SubmitError::NotSubscribed.code(), 25);
 }
 
 /// _mining.subscribe("user agent/version", "extranonce1")_

--- a/sv1/src/methods/mod.rs
+++ b/sv1/src/methods/mod.rs
@@ -178,6 +178,7 @@ pub enum Server2ClientResponse {
     Subscribe(server_to_client::Subscribe),
     GeneralResponse(server_to_client::GeneralResponse),
     Authorize(server_to_client::Authorize),
+    ExtranonceSubscribe(server_to_client::ExtranonceSubscribe),
     Submit(server_to_client::Submit),
     SetDifficulty(server_to_client::SetDifficulty),
 }
@@ -225,9 +226,15 @@ impl TryFrom<Message> for Method {
                         .map_err(|e: ParsingMethodError| e.as_method_error(msg))?;
                     Ok(Method::Client2Server(Client2Server::Authorize(method)))
                 }
-                "mining.extranonce.subscribe" => Ok(Method::Client2Server(
-                    Client2Server::ExtranonceSubscribe(client_to_server::ExtranonceSubscribe()),
-                )),
+                "mining.extranonce.subscribe" => {
+                    let method = request
+                        .clone()
+                        .try_into()
+                        .map_err(|e: ParsingMethodError| e.as_method_error(msg))?;
+                    Ok(Method::Client2Server(Client2Server::ExtranonceSubscribe(
+                        method,
+                    )))
+                }
                 "mining.submit" => {
                     let method = request
                         .clone()

--- a/sv1/src/methods/server_to_client.rs
+++ b/sv1/src/methods/server_to_client.rs
@@ -357,6 +357,13 @@ impl GeneralResponse {
             is_ok: self.result,
         }
     }
+
+    pub fn into_extranonce_subscribe(self) -> ExtranonceSubscribe {
+        ExtranonceSubscribe {
+            id: self.id,
+            acknowledged: self.result,
+        }
+    }
 }
 
 impl TryFrom<&Response> for GeneralResponse {
@@ -368,6 +375,19 @@ impl TryFrom<&Response> for GeneralResponse {
             ParsingMethodError::ImpossibleToParseResultField(Box::new(msg.clone()))
         })?;
         Ok(GeneralResponse { id, result })
+    }
+}
+
+/// Response to `mining.extranonce.subscribe`.
+#[derive(Debug, Clone)]
+pub struct ExtranonceSubscribe {
+    pub id: u64,
+    pub acknowledged: bool,
+}
+
+impl ExtranonceSubscribe {
+    pub fn is_ok(&self) -> bool {
+        self.acknowledged
     }
 }
 

--- a/sv2/channels-sv2/README.md
+++ b/sv2/channels-sv2/README.md
@@ -16,6 +16,44 @@ The `client` module is compatible with `no_std` environments. To enable this mod
 cargo build --features no_std
 ```
 
+## Prefix updates and allocation lifetime
+
+The allocator divides the extranonce into
+`[upstream_prefix | local_prefix | local_index | rollable]`.
+An extended channel's prefix contains the first three regions; a standard channel's
+prefix also includes the fixed padding for the rollable region.
+
+An upstream-only update replaces `upstream_prefix` and preserves `local_prefix`,
+`local_index`, standard-channel padding, and the existing allocation bitmap slot.
+Update the allocator with `ExtranonceAllocator::set_upstream_prefix` and each live
+channel with `set_upstream_extranonce_prefix`. These are separate operations:
+the application must validate the complete transition before applying it and
+coordinate downstream notifications. Each setter leaves its own state unchanged
+if validation fails; it does not make the multi-channel transition atomic.
+Wire-sourced prefixes have no allocation slot and are entirely upstream-owned,
+so their complete value is replaced.
+
+Jobs keep the exact prefix bytes captured at creation. For example, with
+one-byte regions, a job created under `[AA | BB | 00]` continues using those
+bytes after an upstream-only update changes the channel to `[CC | BB | 00]`.
+Both prefix versions share the reservation for `local_index = 00`; this does
+not allocate a second slot. If a later whole-prefix rotation changes the
+channel to `[CC | BB | 01]`, slot `00` must remain reserved while the old job
+is live. Otherwise, changing the allocator's upstream prefix back to `AA`
+could reissue `[AA | BB | 00]` while that job still accepts shares.
+
+Channels internally retain old prefix bytes with shared allocation ownership.
+Future, active and past jobs keep matching reservations alive; stale or evicted
+jobs do not. A slot is returned only when neither the current channel prefix
+nor any retained snapshot owns it. Dropping the channel releases its ownership
+of all these reservations. Snapshots do not keep a dropped allocator's bitmap
+alive.
+
+Repeated snapshots of the same allocation and bytes are deduplicated. Distinct
+allocations with identical bytes remain independently reserved. The existing job
+history limits and retirement rules are unchanged: upstream updates neither
+extend job validity nor mutate a job's captured prefix or validation context.
+
 ## Weak-block propagation
 
 `channels_sv2` currently does not support weak-block propagation. The Template Distribution `SetNewPrevHash.target`, which a Template Provider may set below the target `nBits` encodes, is not carried into the channels' chain tip: server channels classify a share as a found block against the `nBits` target alone.

--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -12,9 +12,7 @@ use crate::{
         error::ExtendedChannelError,
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
     },
-    extranonce_manager::{
-        prefix::RetiredExtranoncePrefixes, ExtranoncePrefix, ExtranoncePrefixError,
-    },
+    extranonce_manager::{prefix::RetiredExtranoncePrefixes, ExtranoncePrefix},
     merkle_root::merkle_root_from_path,
     target::{bytes_to_hex, u256_to_block_hash},
     MAX_EXTRANONCE_LEN, MAX_FUTURE_BLOCK_TIME, VERSION_ROLLING_MASK,
@@ -232,10 +230,8 @@ impl ExtendedChannel {
         &mut self,
         new_extranonce_prefix: ExtranoncePrefix,
     ) -> Result<(), ExtendedChannelError> {
-        let full_extranonce_size = new_extranonce_prefix
-            .len()
-            .checked_add(self.rollable_extranonce_size as usize)
-            .ok_or(ExtendedChannelError::NewExtranoncePrefixTooLarge)?;
+        let full_extranonce_size =
+            new_extranonce_prefix.len() + self.rollable_extranonce_size as usize;
         if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtendedChannelError::NewExtranoncePrefixTooLarge);
         }
@@ -269,26 +265,20 @@ impl ExtendedChannel {
     pub fn set_upstream_extranonce_prefix(
         &mut self,
         upstream_prefix: &[u8],
-    ) -> Result<(), ExtranoncePrefixError> {
-        let preserved_prefix_len = self
-            .extranonce_prefix
-            .len()
-            .checked_sub(self.extranonce_prefix.upstream_prefix_len() as usize)
-            .ok_or(ExtranoncePrefixError::ExceedsMaxLength)?;
-        let full_extranonce_size = upstream_prefix
-            .len()
-            .checked_add(preserved_prefix_len)
-            .and_then(|len| len.checked_add(self.rollable_extranonce_size as usize))
-            .ok_or(ExtranoncePrefixError::ExceedsMaxLength)?;
+    ) -> Result<(), ExtendedChannelError> {
+        let full_extranonce_size = upstream_prefix.len()
+            + self.extranonce_prefix.preserved_len()
+            + self.rollable_extranonce_size as usize;
         if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
-            return Err(ExtranoncePrefixError::ExceedsMaxLength);
+            return Err(ExtendedChannelError::NewExtranoncePrefixTooLarge);
         }
 
         let snapshot = self
             .extranonce_prefix
             .snapshot_for_upstream_update(upstream_prefix);
         self.extranonce_prefix
-            .set_upstream_prefix(upstream_prefix)?;
+            .set_upstream_prefix(upstream_prefix)
+            .map_err(|_| ExtendedChannelError::NewExtranoncePrefixTooLarge)?;
         if let Some(snapshot) = snapshot {
             self.retired_extranonce_prefixes.retire(
                 snapshot,
@@ -1031,8 +1021,7 @@ mod tests {
             MAX_FUTURE_JOBS, MAX_PAST_JOBS,
         },
         extranonce_manager::{
-            ExtranonceAllocator, ExtranonceAllocatorError, ExtranoncePrefix, ExtranoncePrefixError,
-            MAX_EXTRANONCE_LEN,
+            ExtranonceAllocator, ExtranonceAllocatorError, ExtranoncePrefix, MAX_EXTRANONCE_LEN,
         },
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
@@ -1173,7 +1162,7 @@ mod tests {
         let result = channel.set_upstream_extranonce_prefix(&[0xdd; 29]);
         assert!(matches!(
             result,
-            Err(ExtranoncePrefixError::ExceedsMaxLength)
+            Err(ExtendedChannelError::NewExtranoncePrefixTooLarge)
         ));
         assert_eq!(channel.get_extranonce_prefix(), &largest_valid_prefix);
         assert_eq!(channel.upstream_prefix_len(), upstream_prefix_len);
@@ -3356,7 +3345,7 @@ mod tests {
             let current_bytes = channel.get_extranonce_prefix().to_vec();
             assert!(matches!(
                 channel.set_upstream_extranonce_prefix(&[0xee; 2]),
-                Err(crate::extranonce_manager::ExtranoncePrefixError::ExceedsMaxLength)
+                Err(ExtendedChannelError::NewExtranoncePrefixTooLarge)
             ));
             assert_eq!(channel.get_extranonce_prefix(), current_bytes);
             assert_eq!(channel.retired_extranonce_prefixes.len(), 1);

--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -12,7 +12,9 @@ use crate::{
         error::ExtendedChannelError,
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
     },
-    extranonce_manager::{prefix::RetiredExtranoncePrefixes, ExtranoncePrefix},
+    extranonce_manager::{
+        prefix::RetiredExtranoncePrefixes, ExtranoncePrefix, ExtranoncePrefixError,
+    },
     merkle_root::merkle_root_from_path,
     target::{bytes_to_hex, u256_to_block_hash},
     MAX_EXTRANONCE_LEN, MAX_FUTURE_BLOCK_TIME, VERSION_ROLLING_MASK,
@@ -171,17 +173,12 @@ impl ExtendedChannel {
         self.extranonce_prefix.as_bytes()
     }
 
-    /// Returns the length of the `upstream_prefix` region of this channel's
-    /// extranonce prefix, if known.
+    /// Returns the length of the leading `upstream_prefix` region of this
+    /// channel's extranonce prefix.
     ///
     /// See [`ExtranoncePrefix::upstream_prefix_len`](crate::extranonce_manager::ExtranoncePrefix::upstream_prefix_len)
-    /// for the full semantics. In particular, this is `None` for channels
-    /// opened from a wire-sourced prefix (the common case on a client),
-    /// and `Some(n)` when the application minted the prefix locally from
-    /// an [`ExtranonceAllocator`](crate::extranonce_manager::ExtranonceAllocator) — e.g. a proxy that
-    /// sub-allocates an upstream-assigned extranonce space and hands one
-    /// slot to each downstream channel.
-    pub fn upstream_prefix_len(&self) -> Option<u8> {
+    /// for the full semantics.
+    pub fn upstream_prefix_len(&self) -> u8 {
         self.extranonce_prefix.upstream_prefix_len()
     }
 
@@ -242,6 +239,39 @@ impl ExtendedChannel {
                 .map(|job| job.extranonce_prefix.as_slice()),
         );
 
+        Ok(())
+    }
+
+    /// Sets the upstream-assigned region of this channel's extranonce prefix.
+    ///
+    /// For an allocator-produced prefix, its locally managed suffix and allocation are preserved.
+    /// For a wire-sourced prefix, the entire prefix is upstream-owned and is replaced. Jobs
+    /// received before this call retain their captured prefix bytes; new jobs use the updated
+    /// prefix.
+    ///
+    /// Old prefix bytes share ownership of the same allocator slot while any future, active or
+    /// past job uses them. A later `set_extranonce_prefix` rotation cannot release that slot
+    /// prematurely. Once those jobs are stale or evicted, only the current prefix (if it still
+    /// uses this allocation) keeps the slot reserved. This update consumes no additional slot.
+    pub fn set_upstream_extranonce_prefix(
+        &mut self,
+        upstream_prefix: &[u8],
+    ) -> Result<(), ExtranoncePrefixError> {
+        let snapshot = self
+            .extranonce_prefix
+            .snapshot_for_upstream_update(upstream_prefix);
+        self.extranonce_prefix
+            .set_upstream_prefix(upstream_prefix)?;
+        if let Some(snapshot) = snapshot {
+            self.retired_extranonce_prefixes.retire(
+                snapshot,
+                self.future_jobs
+                    .values()
+                    .chain(self.active_job.iter())
+                    .chain(self.past_jobs.values())
+                    .map(|job| job.extranonce_prefix.as_slice()),
+            );
+        }
         Ok(())
     }
 
@@ -983,6 +1013,57 @@ mod tests {
         ERROR_CODE_SUBMIT_SHARES_INVALID_NON_ROLLABLE_VERSION_BIT,
     };
     use std::convert::TryInto;
+
+    #[test]
+    fn upstream_prefix_update_only_affects_subsequent_jobs() {
+        // upstream(1) + local_prefix(1) + local_index(1) + rollable(2) = 5
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 5, 256).unwrap();
+        let allocated_prefix = allocator.allocate_extended(2).unwrap();
+        let old_prefix = allocated_prefix.as_bytes().to_vec();
+        let mut channel = ExtendedChannel::new(
+            1,
+            "user_identity".to_string(),
+            allocated_prefix.into(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            2,
+            None,
+        )
+        .unwrap();
+        let job = |job_id| NewExtendedMiningJob {
+            channel_id: 1,
+            job_id,
+            min_ntime: Sv2Option::new(Some(1)),
+            version: 536870912,
+            version_rolling_allowed: true,
+            // Six bytes are enough for the BIP141 detector; byte four is nonzero, so this is
+            // already considered stripped for the purpose of this state-management test.
+            coinbase_tx_prefix: vec![1, 0, 0, 0, 1, 0].try_into().unwrap(),
+            coinbase_tx_suffix: vec![].try_into().unwrap(),
+            merkle_path: vec![].try_into().unwrap(),
+        };
+
+        channel.on_new_extended_mining_job(job(1)).unwrap();
+        channel
+            .set_upstream_extranonce_prefix(&[0xcc, 0xdd])
+            .unwrap();
+        let new_prefix = channel.get_extranonce_prefix().to_vec();
+        channel.on_new_extended_mining_job(job(2)).unwrap();
+
+        assert_eq!(old_prefix, &[0xaa, 0xbb, 0x00]);
+        assert_eq!(new_prefix, &[0xcc, 0xdd, 0xbb, 0x00]);
+        assert_eq!(
+            &channel.get_past_job(1).unwrap().extranonce_prefix,
+            &old_prefix
+        );
+        assert_eq!(
+            &channel.get_active_job().unwrap().extranonce_prefix,
+            &new_prefix
+        );
+        assert_eq!(allocator.allocated_count(), 1);
+    }
 
     #[test]
     fn test_future_job_activation_flow() {
@@ -3116,6 +3197,104 @@ mod tests {
         channel.set_extranonce_prefix(prefix_2.into()).unwrap();
 
         (allocator, channel, prefix_1_bytes)
+    }
+
+    #[test]
+    fn test_mixed_prefix_updates_reserve_slot_until_job_eviction() {
+        for future in [false, true] {
+            let mut allocator =
+                ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 32, 2).unwrap();
+            let prefix = allocator.allocate_extended(8).unwrap();
+            let old_bytes = prefix.as_bytes().to_vec();
+            let rollable_size = (32 - prefix.len()) as u16;
+
+            let mut channel = ExtendedChannel::new(
+                1,
+                "user_identity".to_string(),
+                prefix.into(),
+                Target::from_le_bytes([0xff; 32]),
+                1.0,
+                true,
+                rollable_size,
+                Some(1),
+            )
+            .unwrap();
+            let job_id = 1;
+            let mut job = active_job_template(job_id);
+            if future {
+                job.min_ntime = Sv2Option::new(None);
+            }
+            channel.on_new_extended_mining_job(job).unwrap();
+
+            // Change only upstream_prefix, preserving local_prefix and local_index.
+            allocator.set_upstream_prefix(vec![0xcc]).unwrap();
+            channel.set_upstream_extranonce_prefix(&[0xcc]).unwrap();
+            assert_eq!(allocator.allocated_count(), 1);
+            assert_eq!(&channel.get_extranonce_prefix()[1..], &old_bytes[1..]);
+
+            // Repeated updates without new jobs retain only the original job's prefix snapshot.
+            for upstream in [0xdd, 0xaa, 0xcc, 0xcc] {
+                allocator.set_upstream_prefix(vec![upstream]).unwrap();
+                channel.set_upstream_extranonce_prefix(&[upstream]).unwrap();
+                assert_eq!(channel.retired_extranonce_prefixes.len(), 1);
+            }
+            let current_bytes = channel.get_extranonce_prefix().to_vec();
+            assert!(matches!(
+                channel.set_upstream_extranonce_prefix(&[0xee; 32]),
+                Err(crate::extranonce_manager::ExtranoncePrefixError::ExceedsMaxLength)
+            ));
+            assert_eq!(channel.get_extranonce_prefix(), current_bytes);
+            assert_eq!(channel.retired_extranonce_prefixes.len(), 1);
+            assert_eq!(allocator.allocated_count(), 1);
+
+            // A later whole-prefix rotation must not release the slot used by job 1.
+            let replacement = allocator.allocate_extended(8).unwrap();
+            channel.set_extranonce_prefix(replacement.into()).unwrap();
+            let job = if future {
+                channel.get_future_job(job_id).unwrap()
+            } else {
+                channel.get_active_job().unwrap()
+            };
+            assert_eq!(job.extranonce_prefix, old_bytes);
+            assert_eq!(allocator.allocated_count(), 2);
+            allocator.set_upstream_prefix(vec![0xaa]).unwrap();
+            assert!(matches!(
+                allocator.allocate_extended(8),
+                Err(ExtranonceAllocatorError::CapacityExhausted)
+            ));
+
+            // Activating the future job must preserve its old prefix and allocation.
+            if future {
+                channel
+                    .on_set_new_prev_hash(SetNewPrevHashMp {
+                        channel_id: 1,
+                        job_id,
+                        prev_hash: [2; 32].into(),
+                        min_ntime: 1745596970,
+                        nbits: 545259519,
+                    })
+                    .unwrap();
+                assert_eq!(
+                    channel.get_active_job().unwrap().extranonce_prefix,
+                    old_bytes
+                );
+                assert_eq!(allocator.allocated_count(), 2);
+            }
+
+            // The existing one-past-job limit evicts job 1 after jobs 2 and 3 arrive.
+            for job_id in 2..=3 {
+                channel
+                    .on_new_extended_mining_job(active_job_template(job_id))
+                    .unwrap();
+            }
+            assert!(channel.get_past_job(1).is_none());
+            assert_eq!(allocator.allocated_count(), 1);
+            let reused = allocator.allocate_extended(8).unwrap();
+            assert_eq!(reused.as_bytes(), old_bytes);
+            drop(reused);
+            drop(channel);
+            assert_eq!(allocator.allocated_count(), 0);
+        }
     }
 
     #[test]

--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -219,12 +219,17 @@ impl ExtendedChannel {
     /// allocator cannot hand the same extranonce space to another live channel while those jobs
     /// still validate shares. Wire-sourced prefixes hold no slot and are simply dropped.
     ///
-    /// Returns an error if the new extranonce prefix is too large.
+    /// Returns an error if the new extranonce prefix and the channel's rollable extranonce would
+    /// exceed [`MAX_EXTRANONCE_LEN`].
     pub fn set_extranonce_prefix(
         &mut self,
         new_extranonce_prefix: ExtranoncePrefix,
     ) -> Result<(), ExtendedChannelError> {
-        if new_extranonce_prefix.len() > MAX_EXTRANONCE_LEN as usize {
+        let full_extranonce_size = new_extranonce_prefix
+            .len()
+            .checked_add(self.rollable_extranonce_size as usize)
+            .ok_or(ExtendedChannelError::NewExtranoncePrefixTooLarge)?;
+        if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtendedChannelError::NewExtranoncePrefixTooLarge);
         }
 
@@ -244,10 +249,11 @@ impl ExtendedChannel {
 
     /// Sets the upstream-assigned region of this channel's extranonce prefix.
     ///
-    /// For an allocator-produced prefix, its locally managed suffix and allocation are preserved.
-    /// For a wire-sourced prefix, the entire prefix is upstream-owned and is replaced. Jobs
-    /// received before this call retain their captured prefix bytes; new jobs use the updated
-    /// prefix.
+    /// For an allocator-produced prefix, `local_prefix | local_index` and its allocation are
+    /// preserved. For a wire-sourced prefix, the entire prefix is `upstream_prefix` and is
+    /// replaced. Jobs received before this call retain their captured prefix bytes; new jobs use
+    /// the updated prefix. The channel is left unchanged if the resulting full extranonce would
+    /// exceed [`MAX_EXTRANONCE_LEN`].
     ///
     /// Old prefix bytes share ownership of the same allocator slot while any future, active or
     /// past job uses them. A later `set_extranonce_prefix` rotation cannot release that slot
@@ -257,6 +263,20 @@ impl ExtendedChannel {
         &mut self,
         upstream_prefix: &[u8],
     ) -> Result<(), ExtranoncePrefixError> {
+        let preserved_prefix_len = self
+            .extranonce_prefix
+            .len()
+            .checked_sub(self.extranonce_prefix.upstream_prefix_len() as usize)
+            .ok_or(ExtranoncePrefixError::ExceedsMaxLength)?;
+        let full_extranonce_size = upstream_prefix
+            .len()
+            .checked_add(preserved_prefix_len)
+            .and_then(|len| len.checked_add(self.rollable_extranonce_size as usize))
+            .ok_or(ExtranoncePrefixError::ExceedsMaxLength)?;
+        if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
+            return Err(ExtranoncePrefixError::ExceedsMaxLength);
+        }
+
         let snapshot = self
             .extranonce_prefix
             .snapshot_for_upstream_update(upstream_prefix);
@@ -1003,7 +1023,10 @@ mod tests {
             share_accounting::{ShareValidationError, ShareValidationResult},
             MAX_FUTURE_JOBS, MAX_PAST_JOBS,
         },
-        extranonce_manager::{ExtranonceAllocator, ExtranonceAllocatorError, ExtranoncePrefix},
+        extranonce_manager::{
+            ExtranonceAllocator, ExtranonceAllocatorError, ExtranoncePrefix, ExtranoncePrefixError,
+            MAX_EXTRANONCE_LEN,
+        },
     };
     use binary_sv2::Sv2OptionOwned as Sv2Option;
     use bitcoin::Target;
@@ -1062,6 +1085,72 @@ mod tests {
             &channel.get_active_job().unwrap().extranonce_prefix,
             &new_prefix
         );
+        assert_eq!(allocator.allocated_count(), 1);
+    }
+
+    #[test]
+    fn set_extranonce_prefix_enforces_full_extranonce_size() {
+        let rollable_extranonce_size = 4;
+        let mut channel = ExtendedChannel::new(
+            1,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(vec![0xaa]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            rollable_extranonce_size,
+            None,
+        )
+        .unwrap();
+
+        let largest_valid_prefix =
+            vec![0xbb; MAX_EXTRANONCE_LEN as usize - rollable_extranonce_size as usize];
+        channel
+            .set_extranonce_prefix(
+                ExtranoncePrefix::from_wire(largest_valid_prefix.clone()).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(channel.get_extranonce_prefix(), &largest_valid_prefix);
+
+        let result = channel.set_extranonce_prefix(
+            ExtranoncePrefix::from_wire(vec![0xcc; largest_valid_prefix.len() + 1]).unwrap(),
+        );
+        assert!(matches!(
+            result,
+            Err(ExtendedChannelError::NewExtranoncePrefixTooLarge)
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &largest_valid_prefix);
+    }
+
+    #[test]
+    fn set_upstream_extranonce_prefix_enforces_full_extranonce_size_transactionally() {
+        // local_prefix(1) + local_index(1) and rollable(2) leave 28 bytes for upstream_prefix.
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 5, 256).unwrap();
+        let allocated_prefix = allocator.allocate_extended(2).unwrap();
+        let mut channel = ExtendedChannel::new(
+            1,
+            "user_identity".to_string(),
+            allocated_prefix.into(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            2,
+            None,
+        )
+        .unwrap();
+
+        channel.set_upstream_extranonce_prefix(&[0xcc; 28]).unwrap();
+        let largest_valid_prefix = channel.get_extranonce_prefix().to_vec();
+        let upstream_prefix_len = channel.upstream_prefix_len();
+
+        let result = channel.set_upstream_extranonce_prefix(&[0xdd; 29]);
+        assert!(matches!(
+            result,
+            Err(ExtranoncePrefixError::ExceedsMaxLength)
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &largest_valid_prefix);
+        assert_eq!(channel.upstream_prefix_len(), upstream_prefix_len);
         assert_eq!(allocator.allocated_count(), 1);
     }
 
@@ -3240,7 +3329,7 @@ mod tests {
             }
             let current_bytes = channel.get_extranonce_prefix().to_vec();
             assert!(matches!(
-                channel.set_upstream_extranonce_prefix(&[0xee; 32]),
+                channel.set_upstream_extranonce_prefix(&[0xee; 2]),
                 Err(crate::extranonce_manager::ExtranoncePrefixError::ExceedsMaxLength)
             ));
             assert_eq!(channel.get_extranonce_prefix(), current_bytes);

--- a/sv2/channels-sv2/src/client/extended.rs
+++ b/sv2/channels-sv2/src/client/extended.rs
@@ -114,7 +114,9 @@ impl ExtendedChannel {
     /// `max_past_jobs` caps the past jobs retained under the current chain tip. `None` and
     /// `Some(0)` both select [`MAX_PAST_JOBS`].
     ///
-    /// Returns [`ExtendedChannelError::InvalidTarget`] if `target` is zero.
+    /// Returns [`ExtendedChannelError::InvalidTarget`] if `target` is zero, or
+    /// [`ExtendedChannelError::NewExtranoncePrefixTooLarge`] if the prefix and rollable extranonce
+    /// together exceed [`MAX_EXTRANONCE_LEN`].
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         channel_id: u32,
@@ -128,6 +130,11 @@ impl ExtendedChannel {
     ) -> Result<Self, ExtendedChannelError> {
         if target == Target::ZERO {
             return Err(ExtendedChannelError::InvalidTarget);
+        }
+
+        if extranonce_prefix.len() + rollable_extranonce_size as usize > MAX_EXTRANONCE_LEN as usize
+        {
+            return Err(ExtendedChannelError::NewExtranoncePrefixTooLarge);
         }
 
         // fall back to the default when the caller has no opinion: `None`, or `Some(0)`, which
@@ -1086,6 +1093,25 @@ mod tests {
             &new_prefix
         );
         assert_eq!(allocator.allocated_count(), 1);
+    }
+
+    #[test]
+    fn new_enforces_full_extranonce_size() {
+        let result = ExtendedChannel::new(
+            1,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(vec![0xaa; MAX_EXTRANONCE_LEN as usize]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            1,
+            None,
+        );
+
+        assert!(matches!(
+            result,
+            Err(ExtendedChannelError::NewExtranoncePrefixTooLarge)
+        ));
     }
 
     #[test]

--- a/sv2/channels-sv2/src/client/standard.rs
+++ b/sv2/channels-sv2/src/client/standard.rs
@@ -12,7 +12,9 @@ use crate::{
         error::StandardChannelError,
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
     },
-    extranonce_manager::{prefix::RetiredExtranoncePrefixes, ExtranoncePrefix},
+    extranonce_manager::{
+        prefix::RetiredExtranoncePrefixes, ExtranoncePrefix, ExtranoncePrefixError,
+    },
     merkle_root::merkle_root_from_path,
     target::{bytes_to_hex, u256_to_block_hash},
     MAX_EXTRANONCE_LEN, MAX_FUTURE_BLOCK_TIME, VERSION_ROLLING_MASK,
@@ -240,22 +242,50 @@ impl StandardChannel {
         Ok(())
     }
 
+    /// Sets the upstream-assigned region of this channel's extranonce prefix.
+    ///
+    /// For an allocator-produced prefix, `local_prefix | local_index`, rollable padding, and its
+    /// allocation are preserved. For a wire-sourced prefix, the entire prefix is
+    /// `upstream_prefix` and is replaced. Jobs received before this call retain their captured
+    /// prefix bytes; new jobs use the updated prefix.
+    ///
+    /// Old prefix bytes share ownership of the same allocator slot while any future, active or
+    /// past job uses them. A later `set_extranonce_prefix` rotation cannot release that slot
+    /// prematurely. Once those jobs are stale or evicted, only the current prefix (if it still
+    /// uses this allocation) keeps the slot reserved. This update consumes no additional slot.
+    pub fn set_upstream_extranonce_prefix(
+        &mut self,
+        upstream_prefix: &[u8],
+    ) -> Result<(), ExtranoncePrefixError> {
+        let snapshot = self
+            .extranonce_prefix
+            .snapshot_for_upstream_update(upstream_prefix);
+        self.extranonce_prefix
+            .set_upstream_prefix(upstream_prefix)?;
+        if let Some(snapshot) = snapshot {
+            self.retired_extranonce_prefixes.retire(
+                snapshot,
+                self.future_jobs
+                    .values()
+                    .chain(self.active_job.iter())
+                    .chain(self.past_jobs.values())
+                    .map(|job| job.extranonce_prefix.as_slice()),
+            );
+        }
+        Ok(())
+    }
+
     /// Returns the bytes representing the first part of the extranonce.
     pub fn get_extranonce_prefix(&self) -> &[u8] {
         self.extranonce_prefix.as_bytes()
     }
 
-    /// Returns the length of the `upstream_prefix` region of this channel's
-    /// extranonce prefix, if known.
+    /// Returns the length of the leading `upstream_prefix` region of this
+    /// channel's extranonce prefix.
     ///
     /// See [`ExtranoncePrefix::upstream_prefix_len`](crate::extranonce_manager::ExtranoncePrefix::upstream_prefix_len)
-    /// for the full semantics. In particular, this is `None` for channels
-    /// opened from a wire-sourced prefix (the common case on a client),
-    /// and `Some(n)` when the application minted the prefix locally from
-    /// an [`ExtranonceAllocator`](crate::extranonce_manager::ExtranonceAllocator) — e.g. a proxy that
-    /// sub-allocates an upstream-assigned extranonce space and hands one
-    /// slot to each downstream channel.
-    pub fn upstream_prefix_len(&self) -> Option<u8> {
+    /// for the full semantics.
+    pub fn upstream_prefix_len(&self) -> u8 {
         self.extranonce_prefix.upstream_prefix_len()
     }
 
@@ -2247,6 +2277,102 @@ mod tests {
         channel.set_extranonce_prefix(prefix_2.into()).unwrap();
 
         (allocator, channel, prefix_1_bytes)
+    }
+
+    #[test]
+    fn test_mixed_prefix_updates_reserve_slot_until_job_eviction() {
+        for future in [false, true] {
+            let mut allocator =
+                ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 32, 2).unwrap();
+            let prefix = allocator.allocate_standard().unwrap();
+            let old_bytes = prefix.as_bytes().to_vec();
+
+            let mut channel = StandardChannel::new(
+                1,
+                "user_identity".to_string(),
+                prefix.into(),
+                Target::from_le_bytes([0xff; 32]),
+                1.0,
+                Some(1),
+            )
+            .unwrap();
+            let job_id = 1;
+            channel
+                .on_new_mining_job(job_template(
+                    job_id,
+                    if future { None } else { Some(1745596970) },
+                ))
+                .unwrap();
+
+            // Change only upstream_prefix, preserving local_prefix and local_index.
+            allocator.set_upstream_prefix(vec![0xcc]).unwrap();
+            channel.set_upstream_extranonce_prefix(&[0xcc]).unwrap();
+            assert_eq!(allocator.allocated_count(), 1);
+            assert_eq!(&channel.get_extranonce_prefix()[1..], &old_bytes[1..]);
+
+            // Repeated updates without new jobs retain only the original job's prefix snapshot.
+            for upstream in [0xdd, 0xaa, 0xcc, 0xcc] {
+                allocator.set_upstream_prefix(vec![upstream]).unwrap();
+                channel.set_upstream_extranonce_prefix(&[upstream]).unwrap();
+                assert_eq!(channel.retired_extranonce_prefixes.len(), 1);
+            }
+            let current_bytes = channel.get_extranonce_prefix().to_vec();
+            assert!(matches!(
+                channel.set_upstream_extranonce_prefix(&[0xee; 32]),
+                Err(crate::extranonce_manager::ExtranoncePrefixError::ExceedsMaxLength)
+            ));
+            assert_eq!(channel.get_extranonce_prefix(), current_bytes);
+            assert_eq!(channel.retired_extranonce_prefixes.len(), 1);
+            assert_eq!(allocator.allocated_count(), 1);
+
+            // A later whole-prefix rotation must not release the slot used by job 1.
+            let replacement = allocator.allocate_standard().unwrap();
+            channel.set_extranonce_prefix(replacement.into()).unwrap();
+            let job = if future {
+                channel.get_future_job(job_id).unwrap()
+            } else {
+                channel.get_active_job().unwrap()
+            };
+            assert_eq!(job.extranonce_prefix, old_bytes);
+            assert_eq!(allocator.allocated_count(), 2);
+            allocator.set_upstream_prefix(vec![0xaa]).unwrap();
+            assert!(matches!(
+                allocator.allocate_standard(),
+                Err(ExtranonceAllocatorError::CapacityExhausted)
+            ));
+
+            // Activating the future job must preserve its old prefix and allocation.
+            if future {
+                channel
+                    .on_set_new_prev_hash(SetNewPrevHashMp {
+                        channel_id: 1,
+                        job_id,
+                        prev_hash: [2; 32].into(),
+                        min_ntime: 1745596970,
+                        nbits: 545259519,
+                    })
+                    .unwrap();
+                assert_eq!(
+                    channel.get_active_job().unwrap().extranonce_prefix,
+                    old_bytes
+                );
+                assert_eq!(allocator.allocated_count(), 2);
+            }
+
+            // The existing one-past-job limit evicts job 1 after jobs 2 and 3 arrive.
+            for job_id in 2..=3 {
+                channel
+                    .on_new_mining_job(job_template(job_id, Some(1745596970)))
+                    .unwrap();
+            }
+            assert!(channel.get_past_job(1).is_none());
+            assert_eq!(allocator.allocated_count(), 1);
+            let reused = allocator.allocate_standard().unwrap();
+            assert_eq!(reused.as_bytes(), old_bytes);
+            drop(reused);
+            drop(channel);
+            assert_eq!(allocator.allocated_count(), 0);
+        }
     }
 
     #[test]

--- a/sv2/channels-sv2/src/client/standard.rs
+++ b/sv2/channels-sv2/src/client/standard.rs
@@ -12,9 +12,7 @@ use crate::{
         error::StandardChannelError,
         share_accounting::{ShareAccounting, ShareValidationError, ShareValidationResult},
     },
-    extranonce_manager::{
-        prefix::RetiredExtranoncePrefixes, ExtranoncePrefix, ExtranoncePrefixError,
-    },
+    extranonce_manager::{prefix::RetiredExtranoncePrefixes, ExtranoncePrefix},
     merkle_root::merkle_root_from_path,
     target::{bytes_to_hex, u256_to_block_hash},
     MAX_EXTRANONCE_LEN, MAX_FUTURE_BLOCK_TIME, VERSION_ROLLING_MASK,
@@ -247,7 +245,9 @@ impl StandardChannel {
     /// For an allocator-produced prefix, `local_prefix | local_index`, rollable padding, and its
     /// allocation are preserved. For a wire-sourced prefix, the entire prefix is
     /// `upstream_prefix` and is replaced. Jobs received before this call retain their captured
-    /// prefix bytes; new jobs use the updated prefix.
+    /// prefix bytes; new jobs use the updated prefix. Returns
+    /// [`StandardChannelError::NewExtranoncePrefixTooLarge`] without changing the channel if the
+    /// resulting prefix would exceed [`MAX_EXTRANONCE_LEN`].
     ///
     /// Old prefix bytes share ownership of the same allocator slot while any future, active or
     /// past job uses them. A later `set_extranonce_prefix` rotation cannot release that slot
@@ -256,12 +256,13 @@ impl StandardChannel {
     pub fn set_upstream_extranonce_prefix(
         &mut self,
         upstream_prefix: &[u8],
-    ) -> Result<(), ExtranoncePrefixError> {
+    ) -> Result<(), StandardChannelError> {
         let snapshot = self
             .extranonce_prefix
             .snapshot_for_upstream_update(upstream_prefix);
         self.extranonce_prefix
-            .set_upstream_prefix(upstream_prefix)?;
+            .set_upstream_prefix(upstream_prefix)
+            .map_err(|_| StandardChannelError::NewExtranoncePrefixTooLarge)?;
         if let Some(snapshot) = snapshot {
             self.retired_extranonce_prefixes.retire(
                 snapshot,
@@ -804,6 +805,67 @@ mod tests {
         SetNewPrevHashOwned as SetNewPrevHashMp, SubmitSharesStandardOwned,
         ERROR_CODE_SUBMIT_SHARES_INVALID_NON_ROLLABLE_VERSION_BIT,
     };
+
+    #[test]
+    fn set_upstream_extranonce_prefix_preserves_allocation_transactionally() {
+        // local_prefix(1) + local_index(1) + padding(3) leave 27 bytes for upstream_prefix.
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 256).unwrap();
+        let allocated_prefix = allocator.allocate_standard().unwrap();
+        let preserved_bytes = allocated_prefix.as_bytes()[1..].to_vec();
+        assert_eq!(preserved_bytes, vec![0xbb, 0, 0, 0, 0]);
+        let mut channel = StandardChannel::new(
+            1,
+            "user_identity".to_string(),
+            allocated_prefix.into(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            None,
+        )
+        .unwrap();
+
+        channel.set_upstream_extranonce_prefix(&[0xcc; 27]).unwrap();
+        assert_eq!(channel.upstream_prefix_len(), 27);
+        assert_eq!(&channel.get_extranonce_prefix()[..27], &[0xcc; 27]);
+        assert_eq!(&channel.get_extranonce_prefix()[27..], preserved_bytes);
+        assert_eq!(allocator.allocated_count(), 1);
+        let largest_valid_prefix = channel.get_extranonce_prefix().to_vec();
+
+        assert!(matches!(
+            channel.set_upstream_extranonce_prefix(&[0xdd; 28]),
+            Err(StandardChannelError::NewExtranoncePrefixTooLarge)
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), largest_valid_prefix);
+        assert_eq!(channel.upstream_prefix_len(), 27);
+        assert_eq!(allocator.allocated_count(), 1);
+
+        drop(channel);
+        assert_eq!(allocator.allocated_count(), 0);
+    }
+
+    #[test]
+    fn set_upstream_extranonce_prefix_replaces_wire_prefix_transactionally() {
+        let mut channel = StandardChannel::new(
+            1,
+            "user_identity".to_string(),
+            ExtranoncePrefix::from_wire(vec![0xaa, 0xbb]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            None,
+        )
+        .unwrap();
+
+        channel.set_upstream_extranonce_prefix(&[0xcc; 32]).unwrap();
+        assert_eq!(channel.get_extranonce_prefix(), &[0xcc; 32]);
+        assert_eq!(channel.upstream_prefix_len(), 32);
+
+        assert!(matches!(
+            channel.set_upstream_extranonce_prefix(&[0xdd; 33]),
+            Err(StandardChannelError::NewExtranoncePrefixTooLarge)
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &[0xcc; 32]);
+        assert_eq!(channel.upstream_prefix_len(), 32);
+    }
 
     #[test]
     fn test_future_job_activation_flow() {
@@ -2318,8 +2380,8 @@ mod tests {
             }
             let current_bytes = channel.get_extranonce_prefix().to_vec();
             assert!(matches!(
-                channel.set_upstream_extranonce_prefix(&[0xee; 32]),
-                Err(crate::extranonce_manager::ExtranoncePrefixError::ExceedsMaxLength)
+                channel.set_upstream_extranonce_prefix(&[0xee; 2]),
+                Err(StandardChannelError::NewExtranoncePrefixTooLarge)
             ));
             assert_eq!(channel.get_extranonce_prefix(), current_bytes);
             assert_eq!(channel.retired_extranonce_prefixes.len(), 1);

--- a/sv2/channels-sv2/src/extranonce_manager/allocator.rs
+++ b/sv2/channels-sv2/src/extranonce_manager/allocator.rs
@@ -214,9 +214,17 @@ impl ExtranonceAllocator {
     /// or shrinks with the upstream prefix.
     ///
     /// Prefixes already returned by this allocator are not modified
-    /// automatically. Call
-    /// [`ExtranoncePrefix::set_upstream_prefix`](crate::extranonce_manager::ExtranoncePrefix::set_upstream_prefix)
-    /// on each live prefix so its bytes remain consistent with the allocator.
+    /// automatically. Update each live channel through its `set_upstream_extranonce_prefix`
+    /// method so its bytes remain consistent with the allocator and its live jobs keep their
+    /// allocation reserved. For standalone prefixes not owned by a channel, use
+    /// [`ExtranoncePrefix::set_upstream_prefix`](crate::extranonce_manager::ExtranoncePrefix::set_upstream_prefix).
+    ///
+    /// Applications must coordinate the complete transition. Validate the proposed layout for the
+    /// allocator and every live channel before mutating any state; then update the allocator and
+    /// channels, update group-channel size where applicable, and finally send
+    /// `SetExtranoncePrefix` downstream. If the transition cannot be completed, retain the old
+    /// layout or enter the application's fallback path. Jobs created before a successful update
+    /// continue using the prefix bytes captured when they were created.
     ///
     /// The allocator is left unchanged if the resulting full extranonce would
     /// exceed [`MAX_EXTRANONCE_LEN`].

--- a/sv2/channels-sv2/src/extranonce_manager/allocator.rs
+++ b/sv2/channels-sv2/src/extranonce_manager/allocator.rs
@@ -203,6 +203,44 @@ impl ExtranonceAllocator {
         self.upstream_prefix.len() as u8
     }
 
+    /// Sets the bytes assigned by the upstream while preserving the allocator's
+    /// locally managed layout and rollable extranonce size.
+    ///
+    /// This operation is intended for handling `SetExtranoncePrefix` on a
+    /// channel whose extranonce space is subdivided for downstream channels.
+    /// It preserves `local_prefix`, `local_index`, the allocation bitmap, and
+    /// [`rollable_extranonce_size`](Self::rollable_extranonce_size). As a
+    /// consequence, [`total_extranonce_len`](Self::total_extranonce_len) grows
+    /// or shrinks with the upstream prefix.
+    ///
+    /// Prefixes already returned by this allocator are not modified
+    /// automatically. Call
+    /// [`ExtranoncePrefix::set_upstream_prefix`](crate::extranonce_manager::ExtranoncePrefix::set_upstream_prefix)
+    /// on each live prefix so its bytes remain consistent with the allocator.
+    ///
+    /// The allocator is left unchanged if the resulting full extranonce would
+    /// exceed [`MAX_EXTRANONCE_LEN`].
+    pub fn set_upstream_prefix(
+        &mut self,
+        upstream_prefix_bytes: Vec<u8>,
+    ) -> Result<(), ExtranonceAllocatorError> {
+        let total_extranonce_len = upstream_prefix_bytes
+            .len()
+            .checked_add(self.local_prefix_len() as usize)
+            .and_then(|len| len.checked_add(self.local_index_len() as usize))
+            .and_then(|len| len.checked_add(self.rollable_extranonce_size() as usize))
+            .ok_or(ExtranonceAllocatorError::ExceedsMaxLength)?;
+
+        if total_extranonce_len > MAX_EXTRANONCE_LEN as usize {
+            return Err(ExtranonceAllocatorError::ExceedsMaxLength);
+        }
+
+        self.upstream_prefix = upstream_prefix_bytes;
+        self.total_extranonce_len = total_extranonce_len as u8;
+
+        Ok(())
+    }
+
     /// The `local_prefix` region bytes (caller-owned static bytes only).
     ///
     /// Does **not** include the `local_index` region; use
@@ -680,5 +718,52 @@ mod tests {
         let std = alloc.allocate_standard().unwrap();
 
         assert_ne!(&ext.as_bytes()[..1], &std.as_bytes()[..1]);
+    }
+
+    #[test]
+    fn upstream_prefix_update_preserves_layout_and_allocations() {
+        // upstream(1) + local_prefix(1) + local_index(1) + rollable(3) = 6
+        let mut alloc =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 256).unwrap();
+        let mut first = alloc.allocate_extended(3).unwrap();
+        let mut second = alloc.allocate_extended(3).unwrap();
+
+        alloc.set_upstream_prefix(vec![0xcc, 0xdd]).unwrap();
+        first.set_upstream_prefix(alloc.upstream_prefix()).unwrap();
+        second.set_upstream_prefix(alloc.upstream_prefix()).unwrap();
+
+        assert_eq!(alloc.upstream_prefix(), &[0xcc, 0xdd]);
+        assert_eq!(alloc.local_prefix(), &[0xbb]);
+        assert_eq!(alloc.local_index_len(), 1);
+        assert_eq!(alloc.rollable_extranonce_size(), 3);
+        assert_eq!(alloc.total_extranonce_len(), 7);
+        assert_eq!(alloc.allocated_count(), 2);
+        assert_eq!(first.as_bytes(), &[0xcc, 0xdd, 0xbb, 0x00]);
+        assert_eq!(second.as_bytes(), &[0xcc, 0xdd, 0xbb, 0x01]);
+        assert_eq!(first.upstream_prefix_len(), 2);
+
+        let third = alloc.allocate_extended(3).unwrap();
+        assert_eq!(third.as_bytes(), &[0xcc, 0xdd, 0xbb, 0x02]);
+        assert_eq!(alloc.allocated_count(), 3);
+
+        drop(first);
+        drop(second);
+        drop(third);
+        assert_eq!(alloc.allocated_count(), 0);
+    }
+
+    #[test]
+    fn invalid_upstream_prefix_update_leaves_allocator_unchanged() {
+        // upstream(1) + local_prefix(1) + local_index(1) + rollable(29) = 32
+        let mut alloc =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 32, 256).unwrap();
+
+        assert_eq!(
+            alloc.set_upstream_prefix(vec![0xcc, 0xdd]),
+            Err(ExtranonceAllocatorError::ExceedsMaxLength)
+        );
+        assert_eq!(alloc.upstream_prefix(), &[0xaa]);
+        assert_eq!(alloc.total_extranonce_len(), 32);
+        assert_eq!(alloc.rollable_extranonce_size(), 29);
     }
 }

--- a/sv2/channels-sv2/src/extranonce_manager/allocator.rs
+++ b/sv2/channels-sv2/src/extranonce_manager/allocator.rs
@@ -232,12 +232,10 @@ impl ExtranonceAllocator {
         &mut self,
         upstream_prefix_bytes: Vec<u8>,
     ) -> Result<(), ExtranonceAllocatorError> {
-        let total_extranonce_len = upstream_prefix_bytes
-            .len()
-            .checked_add(self.local_prefix_len() as usize)
-            .and_then(|len| len.checked_add(self.local_index_len() as usize))
-            .and_then(|len| len.checked_add(self.rollable_extranonce_size() as usize))
-            .ok_or(ExtranonceAllocatorError::ExceedsMaxLength)?;
+        let total_extranonce_len = upstream_prefix_bytes.len()
+            + self.local_prefix_len() as usize
+            + self.local_index_len() as usize
+            + self.rollable_extranonce_size() as usize;
 
         if total_extranonce_len > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtranonceAllocatorError::ExceedsMaxLength);
@@ -456,6 +454,7 @@ impl core::fmt::Display for ExtranonceAllocatorError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extranonce_manager::ExtranoncePrefix;
     use std::collections::HashSet;
 
     #[test]
@@ -733,8 +732,8 @@ mod tests {
         // upstream(1) + local_prefix(1) + local_index(1) + rollable(3) = 6
         let mut alloc =
             ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 256).unwrap();
-        let mut first = alloc.allocate_extended(3).unwrap();
-        let mut second = alloc.allocate_extended(3).unwrap();
+        let mut first: ExtranoncePrefix = alloc.allocate_extended(3).unwrap().into();
+        let mut second: ExtranoncePrefix = alloc.allocate_extended(3).unwrap().into();
 
         alloc.set_upstream_prefix(vec![0xcc, 0xdd]).unwrap();
         first.set_upstream_prefix(alloc.upstream_prefix()).unwrap();

--- a/sv2/channels-sv2/src/extranonce_manager/prefix.rs
+++ b/sv2/channels-sv2/src/extranonce_manager/prefix.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use alloc::sync::Weak;
+use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 
 use super::{bitvector::BitVector, MAX_EXTRANONCE_LEN};
@@ -8,7 +8,7 @@ use super::{bitvector::BitVector, MAX_EXTRANONCE_LEN};
 /// An extranonce prefix owned by a channel.
 ///
 /// Carries the raw prefix bytes — accessible via [`as_bytes`](Self::as_bytes) —
-/// and, optionally, a [`PrefixAllocation`] record that ties the prefix to an
+/// and, optionally, an internal `PrefixAllocation` record that ties the prefix to an
 /// [`ExtranonceAllocator`](super::allocator::ExtranonceAllocator)'s bitmap.
 ///
 /// There are two ways to build an [`ExtranoncePrefix`]:
@@ -22,8 +22,9 @@ use super::{bitvector::BitVector, MAX_EXTRANONCE_LEN};
 ///   [`ExtranonceAllocator::allocate_extended`](super::allocator::ExtranonceAllocator::allocate_extended)
 ///   /
 ///   [`allocate_standard`](super::allocator::ExtranonceAllocator::allocate_standard)).
-///   These carry a [`PrefixAllocation`] with a [`Weak`] back-reference to the
-///   allocator's bitmap; [`Drop`] automatically clears the corresponding bit,
+///   These carry an internal `PrefixAllocation` with a [`Weak`] back-reference to the
+///   allocator's bitmap. The current prefix and any internally retained snapshots
+///   share this record; dropping its last owner clears the corresponding bit,
 ///   returning the slot to the allocator's free pool.
 ///
 /// Server-side channels do **not** accept this loose type directly. They
@@ -38,8 +39,8 @@ use super::{bitvector::BitVector, MAX_EXTRANONCE_LEN};
 ///
 /// # Automatic release on drop
 ///
-/// For allocator-produced prefixes, the allocation is returned to the
-/// allocator automatically when the prefix is dropped. Typical usage is
+/// For allocator-produced prefixes, the allocation is returned to the allocator
+/// automatically when the current prefix and its retained snapshots are dropped. Typical usage is
 /// therefore to store the prefix on the channel and let it drop with the
 /// channel:
 ///
@@ -54,13 +55,12 @@ use super::{bitvector::BitVector, MAX_EXTRANONCE_LEN};
 ///
 /// There is no explicit release API — correct cleanup is enforced by
 /// ownership. Because [`ExtranoncePrefix`] is neither `Copy` nor `Clone`,
-/// double-release is impossible; because dropping the prefix always runs
-/// its [`Drop`] impl, forgetting to release is impossible.
+/// callers cannot duplicate allocation ownership. Internally, the allocation record is shared
+/// through [`Arc`], whose last owner releases the slot exactly once.
 ///
-/// If the allocator itself is dropped before an outstanding prefix, the
-/// prefix's [`Drop`] becomes a silent no-op (the [`Weak`] reference fails
-/// to upgrade). This is safe — the bitmap is gone, so there is nothing to
-/// update.
+/// If the allocator itself is dropped before an outstanding prefix, releasing the
+/// allocation record becomes a silent no-op (the [`Weak`] reference fails to upgrade).
+/// This is safe — the bitmap is gone, so there is nothing to update.
 ///
 /// Note that "the prefix is no longer in use" is not the same as "the
 /// channel stopped using it as its current prefix". Jobs only carry a copy
@@ -71,12 +71,25 @@ use super::{bitvector::BitVector, MAX_EXTRANONCE_LEN};
 /// future, active or past job created under it remains. Releasing it
 /// eagerly would let the allocator hand the same extranonce space to a
 /// second live channel while those jobs still validate shares.
+///
+/// An upstream-only update preserves the allocation and the local suffix. Before updating,
+/// channels snapshot the old bytes and share the same allocation record with that snapshot.
+/// A snapshot is retained only while a future, active or past job uses its bytes. This also
+/// protects the old jobs if a later whole-prefix rotation changes the channel's allocation:
+/// the slot stays reserved until neither the current prefix nor any retained snapshot owns it.
+/// Snapshots do not allocate additional bitmap slots or change the jobs' captured bytes.
 #[derive(Debug)]
 pub struct ExtranoncePrefix {
     prefix: Vec<u8>,
+    /// Length of the leading `upstream_prefix` region.
+    ///
+    /// For wire-sourced prefixes, the entire prefix is upstream-assigned. For
+    /// allocator-produced prefixes, the remaining bytes contain
+    /// `local_prefix | local_index` and, for standard channels, rollable padding.
+    upstream_prefix_len: u8,
     /// `Some(_)` when the prefix was minted by an allocator; `None` when it
     /// was built from wire bytes via [`ExtranoncePrefix::from_wire`].
-    allocation: Option<PrefixAllocation>,
+    allocation: Option<Arc<PrefixAllocation>>,
 }
 
 /// An [`ExtranoncePrefix`] that is guaranteed, at the type level, to have
@@ -104,15 +117,9 @@ pub struct AllocatedExtranoncePrefix(ExtranoncePrefix);
 ///
 /// The [`Weak`] reference means an outstanding prefix does not keep the
 /// allocator's bitmap alive past the allocator's own lifetime.
-///
-/// `upstream_prefix_len` is captured at allocation time so callers can
-/// recover the `[upstream_prefix | local_prefix | local_index]` split from
-/// the prefix alone, without having to keep the producing allocator
-/// reachable.
 #[derive(Debug)]
 struct PrefixAllocation {
     local_index: u32,
-    upstream_prefix_len: u8,
     bitmap: Weak<BitVector>,
 }
 
@@ -122,8 +129,7 @@ impl ExtranoncePrefix {
     /// Intended for client-side channels whose extranonce prefix is chosen
     /// by the upstream server (e.g. via `OpenExtendedMiningChannelSuccess`,
     /// `OpenStandardMiningChannelSuccess`, or `SetExtranoncePrefix`).
-    /// The resulting prefix carries no allocation record and its [`Drop`]
-    /// impl is a silent no-op.
+    /// The resulting prefix carries no allocation record and dropping it releases no slot.
     ///
     /// Returns [`ExtranoncePrefixError::ExceedsMaxLength`] if `prefix` is
     /// longer than [`MAX_EXTRANONCE_LEN`]. This boundary check ensures the
@@ -134,8 +140,10 @@ impl ExtranoncePrefix {
         if prefix.len() > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtranoncePrefixError::ExceedsMaxLength);
         }
+        let upstream_prefix_len = prefix.len() as u8;
         Ok(Self {
             prefix,
+            upstream_prefix_len,
             allocation: None,
         })
     }
@@ -158,19 +166,16 @@ impl ExtranoncePrefix {
         self.prefix.is_empty()
     }
 
-    /// The length of the `upstream_prefix` region, if known.
+    /// The length of the leading `upstream_prefix` region.
     ///
-    /// Returns `Some(n)` for prefixes produced by an
-    /// [`ExtranonceAllocator`](super::allocator::ExtranonceAllocator): `n`
-    /// is the number of bytes at the start of [`as_bytes`](Self::as_bytes)
-    /// that were assigned by the upstream (i.e. the
-    /// `[upstream_prefix]` portion of the standard
-    /// `[upstream_prefix | local_prefix | local_index]` layout).
+    /// For prefixes produced by an
+    /// [`ExtranonceAllocator`](super::allocator::ExtranonceAllocator), this
+    /// is the boundary in the standard
+    /// `[upstream_prefix | local_prefix | local_index]` layout.
     ///
-    /// Returns `None` for prefixes built via
-    /// [`from_wire`](Self::from_wire), because wire bytes carry no
-    /// intra-prefix layout information — the entire slice is semantically
-    /// "opaque upstream bytes" to whoever received it.
+    /// For prefixes built via [`from_wire`](Self::from_wire), the entire
+    /// prefix is upstream-assigned from the receiving node's perspective, so
+    /// this equals [`len`](Self::len).
     ///
     /// Typical use: a proxy that sub-allocates an upstream-assigned
     /// extranonce and then rewrites shares before forwarding them upstream
@@ -178,8 +183,76 @@ impl ExtranoncePrefix {
     /// separate "bytes the upstream minted" from "bytes the proxy
     /// minted", without needing to keep the producing allocator around.
     #[inline]
-    pub fn upstream_prefix_len(&self) -> Option<u8> {
-        self.allocation.as_ref().map(|a| a.upstream_prefix_len)
+    pub fn upstream_prefix_len(&self) -> u8 {
+        self.upstream_prefix_len
+    }
+
+    /// Replaces the upstream-assigned region of this prefix.
+    ///
+    /// Prefixes created by an [`ExtranonceAllocator`](super::allocator::ExtranonceAllocator)
+    /// record the boundary after `upstream_prefix`. This method preserves `local_prefix |
+    /// local_index` (and any standard-channel rollable padding) together with the allocator
+    /// ownership record. Keeping that record attached ensures the bitmap slot cannot be reused
+    /// while its channel remains live.
+    ///
+    /// Prefixes built with [`from_wire`](Self::from_wire) have no locally managed region: the
+    /// entire opaque wire value is upstream-owned from this node's perspective. For those
+    /// prefixes, this method replaces the complete value and keeps it wire-sourced.
+    ///
+    /// Jobs retain the prefix bytes captured when they were created; this only changes the
+    /// current prefix used by future jobs. The prefix is left unchanged if the updated value would
+    /// exceed [`MAX_EXTRANONCE_LEN`].
+    ///
+    /// This value does not track jobs. For channel-owned prefixes, use the channel's
+    /// `set_upstream_extranonce_prefix` method, which also retains allocation ownership for
+    /// old live jobs across subsequent whole-prefix rotations.
+    pub fn set_upstream_prefix(
+        &mut self,
+        upstream_prefix: &[u8],
+    ) -> Result<(), ExtranoncePrefixError> {
+        let preserved_bytes = &self.prefix[self.upstream_prefix_len as usize..];
+        let updated_len = upstream_prefix
+            .len()
+            .checked_add(preserved_bytes.len())
+            .ok_or(ExtranoncePrefixError::ExceedsMaxLength)?;
+
+        if updated_len > MAX_EXTRANONCE_LEN as usize {
+            return Err(ExtranoncePrefixError::ExceedsMaxLength);
+        }
+
+        let mut updated_prefix = Vec::with_capacity(updated_len);
+        updated_prefix.extend_from_slice(upstream_prefix);
+        updated_prefix.extend_from_slice(preserved_bytes);
+
+        self.prefix = updated_prefix;
+        self.upstream_prefix_len = upstream_prefix.len() as u8;
+
+        Ok(())
+    }
+
+    /// Captures the old bytes before an upstream-only update, sharing their allocation.
+    ///
+    /// Channels retire this snapshot only after a successful update, using the same live-job
+    /// tracking as whole-prefix rotations. Unchanged upstream bytes, wire prefixes and prefixes
+    /// whose allocator is gone need no snapshot.
+    pub(crate) fn snapshot_for_upstream_update(&self, upstream_prefix: &[u8]) -> Option<Self> {
+        if upstream_prefix == &self.prefix[..self.upstream_prefix_len as usize]
+            || !self.holds_allocator_slot()
+        {
+            return None;
+        }
+        Some(Self {
+            prefix: self.prefix.clone(),
+            upstream_prefix_len: self.upstream_prefix_len,
+            allocation: self.allocation.clone(),
+        })
+    }
+
+    fn shares_allocation_with(&self, other: &Self) -> bool {
+        match (&self.allocation, &other.allocation) {
+            (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        }
     }
 
     /// Whether this prefix currently reserves a slot in a live allocator's bitmap.
@@ -215,11 +288,11 @@ impl AllocatedExtranoncePrefix {
     ) -> Self {
         Self(ExtranoncePrefix {
             prefix,
-            allocation: Some(PrefixAllocation {
+            upstream_prefix_len,
+            allocation: Some(Arc::new(PrefixAllocation {
                 local_index,
-                upstream_prefix_len,
                 bitmap,
-            }),
+            })),
         })
     }
 
@@ -259,15 +332,20 @@ impl AllocatedExtranoncePrefix {
 
     /// The length of the `upstream_prefix` region.
     ///
-    /// See [`ExtranoncePrefix::upstream_prefix_len`] for the semantics of
-    /// the returned value. Because an [`AllocatedExtranoncePrefix`] is
-    /// always allocator-produced, the length is always known and this
-    /// accessor returns a bare `u8` rather than an `Option`.
+    /// See [`ExtranoncePrefix::upstream_prefix_len`] for the full semantics.
     #[inline]
     pub fn upstream_prefix_len(&self) -> u8 {
-        self.0
-            .upstream_prefix_len()
-            .expect("AllocatedExtranoncePrefix always carries an allocation record")
+        self.0.upstream_prefix_len()
+    }
+
+    /// Replaces `upstream_prefix` while preserving `local_prefix | local_index`,
+    /// any standard-channel rollable padding, and the allocator ownership record.
+    #[inline]
+    pub fn set_upstream_prefix(
+        &mut self,
+        upstream_prefix: &[u8],
+    ) -> Result<(), ExtranoncePrefixError> {
+        self.0.set_upstream_prefix(upstream_prefix)
     }
 }
 
@@ -286,12 +364,10 @@ impl PartialEq for ExtranoncePrefix {
 
 impl Eq for ExtranoncePrefix {}
 
-impl Drop for ExtranoncePrefix {
+impl Drop for PrefixAllocation {
     fn drop(&mut self) {
-        if let Some(allocation) = &self.allocation {
-            if let Some(bitmap) = allocation.bitmap.upgrade() {
-                bitmap.set(allocation.local_index as usize, false);
-            }
+        if let Some(bitmap) = self.bitmap.upgrade() {
+            bitmap.set(self.local_index as usize, false);
         }
     }
 }
@@ -303,11 +379,15 @@ impl Drop for ExtranoncePrefix {
 /// prefix rotation. Dropping the rotated-out [`ExtranoncePrefix`] right away would return its
 /// slot to the allocator while those jobs still validate shares under those bytes, letting the
 /// allocator hand the same extranonce space to a second live channel. Holding the object here
-/// keeps the slot reserved; dropping it releases the slot.
+/// keeps the slot reserved. The slot is released only when the last owner of its allocation
+/// record drops; upstream-only updates can leave several byte snapshots sharing one record.
 ///
 /// Only prefixes that [hold a slot](ExtranoncePrefix::holds_allocator_slot) are ever kept:
 /// wire-sourced prefixes and allocator-produced ones whose allocator is gone reserve nothing,
 /// and retaining them would let byte-identical rotations grow this set once per update.
+/// Snapshots with the same allocation record and bytes are kept only once, so repeated
+/// upstream updates cannot grow the set without additional live job prefixes. Byte-identical
+/// prefixes from distinct allocations are retained independently to keep both slots reserved.
 #[derive(Debug, Default)]
 pub(crate) struct RetiredExtranoncePrefixes(Vec<ExtranoncePrefix>);
 
@@ -316,8 +396,8 @@ impl RetiredExtranoncePrefixes {
     ///
     /// `live_prefixes` yields the prefix bytes of every job that can still accept shares. The
     /// prefix is kept only while it holds an allocator slot and one of them matches; otherwise it
-    /// drops here, releasing its slot right away. The prefixes retired earlier are pruned against
-    /// the same `live_prefixes`.
+    /// drops here, releasing its slot if this was its last allocation owner. The prefixes retired
+    /// earlier are pruned against the same `live_prefixes`.
     pub(crate) fn retire<'a>(
         &mut self,
         prefix: ExtranoncePrefix,
@@ -326,13 +406,17 @@ impl RetiredExtranoncePrefixes {
         self.prune(live_prefixes.clone());
         if prefix.holds_allocator_slot()
             && live_prefixes.clone().any(|live| live == prefix.as_bytes())
+            && !self
+                .0
+                .iter()
+                .any(|retired| retired == &prefix && retired.shares_allocation_with(&prefix))
         {
             self.0.push(prefix);
         }
     }
 
     /// Drops every retired prefix whose bytes no entry of `live_prefixes` matches (or whose
-    /// allocator has since been dropped), releasing their slots.
+    /// allocator has since been dropped), releasing any slots with no remaining allocation owner.
     pub(crate) fn prune<'a>(&mut self, live_prefixes: impl Iterator<Item = &'a [u8]> + Clone) {
         self.0.retain(|prefix| {
             prefix.holds_allocator_slot()
@@ -365,5 +449,151 @@ impl core::fmt::Display for ExtranoncePrefixError {
                 write!(f, "extranonce prefix exceeds {MAX_EXTRANONCE_LEN} bytes")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extranonce_manager::ExtranonceAllocator;
+
+    #[test]
+    fn upstream_snapshots_release_slot_only_after_last_owner_drops() {
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 1).unwrap();
+        let mut current: ExtranoncePrefix = allocator.allocate_extended(3).unwrap().into();
+        let first = current.snapshot_for_upstream_update(&[0xcc]).unwrap();
+        current.set_upstream_prefix(&[0xcc]).unwrap();
+        let second = current.snapshot_for_upstream_update(&[0xdd]).unwrap();
+        current.set_upstream_prefix(&[0xdd]).unwrap();
+        let live_bytes = [first.as_bytes().to_vec(), second.as_bytes().to_vec()];
+        let mut retired = RetiredExtranoncePrefixes::default();
+        retired.retire(first, live_bytes.iter().map(Vec::as_slice));
+        retired.retire(second, live_bytes.iter().map(Vec::as_slice));
+        assert_eq!(retired.len(), 2);
+        assert_eq!(allocator.allocated_count(), 1);
+
+        drop(current);
+        retired.prune(live_bytes[..1].iter().map(Vec::as_slice));
+        assert_eq!(retired.len(), 1);
+        assert_eq!(allocator.allocated_count(), 1);
+        retired.prune(core::iter::empty());
+        assert!(retired.is_empty());
+        assert_eq!(allocator.allocated_count(), 0);
+        assert!(allocator.allocate_extended(3).is_ok());
+    }
+
+    #[test]
+    fn repeated_upstream_snapshots_are_deduplicated_by_allocation_and_bytes() {
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 1).unwrap();
+        let mut current: ExtranoncePrefix = allocator.allocate_extended(3).unwrap().into();
+        let old_bytes = current.as_bytes().to_vec();
+        let mut other_bytes = old_bytes.clone();
+        other_bytes[0] = 0xcc;
+        let live_bytes = [old_bytes, other_bytes];
+        let mut retired = RetiredExtranoncePrefixes::default();
+
+        for _ in 0..100 {
+            for upstream in [0xcc, 0xaa] {
+                let snapshot = current.snapshot_for_upstream_update(&[upstream]).unwrap();
+                current.set_upstream_prefix(&[upstream]).unwrap();
+                retired.retire(snapshot, live_bytes.iter().map(Vec::as_slice));
+                assert!(retired.len() <= 2);
+                assert_eq!(allocator.allocated_count(), 1);
+            }
+        }
+        assert_eq!(retired.len(), 2);
+
+        // Pruning every snapshot must not release the still-current allocation.
+        retired.prune(core::iter::empty());
+        assert!(retired.is_empty());
+        assert_eq!(allocator.allocated_count(), 1);
+        drop(current);
+        assert_eq!(allocator.allocated_count(), 0);
+    }
+
+    #[test]
+    fn byte_identical_snapshots_from_distinct_allocators_keep_both_slots() {
+        let mut first_allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 1).unwrap();
+        let mut second_allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 1).unwrap();
+        let first: ExtranoncePrefix = first_allocator.allocate_extended(3).unwrap().into();
+        let second: ExtranoncePrefix = second_allocator.allocate_extended(3).unwrap().into();
+        assert_eq!(first.as_bytes(), second.as_bytes());
+        let live_bytes = first.as_bytes().to_vec();
+        let mut retired = RetiredExtranoncePrefixes::default();
+        for current in [first, second] {
+            retired.retire(
+                current.snapshot_for_upstream_update(&[0xcc]).unwrap(),
+                core::iter::once(live_bytes.as_slice()),
+            );
+        }
+        assert_eq!(retired.len(), 2);
+        assert_eq!(first_allocator.allocated_count(), 1);
+        assert_eq!(second_allocator.allocated_count(), 1);
+        retired.prune(core::iter::empty());
+        assert_eq!(first_allocator.allocated_count(), 0);
+        assert_eq!(second_allocator.allocated_count(), 0);
+    }
+
+    #[test]
+    fn upstream_snapshots_skip_noops_and_prefixes_without_live_allocators() {
+        let wire = ExtranoncePrefix::from_wire(vec![0xaa]).unwrap();
+        assert!(wire.snapshot_for_upstream_update(&[0xcc]).is_none());
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 1).unwrap();
+        let current: ExtranoncePrefix = allocator.allocate_extended(3).unwrap().into();
+        assert!(current.snapshot_for_upstream_update(&[0xaa]).is_none());
+        let snapshot = current.snapshot_for_upstream_update(&[0xcc]).unwrap();
+        drop(allocator);
+        assert!(!snapshot.holds_allocator_slot());
+        assert!(current.snapshot_for_upstream_update(&[0xcc]).is_none());
+        let mut retired = RetiredExtranoncePrefixes::default();
+        retired.retire(snapshot, core::iter::once(current.as_bytes()));
+        assert!(retired.is_empty());
+    }
+
+    #[test]
+    fn upstream_prefix_update_preserves_local_regions_and_allocation() {
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 256).unwrap();
+        let mut prefix: ExtranoncePrefix = allocator.allocate_extended(3).unwrap().into();
+
+        prefix.set_upstream_prefix(&[0xcc, 0xdd]).unwrap();
+
+        assert_eq!(prefix.as_bytes(), &[0xcc, 0xdd, 0xbb, 0x00]);
+        assert_eq!(prefix.upstream_prefix_len(), 2);
+        assert_eq!(allocator.allocated_count(), 1);
+
+        drop(prefix);
+        assert_eq!(allocator.allocated_count(), 0);
+    }
+
+    #[test]
+    fn upstream_prefix_update_replaces_a_wire_sourced_prefix() {
+        let mut prefix = ExtranoncePrefix::from_wire(vec![0xaa, 0xbb]).unwrap();
+        assert_eq!(prefix.upstream_prefix_len(), 2);
+
+        prefix.set_upstream_prefix(&[0xcc]).unwrap();
+
+        assert_eq!(prefix.as_bytes(), &[0xcc]);
+        assert_eq!(prefix.upstream_prefix_len(), 1);
+    }
+
+    #[test]
+    fn oversized_upstream_prefix_update_is_transactional() {
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 32, 256).unwrap();
+        let mut prefix: ExtranoncePrefix = allocator.allocate_extended(29).unwrap().into();
+
+        assert_eq!(
+            prefix.set_upstream_prefix(&[0xcc; 31]),
+            Err(ExtranoncePrefixError::ExceedsMaxLength)
+        );
+        assert_eq!(prefix.as_bytes(), &[0xaa, 0xbb, 0x00]);
+        assert_eq!(prefix.upstream_prefix_len(), 1);
+        assert_eq!(allocator.allocated_count(), 1);
     }
 }

--- a/sv2/channels-sv2/src/extranonce_manager/prefix.rs
+++ b/sv2/channels-sv2/src/extranonce_manager/prefix.rs
@@ -187,6 +187,13 @@ impl ExtranoncePrefix {
         self.upstream_prefix_len
     }
 
+    /// Bytes retained when replacing the upstream region: `local_prefix | local_index`, plus
+    /// any standard-channel rollable padding. Wire-sourced prefixes have no preserved region.
+    #[inline]
+    pub(crate) fn preserved_len(&self) -> usize {
+        self.len() - self.upstream_prefix_len as usize
+    }
+
     /// Replaces the upstream-assigned region of this prefix.
     ///
     /// Prefixes created by an [`ExtranonceAllocator`](super::allocator::ExtranonceAllocator)
@@ -211,10 +218,7 @@ impl ExtranoncePrefix {
         upstream_prefix: &[u8],
     ) -> Result<(), ExtranoncePrefixError> {
         let preserved_bytes = &self.prefix[self.upstream_prefix_len as usize..];
-        let updated_len = upstream_prefix
-            .len()
-            .checked_add(preserved_bytes.len())
-            .ok_or(ExtranoncePrefixError::ExceedsMaxLength)?;
+        let updated_len = upstream_prefix.len() + preserved_bytes.len();
 
         if updated_len > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtranoncePrefixError::ExceedsMaxLength);
@@ -336,16 +340,6 @@ impl AllocatedExtranoncePrefix {
     #[inline]
     pub fn upstream_prefix_len(&self) -> u8 {
         self.0.upstream_prefix_len()
-    }
-
-    /// Replaces `upstream_prefix` while preserving `local_prefix | local_index`,
-    /// any standard-channel rollable padding, and the allocator ownership record.
-    #[inline]
-    pub fn set_upstream_prefix(
-        &mut self,
-        upstream_prefix: &[u8],
-    ) -> Result<(), ExtranoncePrefixError> {
-        self.0.set_upstream_prefix(upstream_prefix)
     }
 }
 
@@ -553,6 +547,19 @@ mod tests {
         let mut retired = RetiredExtranoncePrefixes::default();
         retired.retire(snapshot, core::iter::once(current.as_bytes()));
         assert!(retired.is_empty());
+    }
+
+    #[test]
+    fn preserved_len_includes_local_index_and_standard_padding() {
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 6, 256).unwrap();
+        let extended: ExtranoncePrefix = allocator.allocate_extended(3).unwrap().into();
+        let standard: ExtranoncePrefix = allocator.allocate_standard().unwrap().into();
+        let wire = ExtranoncePrefix::from_wire(vec![0xaa, 0xbb]).unwrap();
+
+        assert_eq!(extended.preserved_len(), 2);
+        assert_eq!(standard.preserved_len(), 5);
+        assert_eq!(wire.preserved_len(), 0);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -339,23 +339,29 @@ impl ExtendedChannel {
     /// every job created under it has become stale. This prevents the allocator from handing the
     /// same extranonce space to another live channel while those jobs still validate shares.
     ///
-    /// Returns an error if the new extranonce prefix is too large, or if it would push the
-    /// assembled coinbase `scriptSig` past its budget (see
+    /// Returns an error if the new extranonce prefix and the channel's rollable extranonce would
+    /// exceed [`MAX_EXTRANONCE_LEN`], or if they would push the assembled coinbase `scriptSig`
+    /// past its budget (see
     /// [`JobFactory::fits_script_sig_budget`]). The channel is left unchanged in both error
     /// cases.
     pub fn set_extranonce_prefix(
         &mut self,
         extranonce_prefix: AllocatedExtranoncePrefix,
     ) -> Result<(), ExtendedChannelError> {
-        if extranonce_prefix.len() > MAX_EXTRANONCE_LEN as usize {
+        let full_extranonce_size = extranonce_prefix
+            .len()
+            .checked_add(self.rollable_extranonce_size as usize)
+            .ok_or(ExtendedChannelError::ExtranoncePrefixTooLarge)?;
+        if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtendedChannelError::ExtranoncePrefixTooLarge);
         }
 
         // re-run the constructor's invariant: a prefix that is individually valid can still push
         // the assembled scriptSig past the consensus cap
-        if !self.job_factory.fits_script_sig_budget(
-            extranonce_prefix.len() + self.rollable_extranonce_size as usize,
-        ) {
+        if !self
+            .job_factory
+            .fits_script_sig_budget(full_extranonce_size)
+        {
             return Err(ExtendedChannelError::ScriptSigSizeTooLarge);
         }
 
@@ -1983,11 +1989,11 @@ mod tests {
         assert_eq!(channel.get_target(), &not_so_permissive_max_target);
     }
 
-    // a 48 char pool tag places the worst-case scriptSig exactly on the budget:
-    // 8 (MAX_COINBASE_PREFIX_SIZE) + 1 + 3 ("Sv2") + 3 + 48 (tag) + 1 + 28 + 8 (full extranonce)
+    // a 52 char pool tag places the worst-case scriptSig exactly on the budget:
+    // 8 (MAX_COINBASE_PREFIX_SIZE) + 1 + 3 ("Sv2") + 3 + 52 (tag) + 1 + 24 + 8 (full extranonce)
     // = 100
-    const POOL_TAG_AT_SCRIPT_SIG_BUDGET: usize = 48;
-    const EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET: usize = 28;
+    const POOL_TAG_AT_SCRIPT_SIG_BUDGET: usize = 52;
+    const EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET: usize = 24;
     const ROLLABLE_EXTRANONCE_SIZE_AT_SCRIPT_SIG_BUDGET: u16 = 8;
 
     fn new_extended_channel_with_pool_tag(
@@ -2050,24 +2056,23 @@ mod tests {
     fn test_set_extranonce_prefix_rejects_oversized_script_sig() {
         // start well within the budget
         let original_prefix_len = 4;
+        // One extra tag byte makes the scriptSig budget bind at a 31-byte full extranonce, below
+        // MAX_EXTRANONCE_LEN. This isolates the scriptSig check from the full-extranonce check.
+        let pool_tag_len = POOL_TAG_AT_SCRIPT_SIG_BUDGET + 1;
+        let largest_valid_prefix_len = EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET - 1;
         let mut channel =
-            new_extended_channel_with_pool_tag(POOL_TAG_AT_SCRIPT_SIG_BUDGET, original_prefix_len)
-                .unwrap();
+            new_extended_channel_with_pool_tag(pool_tag_len, original_prefix_len).unwrap();
         let original_prefix = channel.get_extranonce_prefix().to_vec();
 
         // growing up to the budget is allowed
         channel
             .set_extranonce_prefix(
-                AllocatedExtranoncePrefix::for_test(vec![
-                    0xcd;
-                    EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET
-                ])
-                .unwrap(),
+                AllocatedExtranoncePrefix::for_test(vec![0xcd; largest_valid_prefix_len]).unwrap(),
             )
             .unwrap();
         assert_eq!(
             channel.get_extranonce_prefix().len(),
-            EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET
+            largest_valid_prefix_len
         );
 
         // go back to the original prefix, so we can assert the channel is untouched on error
@@ -2079,7 +2084,7 @@ mod tests {
 
         // a prefix that is individually valid (<= MAX_EXTRANONCE_LEN) but pushes the assembled
         // scriptSig one byte past the budget must be rejected
-        let oversized_prefix = vec![0xcd; EXTRANONCE_PREFIX_LEN_AT_SCRIPT_SIG_BUDGET + 1];
+        let oversized_prefix = vec![0xcd; largest_valid_prefix_len + 1];
         assert!(oversized_prefix.len() <= MAX_EXTRANONCE_LEN as usize);
         let res = channel
             .set_extranonce_prefix(AllocatedExtranoncePrefix::for_test(oversized_prefix).unwrap());
@@ -2088,6 +2093,30 @@ mod tests {
             ExtendedChannelError::ScriptSigSizeTooLarge
         ));
         assert_eq!(channel.get_extranonce_prefix(), &original_prefix[..]);
+    }
+
+    #[test]
+    fn test_set_extranonce_prefix_enforces_full_extranonce_size_transactionally() {
+        let original_prefix_len = 4;
+        let mut channel = new_extended_channel_with_pool_tag(0, original_prefix_len).unwrap();
+
+        let largest_valid_prefix_len =
+            MAX_EXTRANONCE_LEN as usize - ROLLABLE_EXTRANONCE_SIZE_AT_SCRIPT_SIG_BUDGET as usize;
+        let largest_valid_prefix = vec![0xcd; largest_valid_prefix_len];
+        channel
+            .set_extranonce_prefix(
+                AllocatedExtranoncePrefix::for_test(largest_valid_prefix.clone()).unwrap(),
+            )
+            .unwrap();
+
+        let result = channel.set_extranonce_prefix(
+            AllocatedExtranoncePrefix::for_test(vec![0xef; largest_valid_prefix_len + 1]).unwrap(),
+        );
+        assert!(matches!(
+            result,
+            Err(ExtendedChannelError::ExtranoncePrefixTooLarge)
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &largest_valid_prefix);
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -373,6 +373,56 @@ impl ExtendedChannel {
         Ok(())
     }
 
+    /// Replaces the upstream-assigned region of this channel's extranonce prefix.
+    ///
+    /// The locally allocated suffix and its bitmap lease remain attached to the channel, so this
+    /// does not consume a second allocation while jobs created with the previous upstream prefix
+    /// remain valid. Existing jobs retain their captured prefix bytes; new jobs use the updated
+    /// prefix.
+    ///
+    /// The channel is left unchanged if the resulting full extranonce exceeds
+    /// [`MAX_EXTRANONCE_LEN`] or the assembled coinbase `scriptSig` budget.
+    ///
+    /// Old prefix bytes share ownership of the same allocator slot while any future, active or
+    /// past job uses them. A later `set_extranonce_prefix` rotation cannot release that slot
+    /// prematurely. Once those jobs are stale or evicted, only the current prefix (if it still
+    /// uses this allocation) keeps the slot reserved. This update consumes no additional slot.
+    ///
+    /// If this channel belongs to a [`GroupChannel`](super::group::GroupChannel) and the update
+    /// changes its full extranonce size, the application must update the group with
+    /// [`GroupChannel::set_full_extranonce_size`](super::group::GroupChannel::set_full_extranonce_size)
+    /// and register the compatible channel IDs again. Changing the group size clears its current
+    /// channel membership.
+    pub fn set_upstream_extranonce_prefix(
+        &mut self,
+        upstream_prefix: &[u8],
+    ) -> Result<(), ExtendedChannelError> {
+        let preserved_prefix_len =
+            self.extranonce_prefix.len() - self.extranonce_prefix.upstream_prefix_len() as usize;
+        let full_extranonce_size =
+            upstream_prefix.len() + preserved_prefix_len + self.rollable_extranonce_size as usize;
+        if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
+            return Err(ExtendedChannelError::ExtranoncePrefixTooLarge);
+        }
+        if !self
+            .job_factory
+            .fits_script_sig_budget(full_extranonce_size)
+        {
+            return Err(ExtendedChannelError::ScriptSigSizeTooLarge);
+        }
+
+        let snapshot = self
+            .extranonce_prefix
+            .snapshot_for_upstream_update(upstream_prefix);
+        self.extranonce_prefix
+            .set_upstream_prefix(upstream_prefix)
+            .map_err(|_| ExtendedChannelError::ExtranoncePrefixTooLarge)?;
+        if let Some(snapshot) = snapshot {
+            self.job_store.retire_extranonce_prefix(snapshot);
+        }
+        Ok(())
+    }
+
     /// Returns the number of bytes available for the rollable portion of the extranonce.
     pub fn get_rollable_extranonce_size(&self) -> u16 {
         self.rollable_extranonce_size
@@ -2086,8 +2136,16 @@ mod tests {
         // scriptSig one byte past the budget must be rejected
         let oversized_prefix = vec![0xcd; largest_valid_prefix_len + 1];
         assert!(oversized_prefix.len() <= MAX_EXTRANONCE_LEN as usize);
-        let res = channel
-            .set_extranonce_prefix(AllocatedExtranoncePrefix::for_test(oversized_prefix).unwrap());
+        let res = channel.set_extranonce_prefix(
+            AllocatedExtranoncePrefix::for_test(oversized_prefix.clone()).unwrap(),
+        );
+        assert!(matches!(
+            res.unwrap_err(),
+            ExtendedChannelError::ScriptSigSizeTooLarge
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &original_prefix[..]);
+
+        let res = channel.set_upstream_extranonce_prefix(&oversized_prefix);
         assert!(matches!(
             res.unwrap_err(),
             ExtendedChannelError::ScriptSigSizeTooLarge
@@ -2117,6 +2175,47 @@ mod tests {
             Err(ExtendedChannelError::ExtranoncePrefixTooLarge)
         ));
         assert_eq!(channel.get_extranonce_prefix(), &largest_valid_prefix);
+    }
+
+    #[test]
+    fn test_set_upstream_extranonce_prefix_preserves_allocation_transactionally() {
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 5, 256).unwrap();
+        let allocated_prefix = allocator.allocate_extended(2).unwrap();
+        let old_suffix = allocated_prefix.as_bytes()[1..].to_vec();
+        let mut channel = ExtendedChannel::new(
+            1,
+            "user_identity".to_string(),
+            allocated_prefix.into(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            2,
+            100,
+            1.0,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        allocator.set_upstream_prefix(vec![0xcc, 0xdd]).unwrap();
+        channel
+            .set_upstream_extranonce_prefix(allocator.upstream_prefix())
+            .unwrap();
+        let mut expected = vec![0xcc, 0xdd];
+        expected.extend_from_slice(&old_suffix);
+        assert_eq!(channel.get_extranonce_prefix(), &expected);
+        assert_eq!(allocator.allocated_count(), 1);
+
+        let prefix_before_error = channel.get_extranonce_prefix().to_vec();
+        let result = channel.set_upstream_extranonce_prefix(&[0xee; 29]);
+        assert!(matches!(
+            result,
+            Err(ExtendedChannelError::ExtranoncePrefixTooLarge)
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &prefix_before_error);
+        assert_eq!(allocator.allocated_count(), 1);
     }
 
     #[test]
@@ -2284,9 +2383,17 @@ mod tests {
         assert_ne!(prefix_1.as_bytes(), prefix_2.as_bytes());
         assert_eq!(allocator.allocated_count(), 2);
 
+        let (mut channel, prefix_1_bytes, job_id) = extended_channel_with_live_job(prefix_1, false);
+        channel.set_extranonce_prefix(prefix_2).unwrap();
+        (allocator, channel, prefix_1_bytes, job_id)
+    }
+
+    fn extended_channel_with_live_job(
+        prefix_1: AllocatedExtranoncePrefix,
+        future: bool,
+    ) -> (ExtendedChannel, Vec<u8>, u32) {
         let prefix_1_bytes = prefix_1.as_bytes().to_vec();
-        let rollable_extranonce_size =
-            (total_extranonce_len as usize - prefix_1_bytes.len()) as u16;
+        let rollable_extranonce_size = (32 - prefix_1_bytes.len()) as u16;
 
         let mut channel = ExtendedChannel::new_for_pool(
             1,
@@ -2314,7 +2421,7 @@ mod tests {
 
         let template = NewTemplate {
             template_id: 1,
-            future_template: false,
+            future_template: future,
             version: 536870912,
             coinbase_tx_version: 2,
             coinbase_prefix: vec![82, 0].try_into().unwrap(),
@@ -2347,12 +2454,79 @@ mod tests {
         channel
             .on_new_template(template, coinbase_reward_outputs)
             .unwrap();
-        let job_id = channel.get_active_job().unwrap().get_job_id();
+        let job_id = if future {
+            channel.get_future_job_id_from_template_id(1).unwrap()
+        } else {
+            channel.get_active_job().unwrap().get_job_id()
+        };
 
-        // rotate the channel onto the second prefix, while the job above is still live
-        channel.set_extranonce_prefix(prefix_2).unwrap();
+        (channel, prefix_1_bytes, job_id)
+    }
 
-        (allocator, channel, prefix_1_bytes, job_id)
+    #[test]
+    fn test_mixed_prefix_updates_reserve_slot_until_jobs_go_stale() {
+        for future in [false, true] {
+            let mut allocator =
+                ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 32, 2).unwrap();
+            let prefix = allocator.allocate_extended(8).unwrap();
+            let (mut channel, old_bytes, job_id) = extended_channel_with_live_job(prefix, future);
+
+            allocator.set_upstream_prefix(vec![0xcc]).unwrap();
+            channel.set_upstream_extranonce_prefix(&[0xcc]).unwrap();
+            assert_eq!(allocator.allocated_count(), 1);
+            assert_eq!(&channel.get_extranonce_prefix()[1..], &old_bytes[1..]);
+
+            let replacement = allocator.allocate_extended(8).unwrap();
+            channel.set_extranonce_prefix(replacement).unwrap();
+            let job = if future {
+                channel.get_future_job(job_id).unwrap()
+            } else {
+                channel.get_active_job().unwrap()
+            };
+            assert_eq!(job.get_extranonce_prefix(), old_bytes);
+            assert_eq!(allocator.allocated_count(), 2);
+            allocator.set_upstream_prefix(vec![0xaa]).unwrap();
+            assert!(matches!(
+                allocator.allocate_extended(8),
+                Err(ExtranonceAllocatorError::CapacityExhausted)
+            ));
+
+            // Activating the future job must preserve its old prefix and allocation.
+            if future {
+                channel
+                    .on_set_new_prev_hash(SetNewPrevHash {
+                        template_id: 1,
+                        prev_hash: [2; 32].into(),
+                        header_timestamp: 1745596970,
+                        n_bits: 453040064,
+                        target: [0xff; 32].into(),
+                    })
+                    .unwrap();
+                assert_eq!(
+                    channel.get_active_job().unwrap().get_extranonce_prefix(),
+                    old_bytes
+                );
+                assert_eq!(allocator.allocated_count(), 2);
+            }
+
+            // A new tip with no matching future job retires the old work.
+            channel
+                .on_set_new_prev_hash(SetNewPrevHash {
+                    template_id: 999,
+                    prev_hash: [1; 32].into(),
+                    header_timestamp: 1745597510,
+                    n_bits: 453040064,
+                    target: [0xff; 32].into(),
+                })
+                .unwrap();
+            assert!(channel.get_active_job().is_none());
+            assert_eq!(allocator.allocated_count(), 1);
+            let reused = allocator.allocate_extended(8).unwrap();
+            assert_eq!(reused.as_bytes(), old_bytes);
+            drop(reused);
+            drop(channel);
+            assert_eq!(allocator.allocated_count(), 0);
+        }
     }
 
     #[test]

--- a/sv2/channels-sv2/src/server/extended.rs
+++ b/sv2/channels-sv2/src/server/extended.rs
@@ -348,10 +348,7 @@ impl ExtendedChannel {
         &mut self,
         extranonce_prefix: AllocatedExtranoncePrefix,
     ) -> Result<(), ExtendedChannelError> {
-        let full_extranonce_size = extranonce_prefix
-            .len()
-            .checked_add(self.rollable_extranonce_size as usize)
-            .ok_or(ExtendedChannelError::ExtranoncePrefixTooLarge)?;
+        let full_extranonce_size = extranonce_prefix.len() + self.rollable_extranonce_size as usize;
         if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtendedChannelError::ExtranoncePrefixTooLarge);
         }
@@ -397,10 +394,9 @@ impl ExtendedChannel {
         &mut self,
         upstream_prefix: &[u8],
     ) -> Result<(), ExtendedChannelError> {
-        let preserved_prefix_len =
-            self.extranonce_prefix.len() - self.extranonce_prefix.upstream_prefix_len() as usize;
-        let full_extranonce_size =
-            upstream_prefix.len() + preserved_prefix_len + self.rollable_extranonce_size as usize;
+        let full_extranonce_size = upstream_prefix.len()
+            + self.extranonce_prefix.preserved_len()
+            + self.rollable_extranonce_size as usize;
         if full_extranonce_size > MAX_EXTRANONCE_LEN as usize {
             return Err(ExtendedChannelError::ExtranoncePrefixTooLarge);
         }

--- a/sv2/channels-sv2/src/server/jobs/job_store.rs
+++ b/sv2/channels-sv2/src/server/jobs/job_store.rs
@@ -320,8 +320,9 @@ impl<T: Job> JobStore<T> {
         self.prune_retired_extranonce_prefixes();
     }
 
-    /// Takes ownership of an extranonce prefix that is no longer the channel's current one,
-    /// releasing it only once no job created under it can accept shares anymore, see
+    /// Retains a rotated-out prefix or an upstream-update snapshot while a live job uses its
+    /// bytes. Snapshots can share an allocation with the channel's current prefix; its slot is
+    /// released only after the last allocation owner drops. See
     /// [`RetiredExtranoncePrefixes`].
     pub fn retire_extranonce_prefix(&mut self, extranonce_prefix: ExtranoncePrefix) {
         self.retired_extranonce_prefixes.retire(
@@ -335,8 +336,8 @@ impl<T: Job> JobStore<T> {
     }
 
     /// Drops every retired extranonce prefix that no future, active or past job still references.
-    /// Dropping releases the prefix's slot back to its allocator. Stale jobs are not live: shares
-    /// against them are rejected, so they hold no prefix.
+    /// Dropping the last owner of an allocation releases its slot back to its allocator.
+    /// Stale jobs are not live: shares against them are rejected, so they retain no allocation.
     fn prune_retired_extranonce_prefixes(&mut self) {
         self.retired_extranonce_prefixes.prune(
             self.future_jobs

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -351,9 +351,7 @@ impl StandardChannel {
         &mut self,
         upstream_prefix: &[u8],
     ) -> Result<(), StandardChannelError> {
-        let preserved_prefix_len =
-            self.extranonce_prefix.len() - self.extranonce_prefix.upstream_prefix_len() as usize;
-        let updated_prefix_len = upstream_prefix.len() + preserved_prefix_len;
+        let updated_prefix_len = upstream_prefix.len() + self.extranonce_prefix.preserved_len();
         if updated_prefix_len > MAX_EXTRANONCE_LEN as usize {
             return Err(StandardChannelError::ExtranoncePrefixTooLarge);
         }

--- a/sv2/channels-sv2/src/server/standard.rs
+++ b/sv2/channels-sv2/src/server/standard.rs
@@ -327,6 +327,52 @@ impl StandardChannel {
         Ok(())
     }
 
+    /// Replaces the upstream-assigned region of this channel's extranonce prefix.
+    ///
+    /// The locally allocated suffix and its bitmap lease remain attached to the channel, so this
+    /// does not consume a second allocation while jobs created with the previous upstream prefix
+    /// remain valid. Existing jobs retain their captured prefix bytes; new jobs use the updated
+    /// prefix.
+    ///
+    /// The channel is left unchanged if the resulting prefix exceeds
+    /// [`MAX_EXTRANONCE_LEN`] or the assembled coinbase `scriptSig` budget.
+    ///
+    /// Old prefix bytes share ownership of the same allocator slot while any future, active or
+    /// past job uses them. A later `set_extranonce_prefix` rotation cannot release that slot
+    /// prematurely. Once those jobs are stale or evicted, only the current prefix (if it still
+    /// uses this allocation) keeps the slot reserved. This update consumes no additional slot.
+    ///
+    /// If this channel belongs to a [`GroupChannel`](super::group::GroupChannel) and the update
+    /// changes its full extranonce size, the application must update the group with
+    /// [`GroupChannel::set_full_extranonce_size`](super::group::GroupChannel::set_full_extranonce_size)
+    /// and register the compatible channel IDs again. Changing the group size clears its current
+    /// channel membership.
+    pub fn set_upstream_extranonce_prefix(
+        &mut self,
+        upstream_prefix: &[u8],
+    ) -> Result<(), StandardChannelError> {
+        let preserved_prefix_len =
+            self.extranonce_prefix.len() - self.extranonce_prefix.upstream_prefix_len() as usize;
+        let updated_prefix_len = upstream_prefix.len() + preserved_prefix_len;
+        if updated_prefix_len > MAX_EXTRANONCE_LEN as usize {
+            return Err(StandardChannelError::ExtranoncePrefixTooLarge);
+        }
+        if !self.job_factory.fits_script_sig_budget(updated_prefix_len) {
+            return Err(StandardChannelError::ScriptSigSizeTooLarge);
+        }
+
+        let snapshot = self
+            .extranonce_prefix
+            .snapshot_for_upstream_update(upstream_prefix);
+        self.extranonce_prefix
+            .set_upstream_prefix(upstream_prefix)
+            .map_err(|_| StandardChannelError::ExtranoncePrefixTooLarge)?;
+        if let Some(snapshot) = snapshot {
+            self.job_store.retire_extranonce_prefix(snapshot);
+        }
+        Ok(())
+    }
+
     /// Updates the current target for this channel.
     ///
     /// Please note that this will NOT update the target associated with jobs that were already created.
@@ -2141,13 +2187,60 @@ mod tests {
         // scriptSig one byte past the budget must be rejected
         let oversized_prefix = vec![0xcd; EXTRANONCE_PREFIX_LEN_AT_BINDING_BUDGET + 1];
         assert!(oversized_prefix.len() <= MAX_EXTRANONCE_LEN as usize);
-        let res = channel
-            .set_extranonce_prefix(AllocatedExtranoncePrefix::for_test(oversized_prefix).unwrap());
+        let res = channel.set_extranonce_prefix(
+            AllocatedExtranoncePrefix::for_test(oversized_prefix.clone()).unwrap(),
+        );
         assert!(matches!(
             res.unwrap_err(),
             StandardChannelError::ScriptSigSizeTooLarge
         ));
         assert_eq!(channel.get_extranonce_prefix(), &original_prefix[..]);
+
+        let res = channel.set_upstream_extranonce_prefix(&oversized_prefix);
+        assert!(matches!(
+            res.unwrap_err(),
+            StandardChannelError::ScriptSigSizeTooLarge
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &original_prefix[..]);
+    }
+
+    #[test]
+    fn test_set_upstream_extranonce_prefix_preserves_allocation_transactionally() {
+        let mut allocator =
+            ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 5, 256).unwrap();
+        let allocated_prefix = allocator.allocate_standard().unwrap();
+        let old_suffix = allocated_prefix.as_bytes()[1..].to_vec();
+        let mut channel = StandardChannel::new(
+            1,
+            "user_identity".to_string(),
+            allocated_prefix.into(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            100,
+            1.0,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        allocator.set_upstream_prefix(vec![0xcc, 0xdd]).unwrap();
+        channel
+            .set_upstream_extranonce_prefix(allocator.upstream_prefix())
+            .unwrap();
+        let mut expected = vec![0xcc, 0xdd];
+        expected.extend_from_slice(&old_suffix);
+        assert_eq!(channel.get_extranonce_prefix(), &expected);
+        assert_eq!(allocator.allocated_count(), 1);
+
+        let prefix_before_error = channel.get_extranonce_prefix().to_vec();
+        let result = channel.set_upstream_extranonce_prefix(&[0xee; 29]);
+        assert!(matches!(
+            result,
+            Err(StandardChannelError::ExtranoncePrefixTooLarge)
+        ));
+        assert_eq!(channel.get_extranonce_prefix(), &prefix_before_error);
+        assert_eq!(allocator.allocated_count(), 1);
     }
 
     #[test]
@@ -2430,19 +2523,10 @@ mod tests {
         assert!(standard_channel.get_active_job().is_some());
     }
 
-    #[test]
-    fn test_rotated_extranonce_prefix_slot_not_reused_while_job_live() {
-        // Regression test: rotating the channel's extranonce prefix must not return the old
-        // prefix's allocator slot to the free pool while jobs created under it can still accept
-        // shares. Otherwise the allocator could hand the very same extranonce space to a second
-        // live channel, making the same work replayable across both.
-        let mut allocator = ExtranonceAllocator::new(vec![], 32, 2).unwrap();
-
-        let prefix_1 = allocator.allocate_standard().unwrap();
-        let prefix_2 = allocator.allocate_standard().unwrap();
-        assert_ne!(prefix_1.as_bytes(), prefix_2.as_bytes());
-        assert_eq!(allocator.allocated_count(), 2);
-
+    fn standard_channel_with_live_job(
+        prefix_1: AllocatedExtranoncePrefix,
+        future: bool,
+    ) -> (StandardChannel, Vec<u8>) {
         let prefix_1_bytes = prefix_1.as_bytes().to_vec();
 
         let mut standard_channel = StandardChannel::new_for_pool(
@@ -2460,7 +2544,7 @@ mod tests {
 
         let template = NewTemplate {
             template_id: 1,
-            future_template: false,
+            future_template: future,
             version: 536870912,
             coinbase_tx_version: 2,
             coinbase_prefix: vec![2, 159, 0, 0].try_into().unwrap(),
@@ -2501,6 +2585,91 @@ mod tests {
         standard_channel
             .on_new_template(template, coinbase_reward_outputs)
             .unwrap();
+
+        (standard_channel, prefix_1_bytes)
+    }
+
+    #[test]
+    fn test_mixed_prefix_updates_reserve_slot_until_jobs_go_stale() {
+        for future in [false, true] {
+            let mut allocator =
+                ExtranonceAllocator::from_upstream_prefix(vec![0xaa], vec![0xbb], 32, 2).unwrap();
+            let prefix = allocator.allocate_standard().unwrap();
+            let (mut channel, old_bytes) = standard_channel_with_live_job(prefix, future);
+            let job_id = if future {
+                channel.get_future_job_id_from_template_id(1).unwrap()
+            } else {
+                channel.get_active_job().unwrap().get_job_id()
+            };
+
+            allocator.set_upstream_prefix(vec![0xcc]).unwrap();
+            channel.set_upstream_extranonce_prefix(&[0xcc]).unwrap();
+            assert_eq!(allocator.allocated_count(), 1);
+            assert_eq!(&channel.get_extranonce_prefix()[1..], &old_bytes[1..]);
+
+            let replacement = allocator.allocate_standard().unwrap();
+            channel.set_extranonce_prefix(replacement).unwrap();
+            let job = if future {
+                channel.get_future_job(job_id).unwrap()
+            } else {
+                channel.get_active_job().unwrap()
+            };
+            assert_eq!(job.get_extranonce_prefix(), old_bytes);
+            assert_eq!(allocator.allocated_count(), 2);
+            allocator.set_upstream_prefix(vec![0xaa]).unwrap();
+            assert!(matches!(
+                allocator.allocate_standard(),
+                Err(ExtranonceAllocatorError::CapacityExhausted)
+            ));
+
+            // Activating the future job must preserve its old prefix and allocation.
+            if future {
+                channel
+                    .on_set_new_prev_hash(SetNewPrevHashTdp {
+                        template_id: 1,
+                        prev_hash: [2; 32].into(),
+                        header_timestamp: 1745596970,
+                        n_bits: 453040064,
+                        target: [0xff; 32].into(),
+                    })
+                    .unwrap();
+                assert_eq!(
+                    channel.get_active_job().unwrap().get_extranonce_prefix(),
+                    old_bytes
+                );
+                assert_eq!(allocator.allocated_count(), 2);
+            }
+
+            // A new tip with no matching future job retires the old work.
+            channel
+                .on_set_new_prev_hash(SetNewPrevHashTdp {
+                    template_id: 999,
+                    prev_hash: [1; 32].into(),
+                    header_timestamp: 1745597510,
+                    n_bits: 453040064,
+                    target: [0xff; 32].into(),
+                })
+                .unwrap();
+            assert!(channel.get_active_job().is_none());
+            assert_eq!(allocator.allocated_count(), 1);
+            let reused = allocator.allocate_standard().unwrap();
+            assert_eq!(reused.as_bytes(), old_bytes);
+            drop(reused);
+            drop(channel);
+            assert_eq!(allocator.allocated_count(), 0);
+        }
+    }
+
+    #[test]
+    fn test_rotated_extranonce_prefix_slot_not_reused_while_job_live() {
+        // A whole-prefix rotation keeps the old slot reserved while its job accepts shares.
+        let mut allocator = ExtranonceAllocator::new(vec![], 32, 2).unwrap();
+        let prefix_1 = allocator.allocate_standard().unwrap();
+        let prefix_2 = allocator.allocate_standard().unwrap();
+        assert_ne!(prefix_1.as_bytes(), prefix_2.as_bytes());
+        assert_eq!(allocator.allocated_count(), 2);
+        let (mut standard_channel, prefix_1_bytes) =
+            standard_channel_with_live_job(prefix_1, false);
 
         // rotate the channel onto the second prefix, while the job above is still live
         standard_channel.set_extranonce_prefix(prefix_2).unwrap();


### PR DESCRIPTION
This PR is a prerequisite for a final PR on `sv2-apps` which is aiming to close almost all the currently tracked issues of tProxy (specifically https://github.com/stratum-mining/sv2-apps/issues/36, https://github.com/stratum-mining/sv2-apps/issues/139, https://github.com/stratum-mining/sv2-apps/issues/164, https://github.com/stratum-mining/sv2-apps/issues/386, https://github.com/stratum-mining/sv2-apps/issues/650).

It has four commits:

- `channels_sv2`: add APIs for replacing the upstream extranonce prefix while preserving local suffixes, channel allocations, bitmap state, and rollable size.
- `channels_sv2`: validate the complete extended extranonce layout transactionally on prefix updates.
- `sv1_api`: acknowledge `mining.extranonce.subscribe`, pass its `client_id` to the server, and use a mutable receiver so tProxy can record downstream support directly.
- `sv1_api`: expose typed submit outcomes for the standard SV1 rejection codes 20–23, serialized in the legacy SV1 error-array format while retaining compatibility with object-form errors.

companion https://github.com/stratum-mining/sv2-apps/pull/823
