### PR TITLE
fix(ci): prevent false green IT skip when no companion is present

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,10 +32,13 @@ jobs:
             || true)
 
           if [ "$ACTION" = "edited" ]; then
-            if [ "$OLD_COMPANION" != "$NEW_COMPANION" ]; then
-              echo "should_run_integration_test=true" >> "$GITHUB_OUTPUT"
-            else
+            # Only skip when a companion line exists and was not changed by the
+            # edit. An edit without a companion line (or with an empty body) is
+            # not a reason to skip: the prior run's failure must remain visible.
+            if [ -n "$NEW_COMPANION" ] && [ "$OLD_COMPANION" = "$NEW_COMPANION" ]; then
               echo "should_run_integration_test=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_run_integration_test=true" >> "$GITHUB_OUTPUT"
             fi
           else
             echo "should_run_integration_test=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
When a PR has no companion line and the body is edited, the old logic compared empty strings, found them equal, and skipped the test run with a green check — masking the prior failing run.

Only skip on edited when a companion line actually exists and was unchanged by the edit. If there's no companion line at all, re-run the tests.

TEST BY EDITING THE DESCRIPTION --> IT SHOULD BE TRIGGERED AND NOT SKIP