### PR TITLE
channels_sv2: bound how far a silent channel's difficulty may be eased

### DIFF
--- a/sv2/channels-sv2/src/vardiff/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/classic.rs
@@ -5,6 +5,24 @@ use tracing::debug;
 /// Default minimum hashrate (H/s) if not specified.
 const DEFAULT_MIN_HASHRATE: f32 = 1.0;
 
+/// How many consecutive zero-share eases the difficulty may take before it is held.
+///
+/// Bounds *displacement* — the ratio of a channel's true hashrate to the believed one, `H_t/H_b`.
+/// The ease is multiplicative, so `n` of them leave the belief `3ⁿ` low, and displacement is a
+/// multiplier on the pool's own share-rate target: at `H_t/H_b = d` a miner asked for `r*`
+/// shares/min sends `r*·d`. At `2` the worst case is `d = 9`, whatever `r*` a deployment chooses;
+/// bounding a count rather than a rate-normalised budget is what makes it independent of `r*`, and
+/// it needs no division.
+///
+/// `9` also keeps a returning miner's correction at `800%`, under the `1000%` arm below that caps
+/// the climb back to `×3` per evaluation. So the channel re-targets in one evaluation instead of
+/// walking up in steps; `d > 11` is where that cap engages.
+///
+/// The floor, `min_allowed_hashrate`, does not stop the descent: from a 200 TH belief its `1.0` H/s
+/// default is ~30 eases away. Production incidents, the probability argument for `2`, and the
+/// rejected alternatives are in the commit that introduced this constant.
+const MAX_CONSECUTIVE_SILENT_EASES: u8 = 2;
+
 use super::{error::VardiffError, Vardiff};
 
 /// Represents the dynamic state for a variable difficulty (Vardiff) connection.
@@ -18,6 +36,9 @@ pub struct VardiffState {
     pub timestamp_of_last_update: u64,
     /// The lowest hashrate (H/s) the system will allow; values below this are clamped.
     pub min_allowed_hashrate: f32,
+    /// Consecutive zero-share eases applied to the difficulty; any share clears it.
+    /// See [`MAX_CONSECUTIVE_SILENT_EASES`].
+    silent_eases: u8,
 }
 
 impl VardiffState {
@@ -51,6 +72,7 @@ impl VardiffState {
             shares_since_last_update: 0,
             timestamp_of_last_update: timestamp_secs,
             min_allowed_hashrate,
+            silent_eases: 0,
         })
     }
 
