### PR TITLE
rename target message fields, aligning with spec cleanup

### DIFF
--- a/stratum-core/stratum-translation/src/sv2_to_sv1.rs
+++ b/stratum-core/stratum-translation/src/sv2_to_sv1.rs
@@ -92,7 +92,7 @@ pub fn build_sv1_notify_from_sv2(
 /// Builds an SV1 `mining.set_difficulty` JSON-RPC message from an SV2 `SetTarget`.
 ///
 /// # Arguments
-/// * `set_target` - The SV2 `SetTarget` message containing the new maximum target.
+/// * `set_target` - The SV2 `SetTarget` message containing the new target.
 ///
 /// # Returns
 /// * `Ok(json_rpc::Message)` - The constructed SV1 mining.set_difficulty message.
@@ -100,12 +100,7 @@ pub fn build_sv1_set_difficulty_from_sv2_set_target(
     set_target: SetTargetOwned,
 ) -> Result<json_rpc::Message> {
     build_sv1_set_difficulty_from_sv2_target(Target::from_le_bytes(
-        set_target
-            .maximum_target
-            .clone()
-            .as_ref()
-            .try_into()
-            .unwrap(),
+        set_target.target.clone().as_ref().try_into().unwrap(),
     ))
 }
 
@@ -308,7 +303,7 @@ mod tests {
     fn test_build_sv1_set_difficulty_from_sv2_set_target() {
         let set_target = Sv2SetTarget {
             channel_id: 1,
-            maximum_target: dummy_target().to_le_bytes().into(),
+            target: dummy_target().to_le_bytes().into(),
         };
         let msg = build_sv1_set_difficulty_from_sv2_set_target(set_target)
             .expect("Should convert SetTarget to difficulty");

--- a/sv2/subprotocols/mining/src/set_target.rs
+++ b/sv2/subprotocols/mining/src/set_target.rs
@@ -8,26 +8,26 @@ use core::convert::TryInto;
 /// All submits leading to hashes higher than the specified target are expected to be rejected by
 /// the upstream.
 ///
-/// [`SetTarget::maximum_target`] is valid until the next [`SetTarget`] message is sent and is
-/// applicable for all jobs received on the channel in the future or already received with flag
+/// [`SetTarget::target`] is valid until the next [`SetTarget`] message is sent and is applicable
+/// for all jobs received on the channel in the future or already received with flag
 /// `future_job=true`.
 ///
-/// When this message is sent to a group channel, the maximum target is applicable to all channels
-/// in the group.
+/// When this message is sent to a group channel, the target is applicable to all channels in the
+/// group.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetTarget<'decoder> {
     /// Channel identifier.
     pub channel_id: u32,
     /// Maximum value of produced hash that will be accepted by a upstream to accept shares.
-    pub maximum_target: U256<'decoder>,
+    pub target: U256<'decoder>,
 }
 
 impl fmt::Display for SetTarget<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "SetTarget(channel_id={}, maximum_target={})",
-            self.channel_id, self.maximum_target
+            "SetTarget(channel_id={}, target={})",
+            self.channel_id, self.target
         )
     }
 }
@@ -36,8 +36,8 @@ impl fmt::Display for SetTargetOwned {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "SetTarget(channel_id={}, maximum_target={})",
-            self.channel_id, self.maximum_target
+            "SetTarget(channel_id={}, target={})",
+            self.channel_id, self.target
         )
     }
 }

--- a/sv2/subprotocols/mining/src/update_channel.rs
+++ b/sv2/subprotocols/mining/src/update_channel.rs
@@ -24,22 +24,21 @@ pub struct UpdateChannel<'decoder> {
     /// messages, based on new job readiness on the server, this field is understood as
     /// downstream’s request.
     ///
-    /// When maximum target is smaller than currently used maximum target for the channel,
-    /// upstream node must reflect the downstreams’s request (and send appropriate [`SetTarget`]
-    /// message).
+    /// When this field is smaller than the channel’s current target, upstream node must reflect
+    /// the downstreams’s request (and send appropriate [`SetTarget`] message).
     ///
-    /// Upstream can change maximum target by sending [`SetTarget`] message.
+    /// Upstream can change the channel target by sending [`SetTarget`] message.
     ///
     /// [`SetTarget`]: crate::SetTarget
-    pub maximum_target: U256<'decoder>,
+    pub max_target: U256<'decoder>,
 }
 
 impl fmt::Display for UpdateChannel<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "⛏️ UpdateChannel(channel_id={}, nominal_hash_rate={}, maximum_target={})",
-            self.channel_id, self.nominal_hash_rate, self.maximum_target
+            "⛏️ UpdateChannel(channel_id={}, nominal_hash_rate={}, max_target={})",
+            self.channel_id, self.nominal_hash_rate, self.max_target
         )
     }
 }
@@ -48,8 +47,8 @@ impl fmt::Display for UpdateChannelOwned {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "⛏️ UpdateChannel(channel_id={}, nominal_hash_rate={}, maximum_target={})",
-            self.channel_id, self.nominal_hash_rate, self.maximum_target
+            "⛏️ UpdateChannel(channel_id={}, nominal_hash_rate={}, max_target={})",
+            self.channel_id, self.nominal_hash_rate, self.max_target
         )
     }
 }


### PR DESCRIPTION
aligned with https://github.com/stratum-mining/sv2-spec/pull/228

draft for now, I'll make it ready for review whenever we decide to merge the spec change

companion https://github.com/stratum-mining/sv2-apps/pull/845