@@ -169,6 +191,25 @@ impl Vardiff for VardiffState {
         let realized_share_per_min =
             self.shares_since_last_update as f64 / (delta_time as f64 / 60.0);
 
+        // Bound the ease on an absent miner. The hold is placed here rather than inside the
+        // zero-share arm below so it survives a change of estimator: the hazard is sustained
+        // silence, not the mechanism that translates it into a lower belief. The counter is
+        // incremented in that arm instead, so it counts eases actually applied — an estimator
+        // that declines to retarget on a silent window must not spend the budget.
+        if realized_share_per_min > 0.0 {
+            self.silent_eases = 0;
+        } else if self.silent_eases >= MAX_CONSECUTIVE_SILENT_EASES {
+            debug!(
+                target: "vardiff",
+                "Difficulty already eased {} times on consecutive silence — holding",
+                self.silent_eases,
+            );
+            // Re-anchor first, so a returning miner is estimated from fresh data rather than
+            // through the accumulated silence.
+            self.reset_counter()?;
+            return Ok(None);
+        }
+
         debug!(
             target: "vardiff",
             "Hashrate update check triggered:
@@ -224,6 +265,9 @@ impl Vardiff for VardiffState {
         // realized_share_per_min is 0.0 when d.difficulty_mgmt.shares_since_last_update is 0
         // so it's safe to compare realized_share_per_min with == 0.0
         if realized_share_per_min == 0.0 {
+            // Bounded by the hold above, which returns before this arm once the budget is spent,
+            // so this cannot exceed `MAX_CONSECUTIVE_SILENT_EASES`.
+            self.silent_eases += 1;
             new_hashrate = match delta_time {
                 dt if dt <= 30 => hashrate / 1.5,
                 dt if dt < 60 => hashrate / 2.0,

--- a/sv2/channels-sv2/src/vardiff/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/classic.rs
@@ -7,20 +7,10 @@ const DEFAULT_MIN_HASHRATE: f32 = 1.0;
 
 /// How many consecutive zero-share eases the difficulty may take before it is held.
 ///
-/// Bounds *displacement* — the ratio of a channel's true hashrate to the believed one, `H_t/H_b`.
-/// The ease is multiplicative, so `n` of them leave the belief `3ⁿ` low, and displacement is a
-/// multiplier on the pool's own share-rate target: at `H_t/H_b = d` a miner asked for `r*`
-/// shares/min sends `r*·d`. At `2` the worst case is `d = 9`, whatever `r*` a deployment chooses;
-/// bounding a count rather than a rate-normalised budget is what makes it independent of `r*`, and
-/// it needs no division.
-///
-/// `9` also keeps a returning miner's correction at `800%`, under the `1000%` arm below that caps
-/// the climb back to `×3` per evaluation. So the channel re-targets in one evaluation instead of
-/// walking up in steps; `d > 11` is where that cap engages.
-///
-/// The floor, `min_allowed_hashrate`, does not stop the descent: from a 200 TH belief its `1.0` H/s
-/// default is ~30 eases away. Production incidents, the probability argument for `2`, and the
-/// rejected alternatives are in the commit that introduced this constant.
+/// Each ease is multiplicative, so `n` of them leave the believed hashrate `3ⁿ` low; at `2` a
+/// returning miner is served at most `9×` too little difficulty. `min_allowed_hashrate` does not
+/// bound this — from a 200 TH belief its default floor is ~30 eases away. Derivation and the
+/// choice of `2` are in the introducing commit.
 const MAX_CONSECUTIVE_SILENT_EASES: u8 = 2;
 
 use super::{error::VardiffError, Vardiff};
@@ -265,8 +255,7 @@ impl Vardiff for VardiffState {
         // realized_share_per_min is 0.0 when d.difficulty_mgmt.shares_since_last_update is 0
         // so it's safe to compare realized_share_per_min with == 0.0
         if realized_share_per_min == 0.0 {
-            // Bounded by the hold above, which returns before this arm once the budget is spent,
-            // so this cannot exceed `MAX_CONSECUTIVE_SILENT_EASES`.
+            // Cannot exceed the bound: the hold above returns once the budget is spent.
             self.silent_eases += 1;
             new_hashrate = match delta_time {
                 dt if dt <= 30 => hashrate / 1.5,

--- a/sv2/channels-sv2/src/vardiff/test/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/test/classic.rs
@@ -1,6 +1,7 @@
 /// Classic implementation test suite
 use crate::vardiff::test::{
-    simulate_shares_and_wait, TEST_MIN_ALLOWED_HASHRATE, TEST_SHARES_PER_MINUTE,
+    simulate_shares_and_wait, TEST_INITIAL_HASHRATE, TEST_MIN_ALLOWED_HASHRATE,
+    TEST_SHARES_PER_MINUTE,
 };
 use crate::{target::hash_rate_to_target, vardiff::VardiffError, VardiffState};
 
@@ -187,4 +188,68 @@ fn test_new_with_min_rejects_unusable_floor() {
             "min_allowed_hashrate {min} from input {bad} is unusable as a baseline"
         );
     }
+}
+
+// A fully-silent channel must not be eased all the way to the floor. The zero-share path removes
+// up to `÷3` per evaluation with nothing bounding how many times it runs, so displacement after
+// `n` silent evaluations is `3ⁿ`. A returning miner is then served a difficulty that much too easy
+// and floods shares until vardiff climbs back.
+#[test]
+fn test_silent_channel_ease_displacement_is_bounded() {
+    let mut vardiff = new_test_vardiff_state().expect("Failed to create VardiffState");
+    let mut hashrate = TEST_INITIAL_HASHRATE;
+    let target =
+        hash_rate_to_target(hashrate.into(), TEST_SHARES_PER_MINUTE.into()).expect("valid target");
+
+    // Forty consecutive silent evaluations. Unbounded, the ~4 that carry
+    // TEST_INITIAL_HASHRATE down to TEST_MIN_ALLOWED_HASHRATE are spent in the first few.
+    for _ in 0..40 {
+        simulate_shares_and_wait(&mut vardiff, 0, 61);
+        if let Ok(Some(updated)) = vardiff.try_vardiff(hashrate, &target, TEST_SHARES_PER_MINUTE) {
+            hashrate = updated;
+        }
+    }
+
+    // Displacement must settle at `3² = 9×`, the bound `MAX_CONSECUTIVE_SILENT_EASES = 2` sets.
+    // Written as a literal rather than derived from that constant deliberately: a derived
+    // expectation moves with the constant and would assert nothing, and this way the test also
+    // compiles and fails against a tree without the bound at all.
+    let expected = TEST_INITIAL_HASHRATE / 9.0;
+    assert!(
+        (hashrate / expected - 1.0).abs() < 1e-3,
+        "silent channel settled at {hashrate} H/s, not the {expected} H/s that a 9× bound \
+         allows (floor is {}) — a returning miner would be served a difficulty that much too easy",
+        vardiff.min_allowed_hashrate()
+    );
+}
+
+// The bound is on *consecutive* silence, so any share activity must restore the full budget.
+// Otherwise a long-lived channel that goes briefly quiet many times would eventually exhaust it
+// and stop easing for a genuine decline.
+#[test]
+fn test_share_activity_clears_the_silence_budget() {
+    let mut vardiff = new_test_vardiff_state().expect("Failed to create VardiffState");
+    let hashrate = TEST_INITIAL_HASHRATE;
+    let target =
+        hash_rate_to_target(hashrate.into(), TEST_SHARES_PER_MINUTE.into()).expect("valid target");
+
+    // Spend the whole budget in silence, then submit, three times over. `2` is
+    // MAX_CONSECUTIVE_SILENT_EASES, as a literal so this also compiles against a tree without it.
+    for _ in 0..3 {
+        for _ in 0..2 {
+            simulate_shares_and_wait(&mut vardiff, 0, 61);
+            let _ = vardiff.try_vardiff(hashrate, &target, TEST_SHARES_PER_MINUTE);
+        }
+        simulate_shares_and_wait(&mut vardiff, 20, 61);
+        let _ = vardiff.try_vardiff(hashrate, &target, TEST_SHARES_PER_MINUTE);
+    }
+
+    // A fresh silent evaluation must still ease, which it cannot do if activity left the
+    // accumulated silence in place.
+    simulate_shares_and_wait(&mut vardiff, 0, 61);
+    let eased = vardiff.try_vardiff(hashrate, &target, TEST_SHARES_PER_MINUTE);
+    assert!(
+        matches!(eased, Ok(Some(h)) if h < hashrate),
+        "activity did not clear the silence budget: {eased:?}"
+    );
 }

--- a/sv2/channels-sv2/src/vardiff/test/classic.rs
+++ b/sv2/channels-sv2/src/vardiff/test/classic.rs
@@ -210,10 +210,8 @@ fn test_silent_channel_ease_displacement_is_bounded() {
         }
     }
 
-    // Displacement must settle at `3² = 9×`, the bound `MAX_CONSECUTIVE_SILENT_EASES = 2` sets.
-    // Written as a literal rather than derived from that constant deliberately: a derived
-    // expectation moves with the constant and would assert nothing, and this way the test also
-    // compiles and fails against a tree without the bound at all.
+    // `3² = 9×`, the bound `MAX_CONSECUTIVE_SILENT_EASES = 2` sets. Literal, not derived from the
+    // constant: a derived expectation moves with it and asserts nothing.
     let expected = TEST_INITIAL_HASHRATE / 9.0;
     assert!(
         (hashrate / expected - 1.0).abs() < 1e-3,
@@ -233,8 +231,7 @@ fn test_share_activity_clears_the_silence_budget() {
     let target =
         hash_rate_to_target(hashrate.into(), TEST_SHARES_PER_MINUTE.into()).expect("valid target");
 
-    // Spend the whole budget in silence, then submit, three times over. `2` is
-    // MAX_CONSECUTIVE_SILENT_EASES, as a literal so this also compiles against a tree without it.
+    // Spend the whole budget in silence, then submit, three times over.
     for _ in 0..3 {
         for _ in 0..2 {
             simulate_shares_and_wait(&mut vardiff, 0, 61);


### PR DESCRIPTION
`try_vardiff`'s zero-share path lowers difficulty multiplicatively — up to `÷3` per evaluation — and nothing
bounds how many times it may do so. After `n` consecutive silent evaluations the belief is `3ⁿ` low.
`min_allowed_hashrate` is the only existing limit and defaults to `1.0` H/s, which from a 200 TH belief is
`log₃(2×10¹⁴) ≈ 30` evaluations away. **The floor exists, but it is never the thing that stops the descent.**

### Displacement, and why it is the quantity that hurts

**Displacement** is the ratio of a channel's true hashrate to the believed one, `d = H_t/H_b` — dimensionless, and
the same quantity as the `3ⁿ` above. It matters because it is a **multiplier on the pool's own target**: a pool that
wants `r*` shares/min derives the target from `H_b`, so the miner actually sends `r*·d`.

| the pool believes | `d` | a 200 TH/s miner then sends |
|---|---|---|
| 200 TH/s — correct | 1 | `r*` — the rate asked for |
| 1 TH/s | 200 | `200·r*` |
| **1.0 H/s — the floor** | **2×10¹⁴** | **`2×10¹⁴·r*`** |

Note that no particular `r*` is needed to read that table, which is the point: at the floor the difficulty imposes
no practical limit, and emission is bounded by the miner's link and the pool's validation loop rather than by
anything the pool configured. Payouts are unaffected — a share is worth its own difficulty — so this is a
self-inflicted availability problem, not a theft vector.

**It is reachable and has been reached.** Three starvation runaways observed on a deployed pool at `d` of **1040**,
**2×10⁷** and **1.4×10¹⁴** — the same rule running for 6, 15 and 30 minutes of unbroken silence.

### What `d` costs: recovery takes as long as the silence did

Two facts from `classic.rs`, and the pool ticks vardiff **once a minute**:

- silence eases the belief **`÷3` per tick**;
- the climb back is capped at **`×3` per tick** while the implied correction exceeds `1000%` — that is, while
  `d > 11`. The `×3` is the figure for a 60 s tick; the cap is `×5` under 60 s and `×10` at or under 30 s. Below the
  threshold the ordinary estimate applies instead of a capped step.

Same speed, opposite directions. So `d = 3^(minutes of silence)`, the climb needs `log₃(d/11)` capped steps plus a
final tick, and **a disconnect costs roughly twice its own length**:

| silence | `d` reached | recovery today | with this bound |
|---|---|---|---|
| 2 min | 9 | 1 tick | 1 tick — **no change** |
| 3 min | 27 | 2 min | 1–2 min |
| 5 min | 243 | 4 min | 1–2 min |
| **6 min** | 729 | **5 min** | 1–2 min |
| 10 min | 5.9×10⁴ | 9 min | 1–2 min |
| **15 min** | 1.4×10⁷ | **14 min** | 1–2 min |
| **30 min** | 2×10¹⁴ — the floor | **29 min** | 1–2 min |

The three bold rows are the observed incidents. Read as total disruption — the outage plus the recovery — a 5-minute
blip costs 9 minutes today and 6–7 with the bound; a 15-minute blip, 29 → 16–17; a 30-minute blip,
**59 → 31–32**.

This also explains the choice of `2` rather than `3` or `4`: `d = 9` implies an `800%` correction, just under the
`1000%` cap, so `9` is the largest displacement that still draws the ordinary estimate rather than a capped step.
Recovery is a single evaluation when the miner's return lands on a tick boundary and two when it does not — a return
part-way through an evaluation leaves a partial window, so the first correction reads low and a second tick finishes
the climb.

Two honest notes. The 2-minute row is where this fix does nothing — short gaps already recover in one tick, so the
bound only bites where current behaviour is already pathological. And the `×3` cap governs the climb regardless of
whether the miner can actually emit `r*·d` shares/min; it only needs the correction to exceed `1000%`, which it does
by a wide margin.

### The fix

Past a point, silence is not evidence of a *lower* hashrate; it is evidence of an *absent* miner, and easing
answers the wrong question. A miner at 10% of its rate is not silent — it still submits — so this path only ever
sees a departure or a brief gap.

`MAX_CONSECUTIVE_SILENT_EASES = 2` caps `d` at **9, whatever `r*` a deployment chooses**, after which the difficulty
is held until a share arrives. That independence from `r*` is the property that made a count the right form. Two
consecutive silent evaluations are conclusive across the deployed range: `P(0 shares) = e^-r*` per evaluation, so
`e⁻⁸ ≈ 3×10⁻⁴` over two of them even at `r* = 4`.

### What the probability argument does not cover

`e^-r*` assumes `d = 1` — which is the thing the ease exists to establish, so the argument above is worth pinning
down rather than leaving as it stands. The mirror case is a belief `k×` too *high*, where the miner sends `r*/k`, so
`P(0 shares) = e^(-r*/k)` approaches 1 exactly where easing is wanted.

The case that reaches is a channel opened with a miner-supplied `nominal_hash_rate` orders of magnitude too high.
It descends 9× and then holds. **It is not stranded** — the first share clears the counter and the ordinary
non-zero path recomputes from realized rate — but convergence goes from `log₃ k` evaluations to however long one
share takes to land. That is the price of the bound, and it is worth paying to fix a runaway in shipped code;
it is not zero.

### Why bound `d`, and not a time or expected-share budget

Worth stating because the alternative looks more principled and is worse. It is also not arbitrary: easing on
elapsed time normalised by the expected inter-event time is what chain difficulty adjustment does — see Harding,
[*Real-Time Block Rate Targeting*](https://doi.org/10.5195/LEDGER.2020.195), Ledger 5 (2020), open access — which is
why it reads as the principled form.

It is the wrong one here. Capping *expected-but-unseen shares* at 30 makes the permitted ease count scale as `30/r*`:
**0 eases at `r*` 30**, where the zero-share arm would never ease at all, and **4 eases — `d ≤ 81` — at `r*` 6**. And
`r*` genuinely varies across deployments: the sim baselines run 6 and 8, the crate's fixture 10. So a rate-dependent
bound swings from doing nothing to doing too little across the range already in use, while the measured displacements
above are what they are regardless of `r*`. The count-based bound also needs no float arithmetic and no division, and
therefore no guard for an unusable `shares_per_minute`.

### Two placement decisions worth a reviewer's eye

- **The hold sits before the zero-share arm, not inside it.** The hazard is sustained silence, not the mechanism
  that translates it into a lower belief, so the hold survives a change of estimator. The counter increments
  *inside* that arm, so it counts eases applied rather than evaluations seen; under this estimator the two coincide,
  because zero shares always clears `should_update`, and no test distinguishes them. The distinction starts to
  matter only for an estimator that declines to retarget on a silent window.
- **On holding, the window is re-anchored via `reset_counter()`**, so a returning miner is estimated from fresh
  data rather than through the accumulated silence. Without that, bounding one dilution would introduce another.

### Tests

- `test_silent_channel_ease_displacement_is_bounded` — **has teeth**: against `main` it fails with *"silent channel
  settled at 10 H/s, not the 111.111115 H/s that a 9× bound allows"*, reaching the floor exactly as described. It
  asserts that 9× as a literal rather than deriving it from the constant: a derived expectation moves with the
  constant and asserts nothing, and the literal is what keeps the test compilable against a tree with no bound.
- `test_share_activity_clears_the_silence_budget` — guards the clearing behaviour. To be explicit: **it passes
  without this change too**, since with no bound there is nothing to exhaust. It is a regression guard for the new
  state, not a demonstration of the defect — deleting the clear-on-activity line does fail it.

Verified at the repo's pinned 1.75.0 against `main` @ `d3a05cfa`: build clean, `cargo fmt --all -- --check` clean,
`cargo clippy -p channels_sv2 --all-features -- -D warnings` clean, **176 crate tests and 3 doc-tests pass**. Tests
run on default features, because the crate's test target does not build under `--all-features` on `main` either.

### Scope

Deliberately out of scope: this bounds the ease that exists today and does not change the estimator, the fire
threshold, or the asymmetry. One API note: the new field is private on a `pub struct` whose other fields are all
`pub`, so a downstream struct literal would stop compiling. Nothing in-tree constructs it that way.

It is **orthogonal to the vardiff estimator work in #2188**:

> **#2188 changes how fast the belief tracks evidence. This changes how far the belief may move on *no* evidence.**

A new estimator does not remove the need for the bound — any rule that eases on absent evidence needs a limit on how
far — and the check here is written against the *decision to adjust* rather than against the `÷3` arm, so it does not
depend on which controller wins. Reviewable and landable on its own: the runaway is in shipped code today.


